### PR TITLE
feat: skeleton for crawl-based API discovery architecture

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main is the entry point for the vespasian CLI.
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/alecthomas/kong"
+)
+
+// CLI defines the complete command-line interface structure.
+var CLI struct {
+	Crawl    CrawlCmd    `cmd:"" help:"Crawl a web application to discover API endpoints"`
+	Import   ImportCmd   `cmd:"" help:"Import traffic capture from external sources"`
+	Generate GenerateCmd `cmd:"" help:"Generate API specifications from captured traffic"`
+	Scan     ScanCmd     `cmd:"" help:"Full pipeline: crawl, classify, and generate specs"`
+	Version  VersionCmd  `cmd:"" help:"Show version information"`
+}
+
+// CrawlCmd crawls a web application to capture HTTP traffic.
+type CrawlCmd struct {
+	URL      string        `arg:"" help:"Target URL to crawl"`
+	Header   []string      `short:"H" help:"Custom headers (repeatable)"`
+	Output   string        `short:"o" help:"Output file path"`
+	Format   string        `default:"json" enum:"json,yaml" help:"Output format"`
+	Depth    int           `default:"3" help:"Maximum crawl depth"`
+	MaxPages int           `default:"100" help:"Maximum pages to crawl"`
+	Timeout  time.Duration `default:"30s" help:"Request timeout"`
+	Scope    string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
+	Headless bool          `default:"true" help:"Use headless browser"`
+	Verbose  bool          `short:"v" help:"Enable verbose logging"`
+}
+
+// Run executes the crawl command.
+func (c *CrawlCmd) Run() error {
+	fmt.Println("crawl: not implemented")
+	return nil
+}
+
+// ImportCmd imports traffic capture from external sources.
+type ImportCmd struct {
+	Format  string `arg:"" help:"Import format (e.g., burp, har, mitmproxy)"`
+	File    string `arg:"" help:"Input file path"`
+	Output  string `short:"o" help:"Output file path"`
+	Scope   string `optional:"" help:"Filter scope (optional: same-origin or same-domain)"`
+	Verbose bool   `short:"v" help:"Enable verbose logging"`
+}
+
+// Run executes the import command.
+func (c *ImportCmd) Run() error {
+	fmt.Println("import: not implemented")
+	return nil
+}
+
+// GenerateCmd generates API specifications from captured traffic.
+type GenerateCmd struct {
+	APIType    string  `arg:"" enum:"rest" help:"API type to generate"`
+	Capture    string  `arg:"" help:"Capture file path"`
+	Output     string  `short:"o" help:"Output file path"`
+	Confidence float64 `default:"0.5" help:"Minimum confidence threshold"`
+	Probe      bool    `default:"true" help:"Enable endpoint probing"`
+	Verbose    bool    `short:"v" help:"Enable verbose logging"`
+}
+
+// Run executes the generate command.
+func (c *GenerateCmd) Run() error {
+	fmt.Println("generate: not implemented")
+	return nil
+}
+
+// ScanCmd runs the full pipeline: crawl, classify, and generate.
+type ScanCmd struct {
+	URL        string        `arg:"" help:"Target URL to scan"`
+	Header     []string      `short:"H" help:"Custom headers (repeatable)"`
+	Output     string        `short:"o" help:"Output file path"`
+	Depth      int           `default:"3" help:"Maximum crawl depth"`
+	MaxPages   int           `default:"100" help:"Maximum pages to crawl"`
+	Timeout    time.Duration `default:"30s" help:"Request timeout"`
+	Scope      string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
+	Headless   bool          `default:"true" help:"Use headless browser"`
+	Confidence float64       `default:"0.5" help:"Minimum confidence threshold"`
+	Probe      bool          `default:"true" help:"Enable endpoint probing"`
+	Verbose    bool          `short:"v" help:"Enable verbose logging"`
+}
+
+// Run executes the scan command.
+func (c *ScanCmd) Run() error {
+	fmt.Println("scan: not implemented")
+	return nil
+}
+
+// VersionCmd shows version information.
+type VersionCmd struct{}
+
+// Run executes the version command.
+func (c *VersionCmd) Run() error {
+	fmt.Println("vespasian version dev")
+	return nil
+}
+
+func main() {
+	ctx := kong.Parse(&CLI,
+		kong.Name("vespasian"),
+		kong.Description("API discovery tool for security assessments."),
+		kong.UsageOnError(),
+	)
+	err := ctx.Run()
+	ctx.FatalIfErrorf(err)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/praetorian-inc/vespasian
+
+go 1.24
+
+require github.com/alecthomas/kong v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
+github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/kong v1.14.0 h1:gFgEUZWu2ZmZ+UhyZ1bDhuutbKN1nTtJTwh19Wsn21s=
+github.com/alecthomas/kong v1.14.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
+github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
+github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package classify
+
+import (
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// APIClassifier determines if a request is an API call.
+type APIClassifier interface {
+	// Name returns the classifier name (e.g., "rest", "graphql").
+	Name() string
+
+	// Classify returns whether the request is an API call and the confidence score.
+	Classify(req crawl.ObservedRequest) (bool, float64)
+}
+
+// RunClassifiers applies all classifiers to requests and returns classified results.
+func RunClassifiers(classifiers []APIClassifier, requests []crawl.ObservedRequest, threshold float64) []ClassifiedRequest {
+	var results []ClassifiedRequest
+
+	for _, req := range requests {
+		var bestMatch ClassifiedRequest
+		bestMatch.ObservedRequest = req
+		bestMatch.IsAPI = false
+		bestMatch.Confidence = 0
+
+		for _, classifier := range classifiers {
+			isAPI, confidence := classifier.Classify(req)
+			if isAPI && confidence > bestMatch.Confidence {
+				bestMatch.IsAPI = true
+				bestMatch.Confidence = confidence
+				bestMatch.APIType = classifier.Name()
+				bestMatch.Reason = "Classified by " + classifier.Name()
+			}
+		}
+
+		if bestMatch.Confidence >= threshold {
+			results = append(results, bestMatch)
+		}
+	}
+
+	return results
+}

--- a/pkg/classify/rest.go
+++ b/pkg/classify/rest.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package classify
+
+import (
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// RESTClassifier classifies REST API requests.
+type RESTClassifier struct{}
+
+// Name returns the classifier name.
+func (c *RESTClassifier) Name() string {
+	return "rest"
+}
+
+// Classify determines if the request is a REST API call.
+func (c *RESTClassifier) Classify(_ crawl.ObservedRequest) (bool, float64) {
+	return false, 0
+}

--- a/pkg/classify/types.go
+++ b/pkg/classify/types.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package classify provides API classification for observed HTTP requests.
+package classify
+
+import (
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// ClassifiedRequest extends ObservedRequest with classification metadata.
+type ClassifiedRequest struct {
+	crawl.ObservedRequest
+	IsAPI      bool    `json:"is_api"`
+	Confidence float64 `json:"confidence"`
+	Reason     string  `json:"reason"`
+	APIType    string  `json:"api_type"`
+}

--- a/pkg/crawl/capture.go
+++ b/pkg/crawl/capture.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// WriteCapture writes observed requests to a writer in JSON format.
+func WriteCapture(w io.Writer, requests []ObservedRequest) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(requests)
+}
+
+// ReadCapture reads observed requests from a reader in JSON format.
+func ReadCapture(r io.Reader) ([]ObservedRequest, error) {
+	var requests []ObservedRequest
+	decoder := json.NewDecoder(r)
+	if err := decoder.Decode(&requests); err != nil {
+		return nil, err
+	}
+	return requests, nil
+}

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// CrawlerOptions configures the crawler behavior.
+type CrawlerOptions struct {
+	Depth    int
+	MaxPages int
+	Timeout  time.Duration
+	Scope    string
+	Headless bool
+	Headers  map[string]string
+}
+
+// Crawler performs web crawling to capture HTTP traffic.
+type Crawler struct {
+	opts CrawlerOptions
+}
+
+// NewCrawler creates a new crawler with the given options.
+func NewCrawler(opts CrawlerOptions) *Crawler {
+	return &Crawler{opts: opts}
+}
+
+// Crawl crawls the target URL and returns observed requests.
+func (c *Crawler) Crawl(_ context.Context, _ string) ([]ObservedRequest, error) {
+	return nil, errors.New("crawl: not implemented")
+}

--- a/pkg/crawl/types.go
+++ b/pkg/crawl/types.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package crawl provides types and utilities for capturing HTTP traffic.
+package crawl
+
+// ObservedRequest represents a captured HTTP request and its response.
+type ObservedRequest struct {
+	Method      string            `json:"method"`
+	URL         string            `json:"url"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	QueryParams map[string]string `json:"query_params,omitempty"`
+	Body        []byte            `json:"body,omitempty"`
+	Response    ObservedResponse  `json:"response"`
+	Source      string            `json:"source"`
+	PageURL     string            `json:"page_url,omitempty"`
+}
+
+// ObservedResponse represents a captured HTTP response.
+type ObservedResponse struct {
+	StatusCode  int               `json:"status_code"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	ContentType string            `json:"content_type,omitempty"`
+	Body        []byte            `json:"body,omitempty"`
+}

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package generate defines the interface for producing API specifications
+// from classified requests.
+package generate
+
+import (
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// SpecGenerator generates API specifications from classified requests.
+type SpecGenerator interface {
+	// APIType returns the API type this generator supports (e.g., "rest", "graphql").
+	APIType() string
+
+	// Generate produces an API specification from the endpoints.
+	Generate(endpoints []classify.ClassifiedRequest) ([]byte, error)
+
+	// DefaultExtension returns the default file extension for the generated spec.
+	DefaultExtension() string
+}

--- a/pkg/generate/rest/normalize.go
+++ b/pkg/generate/rest/normalize.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+// NormalizePath normalizes a URL path for OpenAPI specification.
+func NormalizePath(path string) string {
+	return path
+}

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rest generates OpenAPI 3.0 specifications from classified REST requests.
+package rest
+
+import (
+	"errors"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// OpenAPIGenerator generates OpenAPI 3.0 specifications.
+type OpenAPIGenerator struct{}
+
+// APIType returns the API type.
+func (g *OpenAPIGenerator) APIType() string {
+	return "rest"
+}
+
+// Generate produces an OpenAPI specification.
+func (g *OpenAPIGenerator) Generate(_ []classify.ClassifiedRequest) ([]byte, error) {
+	return nil, errors.New("openapi generate: not implemented")
+}
+
+// DefaultExtension returns the default file extension.
+func (g *OpenAPIGenerator) DefaultExtension() string {
+	return ".yaml"
+}

--- a/pkg/generate/rest/schema.go
+++ b/pkg/generate/rest/schema.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+// InferSchema infers JSON schema from response body.
+func InferSchema(body []byte) map[string]any {
+	_ = body
+	return nil
+}

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package importer defines the interface for converting external traffic
+// captures into the vespasian ObservedRequest format.
+package importer
+
+import (
+	"io"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// TrafficImporter converts external traffic captures to ObservedRequest format.
+type TrafficImporter interface {
+	// Name returns the importer name (e.g., "burp", "har").
+	Name() string
+
+	// Import reads external traffic and converts it to ObservedRequest format.
+	Import(r io.Reader) ([]crawl.ObservedRequest, error)
+}

--- a/pkg/probe/options.go
+++ b/pkg/probe/options.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe
+
+import (
+	"context"
+	"errors"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// OptionsProbe sends OPTIONS requests to discover supported HTTP methods.
+type OptionsProbe struct{}
+
+// Name returns the probe name.
+func (p *OptionsProbe) Name() string {
+	return "options"
+}
+
+// Probe enriches endpoints by sending OPTIONS requests.
+func (p *OptionsProbe) Probe(_ context.Context, _ []classify.ClassifiedRequest) ([]classify.ClassifiedRequest, error) {
+	return nil, errors.New("options probe: not implemented")
+}

--- a/pkg/probe/prober.go
+++ b/pkg/probe/prober.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package probe provides strategies for enriching discovered API endpoints.
+package probe
+
+import (
+	"context"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// ProbeStrategy enriches classified requests with additional information.
+//
+//nolint:revive // ProbeStrategy name is intentional per specification
+type ProbeStrategy interface {
+	// Name returns the strategy name (e.g., "options", "schema").
+	Name() string
+
+	// Probe enriches the classified requests with additional data.
+	Probe(ctx context.Context, endpoints []classify.ClassifiedRequest) ([]classify.ClassifiedRequest, error)
+}
+
+// RunStrategies applies all probe strategies sequentially to the endpoints.
+func RunStrategies(ctx context.Context, strategies []ProbeStrategy, endpoints []classify.ClassifiedRequest) ([]classify.ClassifiedRequest, error) {
+	result := endpoints
+
+	for _, strategy := range strategies {
+		enriched, err := strategy.Probe(ctx, result)
+		if err != nil {
+			return nil, err
+		}
+		result = enriched
+	}
+
+	return result, nil
+}

--- a/pkg/probe/schema.go
+++ b/pkg/probe/schema.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe
+
+import (
+	"context"
+	"errors"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// SchemaProbe attempts to discover schema information from endpoints.
+type SchemaProbe struct{}
+
+// Name returns the probe name.
+func (p *SchemaProbe) Name() string {
+	return "schema"
+}
+
+// Probe enriches endpoints with schema information.
+func (p *SchemaProbe) Probe(_ context.Context, _ []classify.ClassifiedRequest) ([]classify.ClassifiedRequest, error) {
+	return nil, errors.New("schema probe: not implemented")
+}


### PR DESCRIPTION
## Summary

Scaffolds the package structure and interfaces for the two-stage (capture → generate) API discovery pipeline, enabling engineers to work sub-issues (ENG-1416 through ENG-1471) in parallel.

- **Kong CLI** (`cmd/vespasian/`): `crawl`, `import`, `generate`, `scan`, `version` commands with all flags from the design spec
- **`pkg/crawl/`**: `ObservedRequest`/`ObservedResponse` types, capture file read/write, `Crawler` stub
- **`pkg/importer/`**: `TrafficImporter` interface (Burp, HAR, mitmproxy adapters to come)
- **`pkg/classify/`**: `APIClassifier` interface, `RunClassifiers` runner, `RESTClassifier` stub
- **`pkg/probe/`**: `ProbeStrategy` interface, `RunStrategies` runner, `OptionsProbe`/`SchemaProbe` stubs
- **`pkg/generate/`**: `SpecGenerator` interface
- **`pkg/generate/rest/`**: `OpenAPIGenerator`, `NormalizePath`, `InferSchema` stubs

All stubs compile and pass CI gates (`go build`, `go test -race`, `go vet`, `golangci-lint run`, `gofmt`).

Ref: ENG-1175

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (no tests yet, no failures)
- [x] `go vet ./...` passes
- [x] `golangci-lint run` passes (0 issues)
- [x] `gofmt -l .` returns no output
- [x] `bin/vespasian --help` shows all 5 commands