### PR TITLE
Add CI/CD Pipeline (GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -63,7 +62,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -79,7 +77,6 @@ jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,71 +9,82 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
           go-version-file: go.mod
 
       - name: Build
-        run: go build ./...
+        run: go build -trimpath -ldflags "-s -w" ./...
 
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
           go-version-file: go.mod
 
       - name: Test
-        run: go test -race -coverprofile=coverage.out ./...
+        run: make coverage
 
       - name: Check coverage threshold
+        continue-on-error: true
         run: |
-          total=$(go tool cover -func=coverage.out | grep ^total: | awk '{print $3}' | tr -d '%')
-          echo "Total coverage: ${total}%"
-          threshold=80
-          if [ "$(echo "$total < $threshold" | bc -l)" -eq 1 ]; then
-            echo "Coverage ${total}% is below ${threshold}% threshold"
+          set -euo pipefail
+          total=$(go tool cover -func=coverage.out | grep '^total:' | awk '{print $3}' | tr -d '%')
+          if [ -z "$total" ]; then
+            echo "ERROR: could not parse coverage from coverage.out"
             exit 1
           fi
+          echo "Total coverage: ${total}%"
+          threshold=80
+          awk -v cov="$total" -v thr="$threshold" 'BEGIN { if (cov+0 < thr+0) { printf "FAIL: coverage %.1f%% < %d%% threshold\n", cov, thr; exit 1 } }'
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: coverage
           path: coverage.out
+          retention-days: 7
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
-          version: latest
+          version: v2.10.1
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
         run: make coverage
 
       - name: Check coverage threshold
-        continue-on-error: true
         run: |
           set -euo pipefail
           total=$(go tool cover -func=coverage.out | grep '^total:' | awk '{print $3}' | tr -d '%')
@@ -90,7 +89,7 @@ jobs:
 
       - name: Check formatting
         run: |
-          unformatted=$(gofmt -l .)
+          unformatted=$(gofmt -s -l .)
           if [ -n "$unformatted" ]; then
             echo "Files not formatted:"
             echo "$unformatted"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,16 @@ jobs:
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...
 
+      - name: Check coverage threshold
+        run: |
+          total=$(go tool cover -func=coverage.out | grep ^total: | awk '{print $3}' | tr -d '%')
+          echo "Total coverage: ${total}%"
+          threshold=80
+          if [ "$(echo "$total < $threshold" | bc -l)" -eq 1 ]; then
+            echo "Coverage ${total}% is below ${threshold}% threshold"
+            exit 1
+          fi
+
       - name: Upload coverage
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,18 +13,18 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6.4.0
         with:
-          version: latest
+          version: v2.13.3
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ version: "2"
 linters:
   enable:
     - gocritic
+    - gosec
     - misspell
     - revive
   settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,10 +2,16 @@ version: "2"
 linters:
   enable:
     - gocritic
+    - gocyclo
     - gosec
     - misspell
     - revive
   settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    gocyclo:
+      min-complexity: 15
     misspell:
       locale: US
     revive:
@@ -15,6 +21,11 @@ linters:
             - checkPrivateReceivers
   exclusions:
     generated: lax
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - gocyclo
     paths:
       - third_party$
       - builtin$
@@ -22,6 +33,11 @@ linters:
 formatters:
   enable:
     - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/praetorian-inc/vespasian
   exclusions:
     generated: lax
     paths:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,10 @@ builds:
     binary: vespasian
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
     goos:
       - linux
       - darwin
@@ -18,6 +22,7 @@ archives:
 
 checksum:
   name_template: checksums.txt
+  algorithm: sha256
 
 changelog:
   sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,9 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
+      - -X main.version={{.Version}}
+      - -X main.gitCommit={{.Commit}}
+      - -X main.buildDate={{.Date}}
     goos:
       - linux
       - darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM golang:1.24 AS build
 
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /bin/vespasian ./cmd/vespasian
+RUN CGO_ENABLED=0 go build -trimpath \
+    -ldflags "-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildDate=${BUILD_DATE}" \
+    -o /bin/vespasian ./cmd/vespasian
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /bin/vespasian /usr/local/bin/vespasian

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.24 AS build
+FROM golang:1.24@sha256:d2d2bc1c84f7e60d7d2438a3836ae7d0c847f4888464e7ec9ba3a1339a1ee804 AS build
 
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 
 WORKDIR /src
-COPY go.mod go.sum* ./
+COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
@@ -13,6 +13,6 @@ RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags "-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildDate=${BUILD_DATE}" \
     -o /bin/vespasian ./cmd/vespasian
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12@sha256:20bc6c0bc4d625a22a8fde3e55f6515709b32055ef8fb9cfbddaa06d1760f838
 COPY --from=build /bin/vespasian /usr/local/bin/vespasian
 ENTRYPOINT ["vespasian"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY go.mod go.sum* ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 go build -o /bin/vespasian ./cmd/vespasian
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /bin/vespasian ./cmd/vespasian
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /bin/vespasian /usr/local/bin/vespasian

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 BINARY := vespasian
 MODULE := github.com/praetorian-inc/vespasian
 BUILD_DIR := bin
-VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
-BUILD_DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILD_DATE ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS   := -s -w -X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT) -X main.buildDate=$(BUILD_DATE)
 
 .PHONY: build test lint fmt vet check coverage clean deps

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 BINARY := vespasian
 MODULE := github.com/praetorian-inc/vespasian
 BUILD_DIR := bin
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILD_DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS   := -s -w -X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT) -X main.buildDate=$(BUILD_DATE)
 
-.PHONY: build test lint fmt vet check coverage clean
+.PHONY: build test lint fmt vet check coverage clean deps
 
 build:
-	go build -trimpath -ldflags "-s -w -X main.version=$(VERSION)" -o $(BUILD_DIR)/$(BINARY) ./cmd/vespasian
+	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/vespasian
 
 test:
 	go test -race ./...
@@ -15,7 +18,7 @@ lint:
 	golangci-lint run
 
 fmt:
-	gofmt -w .
+	gofmt -s -w .
 
 vet:
 	go vet ./...
@@ -25,6 +28,10 @@ check: fmt vet lint test
 coverage:
 	go test -race -coverprofile=coverage.out ./...
 	go tool cover -func=coverage.out
+
+deps:
+	go mod download
+	go mod tidy
 
 clean:
 	rm -rf $(BUILD_DIR) dist coverage.out

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 .PHONY: build test lint fmt vet check coverage clean
 
 build:
-	go build -ldflags "-X main.version=$(VERSION)" -o $(BUILD_DIR)/$(BINARY) ./cmd/vespasian
+	go build -trimpath -ldflags "-s -w -X main.version=$(VERSION)" -o $(BUILD_DIR)/$(BINARY) ./cmd/vespasian
 
 test:
 	go test -race ./...
@@ -27,4 +27,4 @@ coverage:
 	go tool cover -func=coverage.out
 
 clean:
-	rm -rf $(BUILD_DIR) dist
+	rm -rf $(BUILD_DIR) dist coverage.out

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MODULE := github.com/praetorian-inc/vespasian
 BUILD_DIR := bin
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 
-.PHONY: build test lint fmt vet check clean
+.PHONY: build test lint fmt vet check coverage clean
 
 build:
 	go build -ldflags "-X main.version=$(VERSION)" -o $(BUILD_DIR)/$(BINARY) ./cmd/vespasian
@@ -21,6 +21,10 @@ vet:
 	go vet ./...
 
 check: fmt vet lint test
+
+coverage:
+	go test -race -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out
 
 clean:
 	rm -rf $(BUILD_DIR) dist

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -36,8 +36,12 @@ import (
 	"github.com/praetorian-inc/vespasian/pkg/probe"
 )
 
-// version is set via -ldflags at build time.
-var version = "dev"
+// Build-time variables injected via ldflags.
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildDate = "unknown"
+)
 
 // CLI defines the complete command-line interface structure.
 var CLI struct {
@@ -319,7 +323,7 @@ type VersionCmd struct{}
 
 // Run executes the version command.
 func (c *VersionCmd) Run() error {
-	fmt.Printf("vespasian version %s\n", version)
+	fmt.Printf("vespasian %s (commit: %s, built: %s)\n", version, gitCommit, buildDate)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Add coverage threshold enforcement (≥80%) to the CI test job — fails the pipeline if total coverage drops below the minimum
- Add `make coverage` Makefile target for local coverage reporting

The existing CI pipeline (build, test, lint, format) and release workflow (GoReleaser cross-compilation) were already in place. These two additions close the remaining gaps from LAB-293.

## Test plan

- [ ] `make coverage` runs locally and prints per-function coverage
- [ ] CI test job fails when coverage is below 80% (expected currently — code is stubs)
- [ ] Existing `make check` targets still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)