### PR TITLE
feat: wire up CLI commands (crawl, import, generate, scan)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# .claude
+.claude/

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -16,10 +16,21 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+	"github.com/praetorian-inc/vespasian/pkg/generate"
+	"github.com/praetorian-inc/vespasian/pkg/importer"
+	"github.com/praetorian-inc/vespasian/pkg/probe"
 )
 
 // CLI defines the complete command-line interface structure.
@@ -47,13 +58,32 @@ type CrawlCmd struct {
 
 // Run executes the crawl command.
 func (c *CrawlCmd) Run() error {
-	fmt.Println("crawl: not implemented")
-	return nil
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	requests, err := executeCrawl(ctx, c.URL, c.Header, crawl.CrawlerOptions{
+		Depth:    c.Depth,
+		MaxPages: c.MaxPages,
+		Timeout:  c.Timeout,
+		Scope:    c.Scope,
+		Headless: c.Headless,
+	}, c.Verbose)
+	if err != nil {
+		return err
+	}
+
+	w, cleanup, err := openOutput(c.Output)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return crawl.WriteCapture(w, requests)
 }
 
 // ImportCmd imports traffic capture from external sources.
 type ImportCmd struct {
-	Format  string `arg:"" help:"Import format (e.g., burp, har, mitmproxy)"`
+	Format  string `arg:"" enum:"burp,har,mitmproxy" help:"Import format (burp, har, mitmproxy)"`
 	File    string `arg:"" help:"Input file path"`
 	Output  string `short:"o" help:"Output file path"`
 	Scope   string `optional:"" help:"Filter scope (optional: same-origin or same-domain)"`
@@ -62,8 +92,37 @@ type ImportCmd struct {
 
 // Run executes the import command.
 func (c *ImportCmd) Run() error {
-	fmt.Println("import: not implemented")
-	return nil
+	imp, err := importer.Get(c.Format)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(c.File)
+	if err != nil {
+		return fmt.Errorf("open input file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "importing %s traffic from %s\n", imp.Name(), c.File)
+	}
+
+	requests, err := imp.Import(f)
+	if err != nil {
+		return fmt.Errorf("import failed: %w", err)
+	}
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "imported %d requests\n", len(requests))
+	}
+
+	w, cleanup, err := openOutput(c.Output)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return crawl.WriteCapture(w, requests)
 }
 
 // GenerateCmd generates API specifications from captured traffic.
@@ -78,8 +137,34 @@ type GenerateCmd struct {
 
 // Run executes the generate command.
 func (c *GenerateCmd) Run() error {
-	fmt.Println("generate: not implemented")
-	return nil
+	f, err := os.Open(c.Capture)
+	if err != nil {
+		return fmt.Errorf("open capture file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	requests, err := crawl.ReadCapture(f)
+	if err != nil {
+		return fmt.Errorf("read capture file: %w", err)
+	}
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "loaded %d captured requests\n", len(requests))
+	}
+
+	spec, err := generateSpec(context.Background(), requests, c.APIType, c.Confidence, c.Probe, c.Verbose)
+	if err != nil {
+		return err
+	}
+
+	w, cleanup, err := openOutput(c.Output)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	_, err = w.Write(spec)
+	return err
 }
 
 // ScanCmd runs the full pipeline: crawl, classify, and generate.
@@ -97,10 +182,39 @@ type ScanCmd struct {
 	Verbose    bool          `short:"v" help:"Enable verbose logging"`
 }
 
-// Run executes the scan command.
+// Run executes the scan command (crawl + generate pipeline).
 func (c *ScanCmd) Run() error {
-	fmt.Println("scan: not implemented")
-	return nil
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	requests, err := executeCrawl(ctx, c.URL, c.Header, crawl.CrawlerOptions{
+		Depth:    c.Depth,
+		MaxPages: c.MaxPages,
+		Timeout:  c.Timeout,
+		Scope:    c.Scope,
+		Headless: c.Headless,
+	}, c.Verbose)
+	if err != nil {
+		return err
+	}
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "generating REST spec\n")
+	}
+
+	spec, err := generateSpec(ctx, requests, "rest", c.Confidence, c.Probe, c.Verbose)
+	if err != nil {
+		return err
+	}
+
+	w, cleanup, err := openOutput(c.Output)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	_, err = w.Write(spec)
+	return err
 }
 
 // VersionCmd shows version information.
@@ -120,4 +234,123 @@ func main() {
 	)
 	err := ctx.Run()
 	ctx.FatalIfErrorf(err)
+}
+
+// executeCrawl validates inputs, creates a crawler, and executes the crawl.
+func executeCrawl(ctx context.Context, targetURL string, rawHeaders []string, opts crawl.CrawlerOptions, verbose bool) ([]crawl.ObservedRequest, error) {
+	if err := validateURL(targetURL); err != nil {
+		return nil, err
+	}
+
+	headers, err := parseHeaders(rawHeaders)
+	if err != nil {
+		return nil, err
+	}
+	opts.Headers = headers
+
+	cr := crawl.NewCrawler(opts)
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "crawling %s (depth=%d, max-pages=%d, timeout=%s)\n",
+			targetURL, opts.Depth, opts.MaxPages, opts.Timeout)
+	}
+
+	requests, err := cr.Crawl(ctx, targetURL)
+	if err != nil {
+		return nil, fmt.Errorf("crawl failed: %w", err)
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "captured %d requests\n", len(requests))
+	}
+
+	return requests, nil
+}
+
+// generateSpec runs the classify → probe → generate pipeline.
+func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, apiType string, confidence float64, doProbe bool, verbose bool) ([]byte, error) {
+	classifiers := classifiersForType(apiType)
+	classified := classify.RunClassifiers(classifiers, requests, confidence)
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "classified %d API requests (threshold=%.2f)\n", len(classified), confidence)
+	}
+
+	if doProbe {
+		strategies := []probe.ProbeStrategy{
+			&probe.OptionsProbe{},
+			&probe.SchemaProbe{},
+		}
+		enriched, err := probe.RunStrategies(ctx, strategies, classified)
+		if err != nil {
+			return nil, fmt.Errorf("probe failed: %w", err)
+		}
+		classified = enriched
+	}
+
+	gen, err := generate.Get(apiType)
+	if err != nil {
+		return nil, err
+	}
+
+	spec, err := gen.Generate(classified)
+	if err != nil {
+		return nil, fmt.Errorf("generate failed: %w", err)
+	}
+
+	return spec, nil
+}
+
+// classifiersForType returns the appropriate classifiers for the given API type.
+func classifiersForType(apiType string) []classify.APIClassifier {
+	switch apiType {
+	case "rest":
+		return []classify.APIClassifier{&classify.RESTClassifier{}}
+	default:
+		return nil
+	}
+}
+
+// validateURL checks that the given string is a valid URL with scheme and host.
+func validateURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("invalid URL %q: must include scheme and host (e.g., https://example.com)", rawURL)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid URL %q: scheme must be http or https", rawURL)
+	}
+	return nil
+}
+
+// parseHeaders parses "Key: Value" header strings into a map.
+func parseHeaders(headers []string) (map[string]string, error) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]string, len(headers))
+	for _, h := range headers {
+		key, value, ok := strings.Cut(h, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid header %q: must be in \"Key: Value\" format", h)
+		}
+		result[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return result, nil
+}
+
+// openOutput returns a writer for the given path, or stdout if path is empty.
+// The returned cleanup function must be called when writing is complete.
+func openOutput(path string) (io.Writer, func(), error) {
+	if path == "" {
+		return os.Stdout, func() {}, nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create output file: %w", err)
+	}
+	return f, func() { _ = f.Close() }, nil
 }

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"valid https", "https://example.com", false},
+		{"valid http", "http://example.com", false},
+		{"valid with path", "https://example.com/api/v1", false},
+		{"valid with port", "https://example.com:8080", false},
+		{"missing scheme", "example.com", true},
+		{"missing host", "https://", true},
+		{"empty string", "", true},
+		{"ftp scheme", "ftp://example.com", true},
+		{"just path", "/api/v1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+		wantLen int
+		wantErr bool
+	}{
+		{"nil headers", nil, 0, false},
+		{"empty headers", []string{}, 0, false},
+		{"single header", []string{"Authorization: Bearer token"}, 1, false},
+		{"multiple headers", []string{"Authorization: Bearer token", "Content-Type: application/json"}, 2, false},
+		{"header with extra colons", []string{"Authorization: Bearer: token: extra"}, 1, false},
+		{"invalid header no colon", []string{"InvalidHeader"}, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseHeaders(tt.headers)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseHeaders() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(result) != tt.wantLen {
+				t.Errorf("parseHeaders() got %d headers, want %d", len(result), tt.wantLen)
+			}
+		})
+	}
+
+	// Verify specific header values
+	t.Run("header values", func(t *testing.T) {
+		result, err := parseHeaders([]string{"Authorization: Bearer token123"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := result["Authorization"]; got != "Bearer token123" {
+			t.Errorf("got %q, want %q", got, "Bearer token123")
+		}
+	})
+
+	// Verify trimming
+	t.Run("header trimming", func(t *testing.T) {
+		result, err := parseHeaders([]string{"  Key  :  Value  "})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := result["Key"]; got != "Value" {
+			t.Errorf("got %q, want %q", got, "Value")
+		}
+	})
+}
+
+func TestOpenOutput(t *testing.T) {
+	t.Run("stdout when empty", func(t *testing.T) {
+		w, cleanup, err := openOutput("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if w != os.Stdout {
+			t.Error("expected os.Stdout for empty path")
+		}
+	})
+
+	t.Run("file when path given", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test-output.json")
+		w, cleanup, err := openOutput(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if w == os.Stdout {
+			t.Error("expected file writer, got os.Stdout")
+		}
+		// Verify file was created
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Error("output file was not created")
+		}
+	})
+
+	t.Run("error on bad path", func(t *testing.T) {
+		_, _, err := openOutput("/nonexistent/directory/file.json")
+		if err == nil {
+			t.Error("expected error for nonexistent directory")
+		}
+	})
+}
+
+func TestClassifiersForType(t *testing.T) {
+	tests := []struct {
+		name    string
+		apiType string
+		wantLen int
+	}{
+		{"rest returns classifier", "rest", 1},
+		{"unknown returns nil", "unknown", 0},
+		{"graphql returns nil", "graphql", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			classifiers := classifiersForType(tt.apiType)
+			if len(classifiers) != tt.wantLen {
+				t.Errorf("classifiersForType(%q) got %d classifiers, want %d", tt.apiType, len(classifiers), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestVersionCmd(t *testing.T) {
+	cmd := &VersionCmd{}
+	if err := cmd.Run(); err != nil {
+		t.Errorf("VersionCmd.Run() error = %v", err)
+	}
+}
+
+func TestCrawlCmdInvalidURL(t *testing.T) {
+	cmd := &CrawlCmd{URL: "not-a-url"}
+	err := cmd.Run()
+	if err == nil {
+		t.Error("expected error for invalid URL")
+	}
+}
+
+func TestCrawlCmdInvalidHeader(t *testing.T) {
+	cmd := &CrawlCmd{
+		URL:    "https://example.com",
+		Header: []string{"no-colon-header"},
+	}
+	err := cmd.Run()
+	if err == nil {
+		t.Error("expected error for invalid header")
+	}
+}
+
+func TestImportCmdMissingFile(t *testing.T) {
+	cmd := &ImportCmd{
+		Format: "burp",
+		File:   "/nonexistent/file.xml",
+	}
+	err := cmd.Run()
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestGenerateCmdMissingCapture(t *testing.T) {
+	cmd := &GenerateCmd{
+		APIType: "rest",
+		Capture: "/nonexistent/capture.json",
+	}
+	err := cmd.Run()
+	if err == nil {
+		t.Error("expected error for missing capture file")
+	}
+}
+
+func TestScanCmdInvalidURL(t *testing.T) {
+	cmd := &ScanCmd{URL: "not-a-url"}
+	err := cmd.Run()
+	if err == nil {
+		t.Error("expected error for invalid URL")
+	}
+}

--- a/pkg/generate/registry.go
+++ b/pkg/generate/registry.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"fmt"
+
+	"github.com/praetorian-inc/vespasian/pkg/generate/rest"
+)
+
+// Get returns a SpecGenerator for the given API type.
+func Get(apiType string) (SpecGenerator, error) {
+	switch apiType {
+	case "rest":
+		return &rest.OpenAPIGenerator{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported API type: %q (supported: rest)", apiType)
+	}
+}

--- a/pkg/generate/registry_test.go
+++ b/pkg/generate/registry_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiType    string
+		wantType   string
+		wantErr    bool
+		errContain string
+	}{
+		{"rest", "rest", "rest", false, ""},
+		{"unsupported graphql", "graphql", "", true, "unsupported API type"},
+		{"empty", "", "", true, "unsupported API type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gen, err := Get(tt.apiType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Get(%q) error = %v, wantErr %v", tt.apiType, err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("Get(%q) error = %q, want containing %q", tt.apiType, err, tt.errContain)
+				}
+				return
+			}
+			if gen.APIType() != tt.wantType {
+				t.Errorf("Get(%q).APIType() = %q, want %q", tt.apiType, gen.APIType(), tt.wantType)
+			}
+		})
+	}
+}

--- a/pkg/importer/burp.go
+++ b/pkg/importer/burp.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import (
+	"errors"
+	"io"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// BurpImporter converts Burp Suite XML traffic exports to ObservedRequest format.
+type BurpImporter struct{}
+
+// Name returns the importer name.
+func (i *BurpImporter) Name() string {
+	return "burp"
+}
+
+// Import reads Burp Suite XML and converts to ObservedRequest format.
+func (i *BurpImporter) Import(_ io.Reader) ([]crawl.ObservedRequest, error) {
+	return nil, errors.New("burp import: not implemented")
+}

--- a/pkg/importer/har.go
+++ b/pkg/importer/har.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import (
+	"errors"
+	"io"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// HARImporter converts HAR (HTTP Archive) files to ObservedRequest format.
+type HARImporter struct{}
+
+// Name returns the importer name.
+func (i *HARImporter) Name() string {
+	return "har"
+}
+
+// Import reads HAR JSON and converts to ObservedRequest format.
+func (i *HARImporter) Import(_ io.Reader) ([]crawl.ObservedRequest, error) {
+	return nil, errors.New("har import: not implemented")
+}

--- a/pkg/importer/mitmproxy.go
+++ b/pkg/importer/mitmproxy.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import (
+	"errors"
+	"io"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// MitmproxyImporter converts mitmproxy flow exports to ObservedRequest format.
+type MitmproxyImporter struct{}
+
+// Name returns the importer name.
+func (i *MitmproxyImporter) Name() string {
+	return "mitmproxy"
+}
+
+// Import reads mitmproxy flows and converts to ObservedRequest format.
+func (i *MitmproxyImporter) Import(_ io.Reader) ([]crawl.ObservedRequest, error) {
+	return nil, errors.New("mitmproxy import: not implemented")
+}

--- a/pkg/importer/registry.go
+++ b/pkg/importer/registry.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import "fmt"
+
+// Get returns a TrafficImporter for the given format name.
+func Get(format string) (TrafficImporter, error) {
+	switch format {
+	case "burp":
+		return &BurpImporter{}, nil
+	case "har":
+		return &HARImporter{}, nil
+	case "mitmproxy":
+		return &MitmproxyImporter{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported import format: %q (supported: burp, har, mitmproxy)", format)
+	}
+}

--- a/pkg/importer/registry_test.go
+++ b/pkg/importer/registry_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name       string
+		format     string
+		wantName   string
+		wantErr    bool
+		errContain string
+	}{
+		{"burp", "burp", "burp", false, ""},
+		{"har", "har", "har", false, ""},
+		{"mitmproxy", "mitmproxy", "mitmproxy", false, ""},
+		{"unsupported", "wireshark", "", true, "unsupported import format"},
+		{"empty", "", "", true, "unsupported import format"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imp, err := Get(tt.format)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Get(%q) error = %v, wantErr %v", tt.format, err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("Get(%q) error = %q, want containing %q", tt.format, err, tt.errContain)
+				}
+				return
+			}
+			if imp.Name() != tt.wantName {
+				t.Errorf("Get(%q).Name() = %q, want %q", tt.format, imp.Name(), tt.wantName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Wire up `crawl`, `import`, `generate`, and `scan` CLI commands to underlying `pkg/` packages (LAB-112)
- Add `executeCrawl` shared helper to eliminate duplication between `crawl` and `scan` commands
- Add `generateSpec` pipeline: classify → probe → generate
- Add importer stubs (burp, har, mitmproxy) with `importer.Get()` registry lookup
- Add generator registry with `generate.Get()` for API type → SpecGenerator resolution
- Add input validation (URL scheme/host, header format, enum-validated import formats)
- Add verbose logging to stderr, output to file or stdout
- Add tests for helper functions and command error handling

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test -race ./...` passes (all packages)
- [x] `go vet ./...` clean
- [x] `gofmt` clean
- [x] `TestValidateURL` covers valid/invalid URLs (9 cases)
- [x] `TestParseHeaders` covers header parsing and edge cases (8 cases)
- [x] `TestOpenOutput` covers stdout, file, and error paths
- [x] `TestClassifiersForType` covers known and unknown types
- [x] Command error tests verify invalid URL, missing file, bad header handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)