### PR TITLE
feat: implement REST API classifier with heuristic scoring and deduplication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,10 @@ module github.com/praetorian-inc/vespasian
 go 1.24
 
 require github.com/alecthomas/kong v1.14.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,15 @@ github.com/alecthomas/kong v1.14.0 h1:gFgEUZWu2ZmZ+UhyZ1bDhuutbKN1nTtJTwh19Wsn21
 github.com/alecthomas/kong v1.14.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -79,7 +79,7 @@ func RunClassifiers(classifiers []APIClassifier, requests []crawl.ObservedReques
 // QueryParams from all duplicate observations are merged.
 func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
 	type entry struct {
-		req   ClassifiedRequest
+		req ClassifiedRequest
 	}
 	seen := make(map[string]*entry)
 	var order []string

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -15,6 +15,8 @@
 package classify
 
 import (
+	"net/url"
+
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
 )
 
@@ -25,6 +27,13 @@ type APIClassifier interface {
 
 	// Classify returns whether the request is an API call and the confidence score.
 	Classify(req crawl.ObservedRequest) (bool, float64)
+}
+
+// DetailedClassifier extends classification with a reason string.
+type DetailedClassifier interface {
+	APIClassifier
+	// ClassifyDetail returns classification result with a reason string.
+	ClassifyDetail(req crawl.ObservedRequest) (bool, float64, string)
 }
 
 // RunClassifiers applies all classifiers to requests and returns classified results.
@@ -38,12 +47,22 @@ func RunClassifiers(classifiers []APIClassifier, requests []crawl.ObservedReques
 		bestMatch.Confidence = 0
 
 		for _, classifier := range classifiers {
-			isAPI, confidence := classifier.Classify(req)
+			var isAPI bool
+			var confidence float64
+			var reason string
+
+			if dc, ok := classifier.(DetailedClassifier); ok {
+				isAPI, confidence, reason = dc.ClassifyDetail(req)
+			} else {
+				isAPI, confidence = classifier.Classify(req)
+				reason = "classified by " + classifier.Name()
+			}
+
 			if isAPI && confidence > bestMatch.Confidence {
 				bestMatch.IsAPI = true
 				bestMatch.Confidence = confidence
 				bestMatch.APIType = classifier.Name()
-				bestMatch.Reason = "Classified by " + classifier.Name()
+				bestMatch.Reason = reason
 			}
 		}
 
@@ -52,5 +71,62 @@ func RunClassifiers(classifiers []APIClassifier, requests []crawl.ObservedReques
 		}
 	}
 
+	return results
+}
+
+// Deduplicate removes duplicate classified requests, keeping the highest confidence.
+// The deduplication key is METHOD:path (query params and fragments stripped).
+// QueryParams from all duplicate observations are merged.
+func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
+	type entry struct {
+		req   ClassifiedRequest
+	}
+	seen := make(map[string]*entry)
+	var order []string
+
+	for _, req := range classified {
+		parsedURL, err := url.Parse(req.URL)
+		if err != nil {
+			// Unparseable URLs: use raw URL as key.
+			key := req.Method + ":" + req.URL
+			if _, found := seen[key]; !found {
+				order = append(order, key)
+				seen[key] = &entry{req: req}
+			}
+			continue
+		}
+
+		key := req.Method + ":" + parsedURL.Path
+
+		existing, found := seen[key]
+		if !found {
+			order = append(order, key)
+			seen[key] = &entry{req: req}
+		} else {
+			// Merge unique QueryParams.
+			if req.QueryParams != nil {
+				if existing.req.QueryParams == nil {
+					existing.req.QueryParams = make(map[string]string)
+				}
+				for k, v := range req.QueryParams {
+					if _, exists := existing.req.QueryParams[k]; !exists {
+						existing.req.QueryParams[k] = v
+					}
+				}
+			}
+
+			// Keep highest confidence, but preserve first occurrence's body/response.
+			if req.Confidence > existing.req.Confidence {
+				existing.req.Confidence = req.Confidence
+				existing.req.Reason = req.Reason
+				existing.req.APIType = req.APIType
+			}
+		}
+	}
+
+	results := make([]ClassifiedRequest, 0, len(order))
+	for _, key := range order {
+		results = append(results, seen[key].req)
+	}
 	return results
 }

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -77,6 +77,11 @@ func RunClassifiers(classifiers []APIClassifier, requests []crawl.ObservedReques
 // Deduplicate removes duplicate classified requests, keeping the highest confidence.
 // The deduplication key is METHOD:path (query params and fragments stripped).
 // QueryParams from all duplicate observations are merged.
+//
+// Memory usage: The map and order slice grow linearly with unique METHOD:path keys.
+// In practice this is bounded by the upstream crawl layer's MaxPages setting
+// (default 100). The import path (ReadCapture) does not enforce size limits,
+// so callers importing from untrusted capture files should validate input size.
 func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
 	type entry struct {
 		req ClassifiedRequest
@@ -96,6 +101,10 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
 			continue
 		}
 
+		// Dedup key intentionally omits host: the crawl layer's scope
+		// restrictions (same-origin / same-domain) make cross-host
+		// duplicates unlikely, and consolidating by path is the desired
+		// behavior for single-target scans.
 		key := req.Method + ":" + parsedURL.Path
 
 		existing, found := seen[key]

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // stubClassifier is a simple classifier for testing that returns fixed values.
@@ -35,9 +37,7 @@ func (s *stubClassifier) Classify(_ crawl.ObservedRequest) (bool, float64) {
 func TestRunClassifiers_Empty(t *testing.T) {
 	classifiers := []APIClassifier{&RESTClassifier{}}
 	results := RunClassifiers(classifiers, nil, 0.5)
-	if len(results) != 0 {
-		t.Errorf("RunClassifiers(nil) = %d results, want 0", len(results))
-	}
+	assert.Empty(t, results)
 }
 
 func TestRunClassifiers_ThresholdFiltering(t *testing.T) {
@@ -62,12 +62,8 @@ func TestRunClassifiers_ThresholdFiltering(t *testing.T) {
 	}
 
 	results := RunClassifiers(classifiers, requests, 0.5)
-	if len(results) != 1 {
-		t.Fatalf("RunClassifiers with threshold 0.5 = %d results, want 1", len(results))
-	}
-	if results[0].Confidence < 0.5 {
-		t.Errorf("result confidence = %v, want >= 0.5", results[0].Confidence)
-	}
+	require.Len(t, results, 1)
+	assert.GreaterOrEqual(t, results[0].Confidence, 0.5)
 }
 
 func TestRunClassifiers_ZeroThreshold(t *testing.T) {
@@ -91,9 +87,7 @@ func TestRunClassifiers_ZeroThreshold(t *testing.T) {
 	}
 
 	results := RunClassifiers(classifiers, requests, 0.0)
-	if len(results) != 2 {
-		t.Errorf("RunClassifiers with threshold 0.0 = %d results, want 2", len(results))
-	}
+	assert.Len(t, results, 2)
 }
 
 func TestRunClassifiers_DetailedReason(t *testing.T) {
@@ -110,15 +104,9 @@ func TestRunClassifiers_DetailedReason(t *testing.T) {
 	}
 
 	results := RunClassifiers(classifiers, requests, 0.5)
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
-	}
-	if results[0].Reason == "" {
-		t.Error("expected non-empty reason from DetailedClassifier")
-	}
-	if results[0].Reason == "classified by rest" {
-		t.Error("expected detailed reason, got generic fallback")
-	}
+	require.Len(t, results, 1)
+	assert.NotEmpty(t, results[0].Reason)
+	assert.NotEqual(t, "classified by rest", results[0].Reason)
 }
 
 func TestRunClassifiers_FallbackReason(t *testing.T) {
@@ -137,12 +125,8 @@ func TestRunClassifiers_FallbackReason(t *testing.T) {
 	}
 
 	results := RunClassifiers(classifiers, requests, 0.5)
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
-	}
-	if results[0].Reason != "classified by stub" {
-		t.Errorf("reason = %q, want %q", results[0].Reason, "classified by stub")
-	}
+	require.Len(t, results, 1)
+	assert.Equal(t, "classified by stub", results[0].Reason)
 }
 
 func TestRunClassifiers_MultipleClassifiers(t *testing.T) {
@@ -158,15 +142,9 @@ func TestRunClassifiers_MultipleClassifiers(t *testing.T) {
 	}
 
 	results := RunClassifiers(classifiers, requests, 0.0)
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
-	}
-	if results[0].APIType != "high" {
-		t.Errorf("APIType = %q, want %q (highest confidence wins)", results[0].APIType, "high")
-	}
-	if results[0].Confidence != 0.9 {
-		t.Errorf("Confidence = %v, want 0.9", results[0].Confidence)
-	}
+	require.Len(t, results, 1)
+	assert.Equal(t, "high", results[0].APIType)
+	assert.InDelta(t, 0.9, results[0].Confidence, 0.001)
 }
 
 func TestDeduplicate_MergesSameEndpoint(t *testing.T) {
@@ -204,17 +182,11 @@ func TestDeduplicate_MergesSameEndpoint(t *testing.T) {
 	}
 
 	result := Deduplicate(classified)
-	if len(result) != 1 {
-		t.Fatalf("Deduplicate = %d results, want 1", len(result))
-	}
+	require.Len(t, result, 1)
 	// Highest confidence kept.
-	if result[0].Confidence != 0.85 {
-		t.Errorf("Confidence = %v, want 0.85", result[0].Confidence)
-	}
+	assert.InDelta(t, 0.85, result[0].Confidence, 0.001)
 	// First occurrence's body preserved.
-	if string(result[0].Response.Body) != `[{"id":1}]` {
-		t.Errorf("Body = %q, want first occurrence body", string(result[0].Response.Body))
-	}
+	assert.Equal(t, `[{"id":1}]`, string(result[0].Response.Body))
 }
 
 func TestDeduplicate_MergesQueryParams(t *testing.T) {
@@ -240,15 +212,9 @@ func TestDeduplicate_MergesQueryParams(t *testing.T) {
 	}
 
 	result := Deduplicate(classified)
-	if len(result) != 1 {
-		t.Fatalf("Deduplicate = %d results, want 1", len(result))
-	}
-	if result[0].QueryParams["page"] != "1" {
-		t.Errorf("missing merged param 'page'")
-	}
-	if result[0].QueryParams["limit"] != "10" {
-		t.Errorf("missing merged param 'limit'")
-	}
+	require.Len(t, result, 1)
+	assert.Equal(t, "1", result[0].QueryParams["page"])
+	assert.Equal(t, "10", result[0].QueryParams["limit"])
 }
 
 func TestDeduplicate_NoDuplicates(t *testing.T) {
@@ -280,9 +246,7 @@ func TestDeduplicate_NoDuplicates(t *testing.T) {
 	}
 
 	result := Deduplicate(classified)
-	if len(result) != 3 {
-		t.Errorf("Deduplicate (no dups) = %d results, want 3", len(result))
-	}
+	assert.Len(t, result, 3)
 }
 
 func TestDeduplicate_KeepsHighestConfidence(t *testing.T) {
@@ -317,20 +281,12 @@ func TestDeduplicate_KeepsHighestConfidence(t *testing.T) {
 	}
 
 	result := Deduplicate(classified)
-	if len(result) != 1 {
-		t.Fatalf("Deduplicate = %d results, want 1", len(result))
-	}
-	if result[0].Confidence != 0.95 {
-		t.Errorf("Confidence = %v, want 0.95 (highest)", result[0].Confidence)
-	}
-	if result[0].Reason != "high" {
-		t.Errorf("Reason = %q, want %q (from highest confidence)", result[0].Reason, "high")
-	}
+	require.Len(t, result, 1)
+	assert.InDelta(t, 0.95, result[0].Confidence, 0.001)
+	assert.Equal(t, "high", result[0].Reason)
 }
 
 func TestDeduplicate_Empty(t *testing.T) {
 	result := Deduplicate(nil)
-	if len(result) != 0 {
-		t.Errorf("Deduplicate(nil) = %d results, want 0", len(result))
-	}
+	assert.Empty(t, result)
 }

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -1,0 +1,336 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package classify
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// stubClassifier is a simple classifier for testing that returns fixed values.
+type stubClassifier struct {
+	name       string
+	isAPI      bool
+	confidence float64
+}
+
+func (s *stubClassifier) Name() string { return s.name }
+func (s *stubClassifier) Classify(_ crawl.ObservedRequest) (bool, float64) {
+	return s.isAPI, s.confidence
+}
+
+func TestRunClassifiers_Empty(t *testing.T) {
+	classifiers := []APIClassifier{&RESTClassifier{}}
+	results := RunClassifiers(classifiers, nil, 0.5)
+	if len(results) != 0 {
+		t.Errorf("RunClassifiers(nil) = %d results, want 0", len(results))
+	}
+}
+
+func TestRunClassifiers_ThresholdFiltering(t *testing.T) {
+	classifiers := []APIClassifier{&RESTClassifier{}}
+	requests := []crawl.ObservedRequest{
+		{
+			Method: "GET",
+			URL:    "https://example.com/api/v1/users",
+			Response: crawl.ObservedResponse{
+				StatusCode:  200,
+				ContentType: "application/json",
+			},
+		},
+		{
+			Method: "GET",
+			URL:    "https://example.com/page",
+			Response: crawl.ObservedResponse{
+				StatusCode:  200,
+				ContentType: "text/html",
+			},
+		},
+	}
+
+	results := RunClassifiers(classifiers, requests, 0.5)
+	if len(results) != 1 {
+		t.Fatalf("RunClassifiers with threshold 0.5 = %d results, want 1", len(results))
+	}
+	if results[0].Confidence < 0.5 {
+		t.Errorf("result confidence = %v, want >= 0.5", results[0].Confidence)
+	}
+}
+
+func TestRunClassifiers_ZeroThreshold(t *testing.T) {
+	classifiers := []APIClassifier{&RESTClassifier{}}
+	requests := []crawl.ObservedRequest{
+		{
+			Method: "GET",
+			URL:    "https://example.com/api/v1/users",
+			Response: crawl.ObservedResponse{
+				StatusCode:  200,
+				ContentType: "application/json",
+			},
+		},
+		{
+			Method: "POST",
+			URL:    "https://example.com/submit",
+			Response: crawl.ObservedResponse{
+				StatusCode: 200,
+			},
+		},
+	}
+
+	results := RunClassifiers(classifiers, requests, 0.0)
+	if len(results) != 2 {
+		t.Errorf("RunClassifiers with threshold 0.0 = %d results, want 2", len(results))
+	}
+}
+
+func TestRunClassifiers_DetailedReason(t *testing.T) {
+	classifiers := []APIClassifier{&RESTClassifier{}}
+	requests := []crawl.ObservedRequest{
+		{
+			Method: "GET",
+			URL:    "https://example.com/data",
+			Response: crawl.ObservedResponse{
+				StatusCode:  200,
+				ContentType: "application/json",
+			},
+		},
+	}
+
+	results := RunClassifiers(classifiers, requests, 0.5)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Reason == "" {
+		t.Error("expected non-empty reason from DetailedClassifier")
+	}
+	if results[0].Reason == "classified by rest" {
+		t.Error("expected detailed reason, got generic fallback")
+	}
+}
+
+func TestRunClassifiers_FallbackReason(t *testing.T) {
+	// Use stub classifier that does NOT implement DetailedClassifier.
+	classifiers := []APIClassifier{
+		&stubClassifier{name: "stub", isAPI: true, confidence: 0.9},
+	}
+	requests := []crawl.ObservedRequest{
+		{
+			Method: "GET",
+			URL:    "https://example.com/data",
+			Response: crawl.ObservedResponse{
+				StatusCode: 200,
+			},
+		},
+	}
+
+	results := RunClassifiers(classifiers, requests, 0.5)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Reason != "classified by stub" {
+		t.Errorf("reason = %q, want %q", results[0].Reason, "classified by stub")
+	}
+}
+
+func TestRunClassifiers_MultipleClassifiers(t *testing.T) {
+	classifiers := []APIClassifier{
+		&stubClassifier{name: "low", isAPI: true, confidence: 0.3},
+		&stubClassifier{name: "high", isAPI: true, confidence: 0.9},
+	}
+	requests := []crawl.ObservedRequest{
+		{
+			Method: "GET",
+			URL:    "https://example.com/data",
+		},
+	}
+
+	results := RunClassifiers(classifiers, requests, 0.0)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].APIType != "high" {
+		t.Errorf("APIType = %q, want %q (highest confidence wins)", results[0].APIType, "high")
+	}
+	if results[0].Confidence != 0.9 {
+		t.Errorf("Confidence = %v, want 0.9", results[0].Confidence)
+	}
+}
+
+func TestDeduplicate_MergesSameEndpoint(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:      "GET",
+				URL:         "https://example.com/api/users?page=1",
+				QueryParams: map[string]string{"page": "1"},
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+					Body:       []byte(`[{"id":1}]`),
+				},
+			},
+			IsAPI:      true,
+			Confidence: 0.8,
+			Reason:     "content-type:application/json",
+			APIType:    "rest",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:      "GET",
+				URL:         "https://example.com/api/users?page=2",
+				QueryParams: map[string]string{"page": "2"},
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+					Body:       []byte(`[{"id":2}]`),
+				},
+			},
+			IsAPI:      true,
+			Confidence: 0.85,
+			Reason:     "content-type+path",
+			APIType:    "rest",
+		},
+	}
+
+	result := Deduplicate(classified)
+	if len(result) != 1 {
+		t.Fatalf("Deduplicate = %d results, want 1", len(result))
+	}
+	// Highest confidence kept.
+	if result[0].Confidence != 0.85 {
+		t.Errorf("Confidence = %v, want 0.85", result[0].Confidence)
+	}
+	// First occurrence's body preserved.
+	if string(result[0].Response.Body) != `[{"id":1}]` {
+		t.Errorf("Body = %q, want first occurrence body", string(result[0].Response.Body))
+	}
+}
+
+func TestDeduplicate_MergesQueryParams(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:      "GET",
+				URL:         "https://example.com/api/users?page=1",
+				QueryParams: map[string]string{"page": "1"},
+			},
+			IsAPI:      true,
+			Confidence: 0.8,
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:      "GET",
+				URL:         "https://example.com/api/users?limit=10",
+				QueryParams: map[string]string{"limit": "10"},
+			},
+			IsAPI:      true,
+			Confidence: 0.7,
+		},
+	}
+
+	result := Deduplicate(classified)
+	if len(result) != 1 {
+		t.Fatalf("Deduplicate = %d results, want 1", len(result))
+	}
+	if result[0].QueryParams["page"] != "1" {
+		t.Errorf("missing merged param 'page'")
+	}
+	if result[0].QueryParams["limit"] != "10" {
+		t.Errorf("missing merged param 'limit'")
+	}
+}
+
+func TestDeduplicate_NoDuplicates(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/api/users",
+			},
+			IsAPI:      true,
+			Confidence: 0.8,
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/api/users",
+			},
+			IsAPI:      true,
+			Confidence: 0.9,
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/api/posts",
+			},
+			IsAPI:      true,
+			Confidence: 0.7,
+		},
+	}
+
+	result := Deduplicate(classified)
+	if len(result) != 3 {
+		t.Errorf("Deduplicate (no dups) = %d results, want 3", len(result))
+	}
+}
+
+func TestDeduplicate_KeepsHighestConfidence(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/api/data",
+			},
+			IsAPI:      true,
+			Confidence: 0.6,
+			Reason:     "low",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/api/data?q=test",
+			},
+			IsAPI:      true,
+			Confidence: 0.95,
+			Reason:     "high",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/api/data?q=other",
+			},
+			IsAPI:      true,
+			Confidence: 0.7,
+			Reason:     "mid",
+		},
+	}
+
+	result := Deduplicate(classified)
+	if len(result) != 1 {
+		t.Fatalf("Deduplicate = %d results, want 1", len(result))
+	}
+	if result[0].Confidence != 0.95 {
+		t.Errorf("Confidence = %v, want 0.95 (highest)", result[0].Confidence)
+	}
+	if result[0].Reason != "high" {
+		t.Errorf("Reason = %q, want %q (from highest confidence)", result[0].Reason, "high")
+	}
+}
+
+func TestDeduplicate_Empty(t *testing.T) {
+	result := Deduplicate(nil)
+	if len(result) != 0 {
+		t.Errorf("Deduplicate(nil) = %d results, want 0", len(result))
+	}
+}

--- a/pkg/classify/rest.go
+++ b/pkg/classify/rest.go
@@ -15,10 +15,35 @@
 package classify
 
 import (
+	"bytes"
+	"net/url"
+	"strings"
+
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
 )
 
-// RESTClassifier classifies REST API requests.
+// staticExtensions lists file extensions that indicate static assets.
+var staticExtensions = []string{
+	".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".ico",
+	".woff", ".woff2", ".ttf", ".eot", ".svg", ".map",
+}
+
+// staticPathSegments lists path segments that indicate static asset directories.
+var staticPathSegments = []string{
+	"/static/", "/assets/", "/dist/", "/bundle/",
+}
+
+// apiContentTypes lists content types that indicate API responses.
+var apiContentTypes = []string{
+	"application/json", "application/xml", "text/xml", "application/problem+json",
+}
+
+// apiPathSegments lists path segments that indicate API endpoints.
+var apiPathSegments = []string{
+	"/api/", "/v1/", "/v2/", "/v3/", "/rest/", "/rpc/", "/graphql",
+}
+
+// RESTClassifier classifies REST API requests using ordered heuristic rules.
 type RESTClassifier struct{}
 
 // Name returns the classifier name.
@@ -27,6 +52,95 @@ func (c *RESTClassifier) Name() string {
 }
 
 // Classify determines if the request is a REST API call.
-func (c *RESTClassifier) Classify(_ crawl.ObservedRequest) (bool, float64) {
-	return false, 0
+func (c *RESTClassifier) Classify(req crawl.ObservedRequest) (bool, float64) {
+	isAPI, confidence, _ := c.ClassifyDetail(req)
+	return isAPI, confidence
+}
+
+// ClassifyDetail returns classification result with a detailed reason string.
+//
+// Heuristic rules applied in order:
+//  1. Static asset exclusion → (false, 0, "")
+//  2. Content-type filter → confidence 0.8
+//  3. Path heuristics → boost +0.15 (cap 1.0)
+//  4. HTTP method signal → confidence max(current, 0.7)
+//  5. Response structure → confidence max(current, 0.85)
+func (c *RESTClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, float64, string) {
+	parsedURL, err := url.Parse(req.URL)
+	if err != nil {
+		return false, 0, ""
+	}
+
+	lowerPath := strings.ToLower(parsedURL.Path)
+
+	// Rule 1: Static asset exclusion.
+	for _, ext := range staticExtensions {
+		if strings.HasSuffix(lowerPath, ext) {
+			return false, 0, ""
+		}
+	}
+	for _, seg := range staticPathSegments {
+		if strings.Contains(lowerPath, seg) {
+			return false, 0, ""
+		}
+	}
+
+	var confidence float64
+	var reason string
+
+	// Rule 2: Content-type filter.
+	ct := strings.ToLower(req.Response.ContentType)
+	// Strip charset parameters (e.g., "application/json; charset=utf-8").
+	if idx := strings.Index(ct, ";"); idx != -1 {
+		ct = strings.TrimSpace(ct[:idx])
+	}
+	for _, apiCT := range apiContentTypes {
+		if ct == apiCT {
+			confidence = 0.8
+			reason = "content-type:" + apiCT
+			break
+		}
+	}
+
+	// Rule 3: Path heuristics.
+	for _, seg := range apiPathSegments {
+		if strings.Contains(lowerPath, seg) {
+			confidence += 0.15
+			if confidence > 1.0 {
+				confidence = 1.0
+			}
+			if reason == "" {
+				reason = "path-heuristic"
+			} else {
+				reason += "+path-heuristic"
+			}
+			break
+		}
+	}
+
+	// Rule 4: HTTP method signal.
+	upper := strings.ToUpper(req.Method)
+	if upper == "POST" || upper == "PUT" || upper == "PATCH" || upper == "DELETE" {
+		if confidence < 0.7 {
+			confidence = 0.7
+		}
+		if reason == "" {
+			reason = "method:" + upper
+		}
+	}
+
+	// Rule 5: Response structure (JSON body).
+	if len(req.Response.Body) > 0 {
+		trimmed := bytes.TrimSpace(req.Response.Body)
+		if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+			if confidence < 0.85 {
+				confidence = 0.85
+			}
+			if reason == "" {
+				reason = "response-structure:json"
+			}
+		}
+	}
+
+	return confidence > 0, confidence, reason
 }

--- a/pkg/classify/rest.go
+++ b/pkg/classify/rest.go
@@ -15,7 +15,6 @@
 package classify
 
 import (
-	"bytes"
 	"net/url"
 	"strings"
 
@@ -36,12 +35,21 @@ var staticPathSegments = []string{
 // apiContentTypes lists content types that indicate API responses.
 var apiContentTypes = []string{
 	"application/json", "application/xml", "text/xml", "application/problem+json",
+	"application/vnd.api+json", "application/hal+json",
 }
 
 // apiPathSegments lists path segments that indicate API endpoints.
 var apiPathSegments = []string{
 	"/api/", "/v1/", "/v2/", "/v3/", "/rest/", "/rpc/", "/graphql",
 }
+
+// Confidence scores assigned by each heuristic rule.
+const (
+	ContentTypeConfidence = 0.8  // Rule 2: API content-type match.
+	PathHeuristicBoost    = 0.15 // Rule 3: API path segment boost.
+	HTTPMethodConfidence  = 0.7  // Rule 4: Non-GET HTTP method signal.
+	JSONBodyConfidence    = 0.85 // Rule 5: JSON response structure.
+)
 
 // RESTClassifier classifies REST API requests using ordered heuristic rules.
 type RESTClassifier struct{}
@@ -96,7 +104,7 @@ func (c *RESTClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, float6
 	}
 	for _, apiCT := range apiContentTypes {
 		if ct == apiCT {
-			confidence = 0.8
+			confidence = ContentTypeConfidence
 			reason = "content-type:" + apiCT
 			break
 		}
@@ -105,7 +113,7 @@ func (c *RESTClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, float6
 	// Rule 3: Path heuristics.
 	for _, seg := range apiPathSegments {
 		if strings.Contains(lowerPath, seg) {
-			confidence += 0.15
+			confidence += PathHeuristicBoost
 			if confidence > 1.0 {
 				confidence = 1.0
 			}
@@ -121,8 +129,8 @@ func (c *RESTClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, float6
 	// Rule 4: HTTP method signal.
 	upper := strings.ToUpper(req.Method)
 	if upper == "POST" || upper == "PUT" || upper == "PATCH" || upper == "DELETE" {
-		if confidence < 0.7 {
-			confidence = 0.7
+		if confidence < HTTPMethodConfidence {
+			confidence = HTTPMethodConfidence
 		}
 		if reason == "" {
 			reason = "method:" + upper
@@ -130,11 +138,12 @@ func (c *RESTClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, float6
 	}
 
 	// Rule 5: Response structure (JSON body).
+	// Forward-only scan: find first non-whitespace byte without scanning
+	// the entire body from both ends (avoids O(n) scan on large bodies).
 	if len(req.Response.Body) > 0 {
-		trimmed := bytes.TrimSpace(req.Response.Body)
-		if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
-			if confidence < 0.85 {
-				confidence = 0.85
+		if b, ok := firstNonSpace(req.Response.Body); ok && (b == '{' || b == '[') {
+			if confidence < JSONBodyConfidence {
+				confidence = JSONBodyConfidence
 			}
 			if reason == "" {
 				reason = "response-structure:json"
@@ -143,4 +152,19 @@ func (c *RESTClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, float6
 	}
 
 	return confidence > 0, confidence, reason
+}
+
+// firstNonSpace returns the first non-ASCII-whitespace byte in b.
+// It scans forward only, making it O(1) for typical HTTP bodies that
+// start with a non-whitespace character.
+func firstNonSpace(b []byte) (byte, bool) {
+	for _, c := range b {
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return c, true
+		}
+	}
+	return 0, false
 }

--- a/pkg/classify/rest_test.go
+++ b/pkg/classify/rest_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package classify
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+func TestRESTClassifier_Name(t *testing.T) {
+	c := &RESTClassifier{}
+	if c.Name() != "rest" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "rest")
+	}
+}
+
+func TestRESTClassifier_Classify(t *testing.T) {
+	c := &RESTClassifier{}
+
+	tests := []struct {
+		name           string
+		req            crawl.ObservedRequest
+		wantIsAPI      bool
+		wantMinConf    float64
+		wantMaxConf    float64
+		wantReasonSub  string // substring expected in reason
+	}{
+		{
+			name: "JSON API response",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.8,
+			wantMaxConf:   1.0,
+			wantReasonSub: "content-type",
+		},
+		{
+			name: "JSON with charset",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json; charset=utf-8",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.8,
+			wantMaxConf:   1.0,
+			wantReasonSub: "content-type",
+		},
+		{
+			name: "XML API response",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data.xml",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/xml",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.8,
+			wantMaxConf:   1.0,
+			wantReasonSub: "content-type",
+		},
+		{
+			name: "Static JS file",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/static/app.js",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/javascript",
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "Static CSS file",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/assets/style.css",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "Image file PNG",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/images/logo.png",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "image/png",
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "Font file WOFF2",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/fonts/roboto.woff2",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "API path with JSON content-type",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/api/v1/users",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`[{"id":1,"name":"Alice"}]`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95, // 0.8 (content-type) + 0.15 (path)
+			wantMaxConf:   1.0,
+			wantReasonSub: "path-heuristic",
+		},
+		{
+			name: "API path only, no content-type, no body",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/api/v2/data",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.15,
+			wantMaxConf:   0.15,
+			wantReasonSub: "path-heuristic",
+		},
+		{
+			name: "POST request no other signals",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/submit",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.7,
+			wantMaxConf:   0.7,
+			wantReasonSub: "method",
+		},
+		{
+			name: "PUT request no other signals",
+			req: crawl.ObservedRequest{
+				Method: "PUT",
+				URL:    "https://example.com/resource/123",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+				},
+			},
+			wantIsAPI:   true,
+			wantMinConf: 0.7,
+			wantMaxConf: 0.7,
+		},
+		{
+			name: "DELETE request no other signals",
+			req: crawl.ObservedRequest{
+				Method: "DELETE",
+				URL:    "https://example.com/resource/123",
+				Response: crawl.ObservedResponse{
+					StatusCode: 204,
+				},
+			},
+			wantIsAPI:   true,
+			wantMinConf: 0.7,
+			wantMaxConf: 0.7,
+		},
+		{
+			name: "JSON body without content-type",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/endpoint",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+					Body:       []byte(`{"status":"ok"}`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.85,
+			wantMaxConf:   0.85,
+			wantReasonSub: "response-structure",
+		},
+		{
+			name: "HTML response no API signals",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/page",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "text/html",
+					Body:        []byte(`<html><body>Hello</body></html>`),
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "Empty response no signals",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/empty",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "GraphQL path heuristic",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/graphql",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"data":{"user":{"id":1}}}`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "path-heuristic",
+		},
+		{
+			name: "JSON array body",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/list",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+					Body:       []byte(`[1,2,3]`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.85,
+			wantMaxConf:   0.85,
+			wantReasonSub: "response-structure",
+		},
+		{
+			name: "Bundle path excluded",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/bundle/main.chunk.js",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "Problem JSON content-type",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/error",
+				Response: crawl.ObservedResponse{
+					StatusCode:  400,
+					ContentType: "application/problem+json",
+					Body:        []byte(`{"type":"about:blank","title":"Bad Request"}`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.8,
+			wantMaxConf:   1.0,
+			wantReasonSub: "content-type",
+		},
+		{
+			name: "REST path segment",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/rest/endpoint",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "path-heuristic",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isAPI, confidence, reason := c.ClassifyDetail(tt.req)
+			if isAPI != tt.wantIsAPI {
+				t.Errorf("isAPI = %v, want %v", isAPI, tt.wantIsAPI)
+			}
+			if confidence < tt.wantMinConf || confidence > tt.wantMaxConf {
+				t.Errorf("confidence = %v, want [%v, %v]", confidence, tt.wantMinConf, tt.wantMaxConf)
+			}
+			if tt.wantReasonSub != "" && !strings.Contains(reason, tt.wantReasonSub) {
+				t.Errorf("reason = %q, want substring %q", reason, tt.wantReasonSub)
+			}
+		})
+	}
+}
+
+func TestRESTClassifier_ImplementsDetailedClassifier(t *testing.T) {
+	var c APIClassifier = &RESTClassifier{}
+	if _, ok := c.(DetailedClassifier); !ok {
+		t.Error("RESTClassifier should implement DetailedClassifier")
+	}
+}

--- a/pkg/classify/rest_test.go
+++ b/pkg/classify/rest_test.go
@@ -32,12 +32,12 @@ func TestRESTClassifier_Classify(t *testing.T) {
 	c := &RESTClassifier{}
 
 	tests := []struct {
-		name           string
-		req            crawl.ObservedRequest
-		wantIsAPI      bool
-		wantMinConf    float64
-		wantMaxConf    float64
-		wantReasonSub  string // substring expected in reason
+		name          string
+		req           crawl.ObservedRequest
+		wantIsAPI     bool
+		wantMinConf   float64
+		wantMaxConf   float64
+		wantReasonSub string // substring expected in reason
 	}{
 		{
 			name: "JSON API response",

--- a/pkg/classify/rest_test.go
+++ b/pkg/classify/rest_test.go
@@ -15,17 +15,15 @@
 package classify
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRESTClassifier_Name(t *testing.T) {
 	c := &RESTClassifier{}
-	if c.Name() != "rest" {
-		t.Errorf("Name() = %q, want %q", c.Name(), "rest")
-	}
+	assert.Equal(t, "rest", c.Name())
 }
 
 func TestRESTClassifier_Classify(t *testing.T) {
@@ -50,7 +48,7 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:     true,
-			wantMinConf:   0.8,
+			wantMinConf:   ContentTypeConfidence,
 			wantMaxConf:   1.0,
 			wantReasonSub: "content-type",
 		},
@@ -65,7 +63,7 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:     true,
-			wantMinConf:   0.8,
+			wantMinConf:   ContentTypeConfidence,
 			wantMaxConf:   1.0,
 			wantReasonSub: "content-type",
 		},
@@ -80,7 +78,37 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:     true,
-			wantMinConf:   0.8,
+			wantMinConf:   ContentTypeConfidence,
+			wantMaxConf:   1.0,
+			wantReasonSub: "content-type",
+		},
+		{
+			name: "vendor JSON:API content-type",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/vnd.api+json",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   ContentTypeConfidence,
+			wantMaxConf:   1.0,
+			wantReasonSub: "content-type",
+		},
+		{
+			name: "HAL JSON content-type",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/hal+json",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   ContentTypeConfidence,
 			wantMaxConf:   1.0,
 			wantReasonSub: "content-type",
 		},
@@ -164,8 +192,8 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:     true,
-			wantMinConf:   0.15,
-			wantMaxConf:   0.15,
+			wantMinConf:   PathHeuristicBoost,
+			wantMaxConf:   PathHeuristicBoost,
 			wantReasonSub: "path-heuristic",
 		},
 		{
@@ -178,8 +206,8 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:     true,
-			wantMinConf:   0.7,
-			wantMaxConf:   0.7,
+			wantMinConf:   HTTPMethodConfidence,
+			wantMaxConf:   HTTPMethodConfidence,
 			wantReasonSub: "method",
 		},
 		{
@@ -192,8 +220,8 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:   true,
-			wantMinConf: 0.7,
-			wantMaxConf: 0.7,
+			wantMinConf: HTTPMethodConfidence,
+			wantMaxConf: HTTPMethodConfidence,
 		},
 		{
 			name: "DELETE request no other signals",
@@ -205,8 +233,8 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:   true,
-			wantMinConf: 0.7,
-			wantMaxConf: 0.7,
+			wantMinConf: HTTPMethodConfidence,
+			wantMaxConf: HTTPMethodConfidence,
 		},
 		{
 			name: "JSON body without content-type",
@@ -219,8 +247,8 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:     true,
-			wantMinConf:   0.85,
-			wantMaxConf:   0.85,
+			wantMinConf:   JSONBodyConfidence,
+			wantMaxConf:   JSONBodyConfidence,
 			wantReasonSub: "response-structure",
 		},
 		{
@@ -278,8 +306,8 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:     true,
-			wantMinConf:   0.85,
-			wantMaxConf:   0.85,
+			wantMinConf:   JSONBodyConfidence,
+			wantMaxConf:   JSONBodyConfidence,
 			wantReasonSub: "response-structure",
 		},
 		{
@@ -307,7 +335,7 @@ func TestRESTClassifier_Classify(t *testing.T) {
 				},
 			},
 			wantIsAPI:     true,
-			wantMinConf:   0.8,
+			wantMinConf:   ContentTypeConfidence,
 			wantMaxConf:   1.0,
 			wantReasonSub: "content-type",
 		},
@@ -331,14 +359,11 @@ func TestRESTClassifier_Classify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			isAPI, confidence, reason := c.ClassifyDetail(tt.req)
-			if isAPI != tt.wantIsAPI {
-				t.Errorf("isAPI = %v, want %v", isAPI, tt.wantIsAPI)
-			}
-			if confidence < tt.wantMinConf || confidence > tt.wantMaxConf {
-				t.Errorf("confidence = %v, want [%v, %v]", confidence, tt.wantMinConf, tt.wantMaxConf)
-			}
-			if tt.wantReasonSub != "" && !strings.Contains(reason, tt.wantReasonSub) {
-				t.Errorf("reason = %q, want substring %q", reason, tt.wantReasonSub)
+			assert.Equal(t, tt.wantIsAPI, isAPI, "isAPI")
+			assert.GreaterOrEqual(t, confidence, tt.wantMinConf, "confidence lower bound")
+			assert.LessOrEqual(t, confidence, tt.wantMaxConf, "confidence upper bound")
+			if tt.wantReasonSub != "" {
+				assert.Contains(t, reason, tt.wantReasonSub, "reason")
 			}
 		})
 	}
@@ -346,7 +371,5 @@ func TestRESTClassifier_Classify(t *testing.T) {
 
 func TestRESTClassifier_ImplementsDetailedClassifier(t *testing.T) {
 	var c APIClassifier = &RESTClassifier{}
-	if _, ok := c.(DetailedClassifier); !ok {
-		t.Error("RESTClassifier should implement DetailedClassifier")
-	}
+	assert.Implements(t, (*DetailedClassifier)(nil), c)
 }


### PR DESCRIPTION
## Ticket
[ENG-1417](https://linear.app/praetorianlabs/issue/ENG-1417/implement-rest-api-classifier)

## Summary

Implement the REST API classifier for vespasian's classify stage — the core heuristic engine that determines whether captured HTTP traffic represents API endpoints or static assets.

- **5-rule heuristic classifier** - Ordered rules with cumulative confidence scoring
- **DetailedClassifier interface** - Extends APIClassifier with reason strings for observability
- **Deduplication** - Merge duplicate endpoint observations, keeping highest confidence and merging query params
- **33 unit tests** - Table-driven tests with race detection covering all heuristic paths

## Problem

Vespasian's classify package had stub implementations (`return false, 0`) that couldn't distinguish API endpoints from static assets. The crawl stage captures all HTTP traffic indiscriminately — the classifier is needed to filter signal from noise before generating API specifications.

## Key Features

### Heuristic Classification Rules (applied in order)

| Rule | Signal | Confidence | Example |
|------|--------|-----------|---------|
| 1. Static exclusion | File extension or path segment | → skip | `.js`, `.css`, `/static/`, `/bundle/` |
| 2. Content-type | API content types | 0.80 | `application/json`, `application/xml` |
| 3. Path heuristic | API path segments | +0.15 (cap 1.0) | `/api/`, `/v1/`, `/graphql` |
| 4. HTTP method | Non-GET methods | max(current, 0.70) | POST, PUT, PATCH, DELETE |
| 5. Response structure | JSON body detection | max(current, 0.85) | `{...}` or `[...]` |

### Deduplication
- Key: `METHOD:path` (query params and fragments stripped)
- Merges unique QueryParams across duplicate observations
- Preserves highest confidence score and first occurrence's response body

### DetailedClassifier Interface
```go
type DetailedClassifier interface {
    APIClassifier
    ClassifyDetail(req crawl.ObservedRequest) (bool, float64, string)
}
```
RunClassifiers uses type assertion to extract detailed reasons when available, falling back to generic reason for plain APIClassifier implementations.

## Files Changed

### Modified
- `pkg/classify/rest.go` - Full heuristic classification with 5 ordered rules, ClassifyDetail implementation
- `pkg/classify/classifier.go` - DetailedClassifier interface, updated RunClassifiers with type assertion, Deduplicate function

### Added
- `pkg/classify/rest_test.go` - 22 test cases (20 table-driven + 2 extra) for REST classifier
- `pkg/classify/classifier_test.go` - 11 test functions for RunClassifiers and Deduplicate

## Test Commands

### Run Unit Tests
```bash
cd modules/vespasian
GOWORK=off go test -v -race ./pkg/classify/...
```

### Build
```bash
cd modules/vespasian
GOWORK=off go build ./...
```

## Test Plan

- [x] All 33 unit tests pass with race detection (`go test -race`)
- [x] Build succeeds (`go build ./...`)
- [x] Static assets correctly excluded (JS, CSS, PNG, WOFF2, ICO, SVG, MAP)
- [x] API content types detected (JSON, XML, problem+json, with charset stripping)
- [x] Path heuristics work (/api/, /v1/, /v2/, /v3/, /rest/, /rpc/, /graphql)
- [x] HTTP method signals work (POST, PUT, PATCH, DELETE)
- [x] JSON body structure detection works (objects and arrays)
- [x] Confidence scores cumulate correctly and cap at 1.0
- [x] Deduplication merges query params and preserves highest confidence
- [x] DetailedClassifier fallback path works for non-detailed classifiers
- [x] Verified against live APIs (JSONPlaceholder, httpbin, mock crAPI)