### PR TITLE
feat: add WSDL/SOAP classifier, probe, and generator (PS-435)

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -17,10 +17,10 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -28,11 +28,19 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
+
 	"github.com/praetorian-inc/vespasian/pkg/classify"
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
 	"github.com/praetorian-inc/vespasian/pkg/generate"
-	wsdlgen "github.com/praetorian-inc/vespasian/pkg/generate/wsdl"
+	"github.com/praetorian-inc/vespasian/pkg/importer"
 	"github.com/praetorian-inc/vespasian/pkg/probe"
+)
+
+// Build-time variables injected via ldflags.
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildDate = "unknown"
 )
 
 // CLI defines the complete command-line interface structure.
@@ -66,17 +74,14 @@ func parseHeaders(raw []string) (map[string]string, error) {
 }
 
 // doCrawl executes the common crawl pipeline: parse headers, create crawler,
-// run the crawl with signal handling, and return the results. On graceful
+// run the crawl with the provided context, and return the results. On graceful
 // shutdown (SIGINT/SIGTERM) partial results are returned instead of an error.
-func doCrawl(targetURL string, rawHeaders []string, opts crawl.CrawlerOptions) ([]crawl.ObservedRequest, error) {
+func doCrawl(ctx context.Context, targetURL string, rawHeaders []string, opts crawl.CrawlerOptions) ([]crawl.ObservedRequest, error) {
 	headers, err := parseHeaders(rawHeaders)
 	if err != nil {
 		return nil, fmt.Errorf("invalid header: %w", err)
 	}
 	opts.Headers = headers
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	crawler := crawl.NewCrawler(opts)
 	requests, err := crawler.Crawl(ctx, targetURL)
@@ -111,12 +116,10 @@ func writeOutput(path string, fn func(io.Writer) error) error {
 	return nil
 }
 
-// CrawlCmd crawls a web application to capture HTTP traffic.
-type CrawlCmd struct {
-	URL      string        `arg:"" help:"Target URL to crawl"`
+// CrawlOptions holds the shared crawl configuration fields used by CrawlCmd and ScanCmd.
+type CrawlOptions struct {
 	Header   []string      `short:"H" help:"Custom headers (repeatable)"`
 	Output   string        `short:"o" help:"Output file path"`
-	Format   string        `default:"json" enum:"json,yaml" help:"Output format"`
 	Depth    int           `default:"3" help:"Maximum crawl depth"`
 	MaxPages int           `default:"100" help:"Maximum pages to crawl"`
 	Timeout  time.Duration `default:"30s" help:"Request timeout"`
@@ -125,8 +128,19 @@ type CrawlCmd struct {
 	Verbose  bool          `short:"v" help:"Enable verbose logging"`
 }
 
+// CrawlCmd crawls a web application to capture HTTP traffic.
+type CrawlCmd struct {
+	URL    string `arg:"" help:"Target URL to crawl"`
+	Format string `default:"json" enum:"json,yaml" help:"Output format"`
+	CrawlOptions
+}
+
 // Run executes the crawl command.
 func (c *CrawlCmd) Run() error {
+	if err := validateURL(c.URL); err != nil {
+		return err
+	}
+
 	opts := crawl.CrawlerOptions{
 		Depth:    c.Depth,
 		MaxPages: c.MaxPages,
@@ -134,10 +148,24 @@ func (c *CrawlCmd) Run() error {
 		Scope:    c.Scope,
 		Headless: c.Headless,
 	}
-	requests, err := doCrawl(c.URL, c.Header, opts)
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "crawling %s (depth=%d, max-pages=%d, timeout=%s)\n",
+			c.URL, opts.Depth, opts.MaxPages, opts.Timeout)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	requests, err := doCrawl(ctx, c.URL, c.Header, opts)
 	if err != nil {
 		return err
 	}
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "captured %d requests\n", len(requests))
+	}
+
 	return writeOutput(c.Output, func(w io.Writer) error {
 		return crawl.WriteCapture(w, requests)
 	})
@@ -145,17 +173,41 @@ func (c *CrawlCmd) Run() error {
 
 // ImportCmd imports traffic capture from external sources.
 type ImportCmd struct {
-	Format  string `arg:"" help:"Import format (e.g., burp, har, mitmproxy)"`
+	Format  string `arg:"" enum:"burp,har,mitmproxy" help:"Import format (burp, har, mitmproxy)"`
 	File    string `arg:"" help:"Input file path"`
 	Output  string `short:"o" help:"Output file path"`
-	Scope   string `optional:"" help:"Filter scope (optional: same-origin or same-domain)"`
 	Verbose bool   `short:"v" help:"Enable verbose logging"`
 }
 
 // Run executes the import command.
 func (c *ImportCmd) Run() error {
-	fmt.Println("import: not implemented")
-	return nil
+	imp, err := importer.Get(c.Format)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(c.File)
+	if err != nil {
+		return fmt.Errorf("open input file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "importing %s traffic from %s\n", imp.Name(), c.File)
+	}
+
+	requests, err := imp.Import(f)
+	if err != nil {
+		return fmt.Errorf("import failed: %w", err)
+	}
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "imported %d requests\n", len(requests))
+	}
+
+	return writeOutput(c.Output, func(w io.Writer) error {
+		return crawl.WriteCapture(w, requests)
+	})
 }
 
 // GenerateCmd generates API specifications from captured traffic.
@@ -168,87 +220,67 @@ type GenerateCmd struct {
 	Verbose    bool    `short:"v" help:"Enable verbose logging"`
 }
 
+// maxCaptureSize is the maximum capture file size (100MB).
+const maxCaptureSize = 100 * 1024 * 1024
+
 // Run executes the generate command.
-func (c *GenerateCmd) Run() error {
+func (c *GenerateCmd) Run() (err error) {
 	f, err := os.Open(c.Capture)
 	if err != nil {
-		return fmt.Errorf("failed to open capture file: %w", err)
+		return fmt.Errorf("open capture file: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing capture file: %w", cerr)
+		}
+	}()
+
+	// Guard against excessively large capture files.
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat capture file: %w", err)
+	}
+	if info.Size() > maxCaptureSize {
+		return fmt.Errorf("capture file too large: %d bytes (max %d)", info.Size(), maxCaptureSize)
+	}
 
 	requests, err := crawl.ReadCapture(f)
 	if err != nil {
-		return fmt.Errorf("failed to read capture: %w", err)
+		return fmt.Errorf("read capture file: %w", err)
 	}
 
-	classifiers := []classify.APIClassifier{
-		&classify.RESTClassifier{},
-		&classify.WSDLClassifier{},
-	}
-	classified := classify.Deduplicate(classify.RunClassifiers(classifiers, requests, c.Confidence))
-
-	var filtered []classify.ClassifiedRequest
-	for _, req := range classified {
-		if req.APIType == c.APIType {
-			filtered = append(filtered, req)
-		}
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "loaded %d captured requests\n", len(requests))
 	}
 
-	if len(filtered) == 0 {
-		return fmt.Errorf("no %s endpoints found in capture", c.APIType)
-	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
-	if c.Probe {
-		var strategies []probe.ProbeStrategy
-		cfg := probe.DefaultConfig()
-		switch c.APIType {
-		case "wsdl":
-			strategies = append(strategies, probe.NewWSDLProbe(cfg))
-		case "rest":
-			strategies = append(strategies, probe.NewOptionsProbe(cfg))
-			strategies = append(strategies, probe.NewSchemaProbe(cfg))
-		}
-		if len(strategies) > 0 {
-			filtered, _ = probe.RunStrategies(context.Background(), strategies, filtered)
-		}
-	}
-
-	var gen generate.SpecGenerator
-	switch c.APIType {
-	case "wsdl":
-		gen = &wsdlgen.Generator{}
-	default:
-		return fmt.Errorf("generator for %q not yet implemented", c.APIType)
-	}
-
-	output, err := gen.Generate(filtered)
+	spec, err := generateSpec(ctx, requests, c.APIType, c.Confidence, c.Probe, c.Verbose)
 	if err != nil {
-		return fmt.Errorf("generation failed: %w", err)
+		return err
 	}
 
 	return writeOutput(c.Output, func(w io.Writer) error {
-		_, err := w.Write(output)
-		return err
+		_, writeErr := w.Write(spec)
+		return writeErr
 	})
 }
 
 // ScanCmd runs the full pipeline: crawl, classify, and generate.
 type ScanCmd struct {
-	URL        string        `arg:"" help:"Target URL to scan"`
-	Header     []string      `short:"H" help:"Custom headers (repeatable)"`
-	Output     string        `short:"o" help:"Output file path"`
-	Depth      int           `default:"3" help:"Maximum crawl depth"`
-	MaxPages   int           `default:"100" help:"Maximum pages to crawl"`
-	Timeout    time.Duration `default:"30s" help:"Request timeout"`
-	Scope      string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
-	Headless   bool          `default:"true" help:"Use headless browser"`
-	Confidence float64       `default:"0.5" help:"Minimum confidence threshold"`
-	Probe      bool          `default:"true" help:"Enable endpoint probing"`
-	Verbose    bool          `short:"v" help:"Enable verbose logging"`
+	URL        string  `arg:"" help:"Target URL to scan"`
+	Confidence float64 `default:"0.5" help:"Minimum confidence threshold"`
+	Probe      bool    `default:"true" help:"Enable endpoint probing"`
+	CrawlOptions
 }
 
-// Run executes the scan command.
+// Run executes the scan command (crawl + generate pipeline).
 func (c *ScanCmd) Run() error {
+	if err := validateURL(c.URL); err != nil {
+		return err
+	}
+
 	opts := crawl.CrawlerOptions{
 		Depth:    c.Depth,
 		MaxPages: c.MaxPages,
@@ -256,23 +288,33 @@ func (c *ScanCmd) Run() error {
 		Scope:    c.Scope,
 		Headless: c.Headless,
 	}
-	requests, err := doCrawl(c.URL, c.Header, opts)
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "crawling %s (depth=%d, max-pages=%d, timeout=%s)\n",
+			c.URL, opts.Depth, opts.MaxPages, opts.Timeout)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	requests, err := doCrawl(ctx, c.URL, c.Header, opts)
 	if err != nil {
 		return err
 	}
 
-	classified := classify.Deduplicate(classify.RunClassifiers(
-		[]classify.APIClassifier{
-			&classify.RESTClassifier{},
-			&classify.WSDLClassifier{},
-		},
-		requests, c.Confidence,
-	))
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "captured %d requests\n", len(requests))
+		fmt.Fprintf(os.Stderr, "generating REST spec\n")
+	}
+
+	spec, err := generateSpec(ctx, requests, "rest", c.Confidence, c.Probe, c.Verbose)
+	if err != nil {
+		return err
+	}
 
 	return writeOutput(c.Output, func(w io.Writer) error {
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(classified)
+		_, writeErr := w.Write(spec)
+		return writeErr
 	})
 }
 
@@ -281,7 +323,7 @@ type VersionCmd struct{}
 
 // Run executes the version command.
 func (c *VersionCmd) Run() error {
-	fmt.Println("vespasian version dev")
+	fmt.Printf("vespasian %s (commit: %s, built: %s)\n", version, gitCommit, buildDate)
 	return nil
 }
 
@@ -293,4 +335,76 @@ func main() {
 	)
 	err := ctx.Run()
 	ctx.FatalIfErrorf(err)
+}
+
+// generateSpec runs the classify → probe → generate pipeline.
+func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, apiType string, confidence float64, doProbe bool, verbose bool) ([]byte, error) {
+	classifiers := classifiersForType(apiType)
+	if classifiers == nil {
+		return nil, fmt.Errorf("unsupported API type: %q", apiType)
+	}
+	classified := classify.Deduplicate(classify.RunClassifiers(classifiers, requests, confidence))
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "classified %d API requests (threshold=%.2f)\n", len(classified), confidence)
+	}
+
+	if doProbe {
+		var strategies []probe.ProbeStrategy
+		switch apiType {
+		case "wsdl":
+			strategies = []probe.ProbeStrategy{probe.NewWSDLProbe(probe.DefaultConfig())}
+		default:
+			strategies = []probe.ProbeStrategy{
+				&probe.OptionsProbe{},
+				&probe.SchemaProbe{},
+			}
+		}
+		enriched, probeErrs := probe.RunStrategies(ctx, strategies, classified)
+		if verbose {
+			for _, e := range probeErrs {
+				fmt.Fprintf(os.Stderr, "probe warning: %v\n", e)
+			}
+		}
+		classified = enriched
+	}
+
+	gen, err := generate.Get(apiType)
+	if err != nil {
+		return nil, err
+	}
+
+	spec, err := gen.Generate(classified)
+	if err != nil {
+		return nil, fmt.Errorf("generate failed: %w", err)
+	}
+
+	return spec, nil
+}
+
+// classifiersForType returns the appropriate classifiers for the given API type.
+func classifiersForType(apiType string) []classify.APIClassifier {
+	switch apiType {
+	case "rest":
+		return []classify.APIClassifier{&classify.RESTClassifier{}}
+	case "wsdl":
+		return []classify.APIClassifier{&classify.WSDLClassifier{}}
+	default:
+		return nil
+	}
+}
+
+// validateURL checks that the given string is a valid URL with scheme and host.
+func validateURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("invalid URL %q: must include scheme and host (e.g., https://example.com)", rawURL)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid URL %q: scheme must be http or https", rawURL)
+	}
+	return nil
 }

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -17,10 +17,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -28,19 +28,11 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
-
 	"github.com/praetorian-inc/vespasian/pkg/classify"
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
 	"github.com/praetorian-inc/vespasian/pkg/generate"
-	"github.com/praetorian-inc/vespasian/pkg/importer"
+	wsdlgen "github.com/praetorian-inc/vespasian/pkg/generate/wsdl"
 	"github.com/praetorian-inc/vespasian/pkg/probe"
-)
-
-// Build-time variables injected via ldflags.
-var (
-	version   = "dev"
-	gitCommit = "unknown"
-	buildDate = "unknown"
 )
 
 // CLI defines the complete command-line interface structure.
@@ -74,14 +66,17 @@ func parseHeaders(raw []string) (map[string]string, error) {
 }
 
 // doCrawl executes the common crawl pipeline: parse headers, create crawler,
-// run the crawl with the provided context, and return the results. On graceful
+// run the crawl with signal handling, and return the results. On graceful
 // shutdown (SIGINT/SIGTERM) partial results are returned instead of an error.
-func doCrawl(ctx context.Context, targetURL string, rawHeaders []string, opts crawl.CrawlerOptions) ([]crawl.ObservedRequest, error) {
+func doCrawl(targetURL string, rawHeaders []string, opts crawl.CrawlerOptions) ([]crawl.ObservedRequest, error) {
 	headers, err := parseHeaders(rawHeaders)
 	if err != nil {
 		return nil, fmt.Errorf("invalid header: %w", err)
 	}
 	opts.Headers = headers
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	crawler := crawl.NewCrawler(opts)
 	requests, err := crawler.Crawl(ctx, targetURL)
@@ -116,10 +111,12 @@ func writeOutput(path string, fn func(io.Writer) error) error {
 	return nil
 }
 
-// CrawlOptions holds the shared crawl configuration fields used by CrawlCmd and ScanCmd.
-type CrawlOptions struct {
+// CrawlCmd crawls a web application to capture HTTP traffic.
+type CrawlCmd struct {
+	URL      string        `arg:"" help:"Target URL to crawl"`
 	Header   []string      `short:"H" help:"Custom headers (repeatable)"`
 	Output   string        `short:"o" help:"Output file path"`
+	Format   string        `default:"json" enum:"json,yaml" help:"Output format"`
 	Depth    int           `default:"3" help:"Maximum crawl depth"`
 	MaxPages int           `default:"100" help:"Maximum pages to crawl"`
 	Timeout  time.Duration `default:"30s" help:"Request timeout"`
@@ -128,19 +125,8 @@ type CrawlOptions struct {
 	Verbose  bool          `short:"v" help:"Enable verbose logging"`
 }
 
-// CrawlCmd crawls a web application to capture HTTP traffic.
-type CrawlCmd struct {
-	URL    string `arg:"" help:"Target URL to crawl"`
-	Format string `default:"json" enum:"json,yaml" help:"Output format"`
-	CrawlOptions
-}
-
 // Run executes the crawl command.
 func (c *CrawlCmd) Run() error {
-	if err := validateURL(c.URL); err != nil {
-		return err
-	}
-
 	opts := crawl.CrawlerOptions{
 		Depth:    c.Depth,
 		MaxPages: c.MaxPages,
@@ -148,24 +134,10 @@ func (c *CrawlCmd) Run() error {
 		Scope:    c.Scope,
 		Headless: c.Headless,
 	}
-
-	if c.Verbose {
-		fmt.Fprintf(os.Stderr, "crawling %s (depth=%d, max-pages=%d, timeout=%s)\n",
-			c.URL, opts.Depth, opts.MaxPages, opts.Timeout)
-	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	requests, err := doCrawl(ctx, c.URL, c.Header, opts)
+	requests, err := doCrawl(c.URL, c.Header, opts)
 	if err != nil {
 		return err
 	}
-
-	if c.Verbose {
-		fmt.Fprintf(os.Stderr, "captured %d requests\n", len(requests))
-	}
-
 	return writeOutput(c.Output, func(w io.Writer) error {
 		return crawl.WriteCapture(w, requests)
 	})
@@ -173,46 +145,22 @@ func (c *CrawlCmd) Run() error {
 
 // ImportCmd imports traffic capture from external sources.
 type ImportCmd struct {
-	Format  string `arg:"" enum:"burp,har,mitmproxy" help:"Import format (burp, har, mitmproxy)"`
+	Format  string `arg:"" help:"Import format (e.g., burp, har, mitmproxy)"`
 	File    string `arg:"" help:"Input file path"`
 	Output  string `short:"o" help:"Output file path"`
+	Scope   string `optional:"" help:"Filter scope (optional: same-origin or same-domain)"`
 	Verbose bool   `short:"v" help:"Enable verbose logging"`
 }
 
 // Run executes the import command.
 func (c *ImportCmd) Run() error {
-	imp, err := importer.Get(c.Format)
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Open(c.File)
-	if err != nil {
-		return fmt.Errorf("open input file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	if c.Verbose {
-		fmt.Fprintf(os.Stderr, "importing %s traffic from %s\n", imp.Name(), c.File)
-	}
-
-	requests, err := imp.Import(f)
-	if err != nil {
-		return fmt.Errorf("import failed: %w", err)
-	}
-
-	if c.Verbose {
-		fmt.Fprintf(os.Stderr, "imported %d requests\n", len(requests))
-	}
-
-	return writeOutput(c.Output, func(w io.Writer) error {
-		return crawl.WriteCapture(w, requests)
-	})
+	fmt.Println("import: not implemented")
+	return nil
 }
 
 // GenerateCmd generates API specifications from captured traffic.
 type GenerateCmd struct {
-	APIType    string  `arg:"" enum:"rest" help:"API type to generate"`
+	APIType    string  `arg:"" enum:"rest,wsdl" help:"API type to generate"`
 	Capture    string  `arg:"" help:"Capture file path"`
 	Output     string  `short:"o" help:"Output file path"`
 	Confidence float64 `default:"0.5" help:"Minimum confidence threshold"`
@@ -220,67 +168,87 @@ type GenerateCmd struct {
 	Verbose    bool    `short:"v" help:"Enable verbose logging"`
 }
 
-// maxCaptureSize is the maximum capture file size (100MB).
-const maxCaptureSize = 100 * 1024 * 1024
-
 // Run executes the generate command.
-func (c *GenerateCmd) Run() (err error) {
+func (c *GenerateCmd) Run() error {
 	f, err := os.Open(c.Capture)
 	if err != nil {
-		return fmt.Errorf("open capture file: %w", err)
+		return fmt.Errorf("failed to open capture file: %w", err)
 	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("closing capture file: %w", cerr)
-		}
-	}()
-
-	// Guard against excessively large capture files.
-	info, err := f.Stat()
-	if err != nil {
-		return fmt.Errorf("stat capture file: %w", err)
-	}
-	if info.Size() > maxCaptureSize {
-		return fmt.Errorf("capture file too large: %d bytes (max %d)", info.Size(), maxCaptureSize)
-	}
+	defer f.Close()
 
 	requests, err := crawl.ReadCapture(f)
 	if err != nil {
-		return fmt.Errorf("read capture file: %w", err)
+		return fmt.Errorf("failed to read capture: %w", err)
 	}
 
-	if c.Verbose {
-		fmt.Fprintf(os.Stderr, "loaded %d captured requests\n", len(requests))
+	classifiers := []classify.APIClassifier{
+		&classify.RESTClassifier{},
+		&classify.WSDLClassifier{},
+	}
+	classified := classify.Deduplicate(classify.RunClassifiers(classifiers, requests, c.Confidence))
+
+	var filtered []classify.ClassifiedRequest
+	for _, req := range classified {
+		if req.APIType == c.APIType {
+			filtered = append(filtered, req)
+		}
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	if len(filtered) == 0 {
+		return fmt.Errorf("no %s endpoints found in capture", c.APIType)
+	}
 
-	spec, err := generateSpec(ctx, requests, c.APIType, c.Confidence, c.Probe, c.Verbose)
+	if c.Probe {
+		var strategies []probe.ProbeStrategy
+		cfg := probe.DefaultConfig()
+		switch c.APIType {
+		case "wsdl":
+			strategies = append(strategies, probe.NewWSDLProbe(cfg))
+		case "rest":
+			strategies = append(strategies, probe.NewOptionsProbe(cfg))
+			strategies = append(strategies, probe.NewSchemaProbe(cfg))
+		}
+		if len(strategies) > 0 {
+			filtered, _ = probe.RunStrategies(context.Background(), strategies, filtered)
+		}
+	}
+
+	var gen generate.SpecGenerator
+	switch c.APIType {
+	case "wsdl":
+		gen = &wsdlgen.Generator{}
+	default:
+		return fmt.Errorf("generator for %q not yet implemented", c.APIType)
+	}
+
+	output, err := gen.Generate(filtered)
 	if err != nil {
-		return err
+		return fmt.Errorf("generation failed: %w", err)
 	}
 
 	return writeOutput(c.Output, func(w io.Writer) error {
-		_, writeErr := w.Write(spec)
-		return writeErr
+		_, err := w.Write(output)
+		return err
 	})
 }
 
 // ScanCmd runs the full pipeline: crawl, classify, and generate.
 type ScanCmd struct {
-	URL        string  `arg:"" help:"Target URL to scan"`
-	Confidence float64 `default:"0.5" help:"Minimum confidence threshold"`
-	Probe      bool    `default:"true" help:"Enable endpoint probing"`
-	CrawlOptions
+	URL        string        `arg:"" help:"Target URL to scan"`
+	Header     []string      `short:"H" help:"Custom headers (repeatable)"`
+	Output     string        `short:"o" help:"Output file path"`
+	Depth      int           `default:"3" help:"Maximum crawl depth"`
+	MaxPages   int           `default:"100" help:"Maximum pages to crawl"`
+	Timeout    time.Duration `default:"30s" help:"Request timeout"`
+	Scope      string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
+	Headless   bool          `default:"true" help:"Use headless browser"`
+	Confidence float64       `default:"0.5" help:"Minimum confidence threshold"`
+	Probe      bool          `default:"true" help:"Enable endpoint probing"`
+	Verbose    bool          `short:"v" help:"Enable verbose logging"`
 }
 
-// Run executes the scan command (crawl + generate pipeline).
+// Run executes the scan command.
 func (c *ScanCmd) Run() error {
-	if err := validateURL(c.URL); err != nil {
-		return err
-	}
-
 	opts := crawl.CrawlerOptions{
 		Depth:    c.Depth,
 		MaxPages: c.MaxPages,
@@ -288,33 +256,23 @@ func (c *ScanCmd) Run() error {
 		Scope:    c.Scope,
 		Headless: c.Headless,
 	}
-
-	if c.Verbose {
-		fmt.Fprintf(os.Stderr, "crawling %s (depth=%d, max-pages=%d, timeout=%s)\n",
-			c.URL, opts.Depth, opts.MaxPages, opts.Timeout)
-	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	requests, err := doCrawl(ctx, c.URL, c.Header, opts)
+	requests, err := doCrawl(c.URL, c.Header, opts)
 	if err != nil {
 		return err
 	}
 
-	if c.Verbose {
-		fmt.Fprintf(os.Stderr, "captured %d requests\n", len(requests))
-		fmt.Fprintf(os.Stderr, "generating REST spec\n")
-	}
-
-	spec, err := generateSpec(ctx, requests, "rest", c.Confidence, c.Probe, c.Verbose)
-	if err != nil {
-		return err
-	}
+	classified := classify.Deduplicate(classify.RunClassifiers(
+		[]classify.APIClassifier{
+			&classify.RESTClassifier{},
+			&classify.WSDLClassifier{},
+		},
+		requests, c.Confidence,
+	))
 
 	return writeOutput(c.Output, func(w io.Writer) error {
-		_, writeErr := w.Write(spec)
-		return writeErr
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(classified)
 	})
 }
 
@@ -323,7 +281,7 @@ type VersionCmd struct{}
 
 // Run executes the version command.
 func (c *VersionCmd) Run() error {
-	fmt.Printf("vespasian %s (commit: %s, built: %s)\n", version, gitCommit, buildDate)
+	fmt.Println("vespasian version dev")
 	return nil
 }
 
@@ -335,68 +293,4 @@ func main() {
 	)
 	err := ctx.Run()
 	ctx.FatalIfErrorf(err)
-}
-
-// generateSpec runs the classify → probe → generate pipeline.
-func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, apiType string, confidence float64, doProbe bool, verbose bool) ([]byte, error) {
-	classifiers := classifiersForType(apiType)
-	if classifiers == nil {
-		return nil, fmt.Errorf("unsupported API type: %q", apiType)
-	}
-	classified := classify.Deduplicate(classify.RunClassifiers(classifiers, requests, confidence))
-
-	if verbose {
-		fmt.Fprintf(os.Stderr, "classified %d API requests (threshold=%.2f)\n", len(classified), confidence)
-	}
-
-	if doProbe {
-		strategies := []probe.ProbeStrategy{
-			&probe.OptionsProbe{},
-			&probe.SchemaProbe{},
-		}
-		enriched, probeErrs := probe.RunStrategies(ctx, strategies, classified)
-		if verbose {
-			for _, e := range probeErrs {
-				fmt.Fprintf(os.Stderr, "probe warning: %v\n", e)
-			}
-		}
-		classified = enriched
-	}
-
-	gen, err := generate.Get(apiType)
-	if err != nil {
-		return nil, err
-	}
-
-	spec, err := gen.Generate(classified)
-	if err != nil {
-		return nil, fmt.Errorf("generate failed: %w", err)
-	}
-
-	return spec, nil
-}
-
-// classifiersForType returns the appropriate classifiers for the given API type.
-func classifiersForType(apiType string) []classify.APIClassifier {
-	switch apiType {
-	case "rest":
-		return []classify.APIClassifier{&classify.RESTClassifier{}}
-	default:
-		return nil
-	}
-}
-
-// validateURL checks that the given string is a valid URL with scheme and host.
-func validateURL(rawURL string) error {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
-	}
-	if u.Scheme == "" || u.Host == "" {
-		return fmt.Errorf("invalid URL %q: must include scheme and host (e.g., https://example.com)", rawURL)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("invalid URL %q: scheme must be http or https", rawURL)
-	}
-	return nil
 }

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -16,6 +16,7 @@ package classify
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
 )
@@ -107,6 +108,12 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
 		// behavior for single-target scans.
 		key := req.Method + ":" + parsedURL.Path
 
+		// For SOAP endpoints, include SOAPAction in the dedup key so distinct
+		// operations on the same URL path are preserved.
+		if sa := getSoapAction(req.Headers); sa != "" {
+			key += ":" + sa
+		}
+
 		existing, found := seen[key]
 		if !found {
 			order = append(order, key)
@@ -138,4 +145,14 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
 		results = append(results, seen[key].req)
 	}
 	return results
+}
+
+// getSoapAction returns the SOAPAction header value, performing a case-insensitive lookup.
+func getSoapAction(headers map[string]string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, "soapaction") {
+			return strings.Trim(v, `"`)
+		}
+	}
+	return ""
 }

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -290,3 +290,122 @@ func TestDeduplicate_Empty(t *testing.T) {
 	result := Deduplicate(nil)
 	assert.Empty(t, result)
 }
+
+func TestDeduplicate_PreservesDistinctSOAPActions(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/service",
+				Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+			},
+			IsAPI: true, Confidence: 0.95, APIType: "wsdl",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/service",
+				Headers: map[string]string{"SOAPAction": `"urn:DeleteUser"`},
+			},
+			IsAPI: true, Confidence: 0.90, APIType: "wsdl",
+		},
+	}
+
+	result := Deduplicate(classified)
+	assert.Len(t, result, 2, "distinct SOAPActions on same URL must not be merged")
+}
+
+func TestDeduplicate_MergesSameSOAPAction(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/service?param=1",
+				Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+			},
+			IsAPI: true, Confidence: 0.80, APIType: "wsdl",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/service?param=2",
+				Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+			},
+			IsAPI: true, Confidence: 0.95, APIType: "wsdl",
+		},
+	}
+
+	result := Deduplicate(classified)
+	require.Len(t, result, 1, "same SOAPAction on same path should merge")
+	assert.InDelta(t, 0.95, result[0].Confidence, 0.001, "highest confidence kept")
+}
+
+func TestDeduplicate_SOAPActionCaseInsensitive(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/service",
+				Headers: map[string]string{"soapaction": `"urn:GetUser"`},
+			},
+			IsAPI: true, Confidence: 0.90, APIType: "wsdl",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/service",
+				Headers: map[string]string{"SOAPACTION": `"urn:GetUser"`},
+			},
+			IsAPI: true, Confidence: 0.85, APIType: "wsdl",
+		},
+	}
+
+	result := Deduplicate(classified)
+	assert.Len(t, result, 1, "case-insensitive SOAPAction should merge")
+}
+
+func TestDeduplicate_NonSOAPEndpointsStillDedupByPath(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: "https://example.com/api/users?page=1"},
+			IsAPI: true, Confidence: 0.80, APIType: "rest",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/service",
+				Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+			},
+			IsAPI: true, Confidence: 0.95, APIType: "wsdl",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: "https://example.com/api/users?page=2"},
+			IsAPI: true, Confidence: 0.85, APIType: "rest",
+		},
+	}
+
+	result := Deduplicate(classified)
+	assert.Len(t, result, 2, "REST deduplicates by path, WSDL separate")
+}
+
+func TestRunClassifiers_WSDLWinsOverREST(t *testing.T) {
+	classifiers := []APIClassifier{
+		&RESTClassifier{},
+		&WSDLClassifier{},
+	}
+	requests := []crawl.ObservedRequest{{
+		Method: "POST",
+		URL:    "https://example.com/service",
+		Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+		Response: crawl.ObservedResponse{
+			StatusCode:  200,
+			ContentType: "text/xml",
+			Body:        []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetUser/></soap:Body></soap:Envelope>`),
+		},
+	}}
+
+	results := RunClassifiers(classifiers, requests, 0.5)
+	require.Len(t, results, 1)
+	assert.Equal(t, "wsdl", results[0].APIType, "WSDL should win for SOAP traffic")
+	assert.GreaterOrEqual(t, results[0].Confidence, 0.90)
+}

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -368,7 +368,7 @@ func TestDeduplicate_NonSOAPEndpointsStillDedupByPath(t *testing.T) {
 	classified := []ClassifiedRequest{
 		{
 			ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: "https://example.com/api/users?page=1"},
-			IsAPI: true, Confidence: 0.80, APIType: "rest",
+			IsAPI:           true, Confidence: 0.80, APIType: "rest",
 		},
 		{
 			ObservedRequest: crawl.ObservedRequest{
@@ -380,7 +380,7 @@ func TestDeduplicate_NonSOAPEndpointsStillDedupByPath(t *testing.T) {
 		},
 		{
 			ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: "https://example.com/api/users?page=2"},
-			IsAPI: true, Confidence: 0.85, APIType: "rest",
+			IsAPI:           true, Confidence: 0.85, APIType: "rest",
 		},
 	}
 
@@ -394,8 +394,8 @@ func TestRunClassifiers_WSDLWinsOverREST(t *testing.T) {
 		&WSDLClassifier{},
 	}
 	requests := []crawl.ObservedRequest{{
-		Method: "POST",
-		URL:    "https://example.com/service",
+		Method:  "POST",
+		URL:     "https://example.com/service",
 		Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
 		Response: crawl.ObservedResponse{
 			StatusCode:  200,

--- a/pkg/classify/types.go
+++ b/pkg/classify/types.go
@@ -30,4 +30,7 @@ type ClassifiedRequest struct {
 	// Probe-enriched fields (populated by pkg/probe strategies)
 	AllowedMethods []string               `json:"allowed_methods,omitempty"`
 	ResponseSchema map[string]interface{} `json:"response_schema,omitempty"`
+
+	// WSDLDocument holds a probed WSDL document for SOAP endpoints.
+	WSDLDocument []byte `json:"wsdl_document,omitempty"`
 }

--- a/pkg/classify/wsdl.go
+++ b/pkg/classify/wsdl.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package classify
+
+import (
+	"bytes"
+	"net/url"
+	"strings"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// WSDLClassifier classifies SOAP/WSDL API requests using ordered heuristic rules.
+type WSDLClassifier struct{}
+
+// Name returns the classifier name.
+func (c *WSDLClassifier) Name() string {
+	return "wsdl"
+}
+
+// Classify determines if the request is a SOAP/WSDL API call.
+func (c *WSDLClassifier) Classify(req crawl.ObservedRequest) (bool, float64) {
+	isAPI, confidence, _ := c.ClassifyDetail(req)
+	return isAPI, confidence
+}
+
+// ClassifyDetail returns classification result with a detailed reason string.
+//
+// Signals applied in order, taking max confidence (not additive):
+//  1. Static asset exclusion → (false, 0, "")
+//  2. SOAPAction header present → confidence 0.95
+//  3. SOAP envelope in request body → confidence 0.90
+//  4. ?wsdl query param or /wsdl path suffix → confidence 0.90
+//  5. Content-type text/xml or application/soap+xml → confidence 0.85
+//
+// Negative signal: RSS/Atom feeds reduce confidence to 0.3 when only
+// the soap-content-type signal matched.
+func (c *WSDLClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, float64, string) {
+	parsedURL, err := url.Parse(req.URL)
+	if err != nil {
+		return false, 0, ""
+	}
+
+	lowerPath := strings.ToLower(parsedURL.Path)
+
+	// Static asset exclusion.
+	for _, ext := range staticExtensions {
+		if strings.HasSuffix(lowerPath, ext) {
+			return false, 0, ""
+		}
+	}
+
+	var confidence float64
+	var reason string
+
+	// Signal 1: SOAPAction header present (case-insensitive).
+	if _, ok := getHeaderCaseInsensitive(req.Headers, "SOAPAction"); ok {
+		confidence = 0.95
+		reason = "soapaction-header"
+	}
+
+	// Signal 2: SOAP envelope in request body.
+	if hasSoapEnvelope(req.Body) {
+		if confidence < 0.90 {
+			confidence = 0.90
+		}
+		if reason == "" {
+			reason = "soap-envelope"
+		} else {
+			reason += "+soap-envelope"
+		}
+	}
+
+	// Signal 3: ?wsdl query param or URL path ends with /wsdl (case-insensitive).
+	lowerQuery := strings.ToLower(parsedURL.RawQuery)
+	if strings.Contains(lowerQuery, "wsdl") || strings.HasSuffix(lowerPath, "/wsdl") {
+		if confidence < 0.90 {
+			confidence = 0.90
+		}
+		if reason == "" {
+			reason = "wsdl-url"
+		} else {
+			reason += "+wsdl-url"
+		}
+	}
+
+	// Signal 4: Content-type is text/xml or application/soap+xml.
+	ct := strings.ToLower(req.Response.ContentType)
+	if idx := strings.Index(ct, ";"); idx != -1 {
+		ct = strings.TrimSpace(ct[:idx])
+	}
+	if ct == "text/xml" || ct == "application/soap+xml" {
+		if confidence < 0.85 {
+			confidence = 0.85
+		}
+		if reason == "" {
+			reason = "soap-content-type"
+		} else {
+			reason += "+soap-content-type"
+		}
+	}
+
+	// Negative signal: RSS/Atom exclusion.
+	// Only reduce confidence when soap-content-type is the sole signal.
+	if confidence == 0.85 && reason == "soap-content-type" {
+		body := req.Response.Body
+		if bytes.Contains(body, []byte("<rss")) ||
+			bytes.Contains(body, []byte("<feed")) ||
+			bytes.Contains(body, []byte("<channel")) {
+			confidence = 0.3
+		}
+	}
+
+	return confidence > 0, confidence, reason
+}
+
+// getHeaderCaseInsensitive looks up a header value using case-insensitive key matching.
+func getHeaderCaseInsensitive(headers map[string]string, key string) (string, bool) {
+	lowerKey := strings.ToLower(key)
+	for k, v := range headers {
+		if strings.ToLower(k) == lowerKey {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// hasSoapEnvelope reports whether body contains a SOAP envelope marker.
+func hasSoapEnvelope(body []byte) bool {
+	return bytes.Contains(body, []byte("<soap:Envelope")) ||
+		bytes.Contains(body, []byte("<SOAP-ENV:Envelope")) ||
+		bytes.Contains(body, []byte("schemas.xmlsoap.org/soap/envelope"))
+}

--- a/pkg/classify/wsdl_test.go
+++ b/pkg/classify/wsdl_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package classify
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWSDLClassifier_Classify(t *testing.T) {
+	c := &WSDLClassifier{}
+
+	tests := []struct {
+		name          string
+		req           crawl.ObservedRequest
+		wantIsAPI     bool
+		wantMinConf   float64
+		wantMaxConf   float64
+		wantReasonSub string
+	}{
+		{
+			name: "SOAPAction header",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/service",
+				Headers: map[string]string{
+					"SOAPAction": `"urn:GetUser"`,
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "soapaction-header",
+		},
+		{
+			name: "soap+xml content-type",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/service",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/soap+xml",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.85,
+			wantMaxConf:   1.0,
+			wantReasonSub: "soap-content-type",
+		},
+		{
+			name: "text/xml content-type",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/service",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "text/xml",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.85,
+			wantMaxConf:   1.0,
+			wantReasonSub: "soap-content-type",
+		},
+		{
+			name: "SOAP envelope in body",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/service",
+				Body:   []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetUser/></soap:Body></soap:Envelope>`),
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.90,
+			wantMaxConf:   1.0,
+			wantReasonSub: "soap-envelope",
+		},
+		{
+			name: "SOAP-ENV envelope in body",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/service",
+				Body:   []byte(`<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body/></SOAP-ENV:Envelope>`),
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.90,
+			wantMaxConf:   1.0,
+			wantReasonSub: "soap-envelope",
+		},
+		{
+			name: "?wsdl URL",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/service?wsdl",
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.90,
+			wantMaxConf:   1.0,
+			wantReasonSub: "wsdl-url",
+		},
+		{
+			name: "/wsdl path",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/service/wsdl",
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.90,
+			wantMaxConf:   1.0,
+			wantReasonSub: "wsdl-url",
+		},
+		{
+			name: "RSS exclusion",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/feed",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "text/xml",
+					Body:        []byte(`<rss version="2.0"><channel><title>My Feed</title></channel></rss>`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.3,
+			wantMaxConf:   0.3,
+			wantReasonSub: "soap-content-type",
+		},
+		{
+			name: "Atom feed exclusion",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/feed",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "text/xml",
+					Body:        []byte(`<feed xmlns="http://www.w3.org/2005/Atom"><title>My Feed</title></feed>`),
+				},
+			},
+			wantIsAPI:   true,
+			wantMinConf: 0.3,
+			wantMaxConf: 0.3,
+		},
+		{
+			name: "HTML exclusion",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/page",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "text/html",
+					Body:        []byte(`<html><body>Hello</body></html>`),
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "All signals combined",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/service",
+				Headers: map[string]string{
+					"SOAPAction": `"urn:GetUser"`,
+				},
+				Body: []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetUser/></soap:Body></soap:Envelope>`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/soap+xml",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "soapaction-header",
+		},
+		{
+			name: "Static asset exclusion",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/app.js",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "text/xml",
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "JSON API not classified as WSDL",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/api/users",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"users":[]}`),
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isAPI, confidence, reason := c.ClassifyDetail(tt.req)
+			assert.Equal(t, tt.wantIsAPI, isAPI, "isAPI")
+			assert.GreaterOrEqual(t, confidence, tt.wantMinConf, "confidence lower bound")
+			assert.LessOrEqual(t, confidence, tt.wantMaxConf, "confidence upper bound")
+			if tt.wantReasonSub != "" {
+				assert.Contains(t, reason, tt.wantReasonSub, "reason")
+			}
+		})
+	}
+}
+
+func TestWSDLClassifier_ImplementsDetailedClassifier(t *testing.T) {
+	var c APIClassifier = &WSDLClassifier{}
+	assert.Implements(t, (*DetailedClassifier)(nil), c)
+}

--- a/pkg/generate/registry.go
+++ b/pkg/generate/registry.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/praetorian-inc/vespasian/pkg/generate/rest"
+	"github.com/praetorian-inc/vespasian/pkg/generate/wsdl"
 )
 
 // Get returns a SpecGenerator for the given API type.
@@ -25,7 +26,9 @@ func Get(apiType string) (SpecGenerator, error) {
 	switch apiType {
 	case "rest":
 		return &rest.OpenAPIGenerator{}, nil
+	case "wsdl":
+		return &wsdl.Generator{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported API type: %q (supported: rest)", apiType)
+		return nil, fmt.Errorf("unsupported API type: %q (supported: rest, wsdl)", apiType)
 	}
 }

--- a/pkg/generate/wsdl/generator.go
+++ b/pkg/generate/wsdl/generator.go
@@ -39,7 +39,7 @@ func (g *Generator) DefaultExtension() string {
 // Phase 2: Fall back to inferring WSDL from observed traffic.
 func (g *Generator) Generate(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	if len(endpoints) == 0 {
-		return nil, errors.New("wsdl generate: no endpoints provided")
+		return nil, errors.New("no endpoints provided")
 	}
 
 	// Phase 1: Use probed WSDLDocument or response body if it contains valid WSDL

--- a/pkg/generate/wsdl/generator.go
+++ b/pkg/generate/wsdl/generator.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wsdl
+
+import (
+	"encoding/xml"
+	"errors"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// Generator produces WSDL specifications from classified SOAP requests.
+type Generator struct{}
+
+// APIType returns the API type this generator supports.
+func (g *Generator) APIType() string {
+	return "wsdl"
+}
+
+// DefaultExtension returns the default file extension for WSDL output.
+func (g *Generator) DefaultExtension() string {
+	return ".wsdl"
+}
+
+// Generate produces a WSDL specification from classified SOAP endpoints.
+// Phase 1: If any endpoint has a WSDLDocument from probing, validate and return it.
+// Phase 2: Fall back to inferring WSDL from observed traffic.
+func (g *Generator) Generate(endpoints []classify.ClassifiedRequest) ([]byte, error) {
+	if len(endpoints) == 0 {
+		return nil, errors.New("wsdl generate: no endpoints provided")
+	}
+
+	// Phase 1: Use probed WSDLDocument or response body if it contains valid WSDL
+	for _, ep := range endpoints {
+		// First try WSDLDocument (set by probe)
+		if len(ep.WSDLDocument) > 0 {
+			if _, err := ParseWSDL(ep.WSDLDocument); err == nil {
+				return ep.WSDLDocument, nil
+			}
+		}
+		// Also check if the response body itself is a valid WSDL (e.g., from ?wsdl crawl)
+		if len(ep.Response.Body) > 0 {
+			if _, err := ParseWSDL(ep.Response.Body); err == nil {
+				return ep.Response.Body, nil
+			}
+		}
+	}
+
+	// Phase 2: Infer from traffic
+	defs, err := InferWSDL(endpoints)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := xml.MarshalIndent(defs, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepend XML declaration
+	return append([]byte(xml.Header), output...), nil
+}

--- a/pkg/generate/wsdl/generator_test.go
+++ b/pkg/generate/wsdl/generator_test.go
@@ -1,0 +1,339 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wsdl
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+func TestGenerator_APIType(t *testing.T) {
+	g := &Generator{}
+	if g.APIType() != "wsdl" {
+		t.Errorf("APIType() = %q, want %q", g.APIType(), "wsdl")
+	}
+}
+
+func TestGenerator_DefaultExtension(t *testing.T) {
+	g := &Generator{}
+	if g.DefaultExtension() != ".wsdl" {
+		t.Errorf("DefaultExtension() = %q, want %q", g.DefaultExtension(), ".wsdl")
+	}
+}
+
+func TestGenerator_Phase1_Passthrough(t *testing.T) {
+	// Valid WSDL document from probe should be returned directly
+	validWSDL := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<definitions name="TestService" xmlns="http://schemas.xmlsoap.org/wsdl/">
+  <message name="GetUserRequest"><part name="parameters" element="tns:GetUser"/></message>
+  <portType name="TestPortType">
+    <operation name="GetUser"/>
+  </portType>
+</definitions>`)
+
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method: "POST",
+			URL:    "http://example.com/service",
+		},
+		WSDLDocument: validWSDL,
+		APIType:      "wsdl",
+	}}
+
+	result, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	if string(result) != string(validWSDL) {
+		t.Errorf("expected passthrough of WSDLDocument")
+	}
+}
+
+func TestGenerator_Phase2_InferFromSOAPAction(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method:  "POST",
+			URL:     "http://example.com/service.php",
+			Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+			Body:    []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetUser/></soap:Body></soap:Envelope>`),
+		},
+		APIType: "wsdl",
+	}}
+
+	result, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	output := string(result)
+	if !strings.Contains(output, "GetUser") {
+		t.Error("expected operation name GetUser in output")
+	}
+	if !strings.Contains(output, "<?xml") {
+		t.Error("expected XML declaration")
+	}
+}
+
+func TestGenerator_Phase2_InferFromBody(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method: "POST",
+			URL:    "http://example.com/service",
+			Body:   []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ListUsers xmlns="http://example.com/"/></soap:Body></soap:Envelope>`),
+		},
+		APIType: "wsdl",
+	}}
+
+	result, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	if !strings.Contains(string(result), "ListUsers") {
+		t.Error("expected operation name ListUsers in output")
+	}
+}
+
+func TestGenerator_ParseRoundTrip(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method:  "POST",
+			URL:     "http://example.com/service",
+			Headers: map[string]string{"SOAPAction": `"urn:Ping"`},
+			Body:    []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><Ping/></soap:Body></soap:Envelope>`),
+		},
+		APIType: "wsdl",
+	}}
+
+	result, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	// Should be parseable back
+	defs, err := ParseWSDL(result)
+	if err != nil {
+		t.Fatalf("ParseWSDL() error: %v", err)
+	}
+
+	if len(defs.PortTypes) == 0 {
+		t.Fatal("expected at least one port type")
+	}
+}
+
+func TestGenerator_EmptyEndpoints(t *testing.T) {
+	g := &Generator{}
+	_, err := g.Generate(nil)
+	if err == nil {
+		t.Error("expected error for empty endpoints")
+	}
+}
+
+func TestGenerator_MalformedWSDLDocument_FallsThrough(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method:  "POST",
+			URL:     "http://example.com/service",
+			Headers: map[string]string{"SOAPAction": `"urn:TestOp"`},
+			Body:    []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><TestOp/></soap:Body></soap:Envelope>`),
+		},
+		WSDLDocument: []byte(`this is not valid XML`),
+		APIType:      "wsdl",
+	}}
+
+	result, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	// Should fall through to inference
+	if !strings.Contains(string(result), "TestOp") {
+		t.Error("expected fallthrough to inference with TestOp operation")
+	}
+}
+
+// Test that xml.Unmarshal roundtrip works for the type structs
+func TestParseWSDL_BasicDocument(t *testing.T) {
+	wsdlXML := `<definitions name="Svc" xmlns="http://schemas.xmlsoap.org/wsdl/">
+  <message name="Msg"><part name="p" type="xsd:string"/></message>
+  <portType name="PT"><operation name="Op"><input message="tns:Msg"/></operation></portType>
+</definitions>`
+
+	defs, err := ParseWSDL([]byte(wsdlXML))
+	if err != nil {
+		t.Fatalf("ParseWSDL error: %v", err)
+	}
+	if defs.Name != "Svc" {
+		t.Errorf("Name = %q, want Svc", defs.Name)
+	}
+	if len(defs.Messages) != 1 {
+		t.Errorf("Messages count = %d, want 1", len(defs.Messages))
+	}
+	if len(defs.PortTypes) != 1 || len(defs.PortTypes[0].Operations) != 1 {
+		t.Error("expected 1 portType with 1 operation")
+	}
+
+	// Verify roundtrip marshalling works
+	_, err = xml.MarshalIndent(defs, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent error: %v", err)
+	}
+}
+
+func TestParseWSDL_FullDocument(t *testing.T) {
+	wsdlXML := `<definitions name="Calculator"
+		xmlns="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:tns="http://example.com/"
+		targetNamespace="http://example.com/">
+	  <types>
+		<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://example.com/">
+		  <element name="Add">
+			<complexType><sequence>
+			  <element name="a" type="xsd:int"/>
+			  <element name="b" type="xsd:int"/>
+			</sequence></complexType>
+		  </element>
+		</schema>
+	  </types>
+	  <message name="AddRequest"><part name="parameters" element="tns:Add"/></message>
+	  <message name="AddResponse"><part name="parameters" element="tns:AddResponse"/></message>
+	  <portType name="CalculatorPortType">
+		<operation name="Add">
+		  <input message="tns:AddRequest"/>
+		  <output message="tns:AddResponse"/>
+		</operation>
+	  </portType>
+	  <binding name="CalculatorBinding" type="tns:CalculatorPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<operation name="Add">
+		  <soap:operation soapAction="http://example.com/Add"/>
+		</operation>
+	  </binding>
+	  <service name="Calculator">
+		<port name="CalculatorPort" binding="tns:CalculatorBinding">
+		  <soap:address location="http://example.com/calculator"/>
+		</port>
+	  </service>
+	</definitions>`
+
+	defs, err := ParseWSDL([]byte(wsdlXML))
+	if err != nil {
+		t.Fatalf("ParseWSDL error: %v", err)
+	}
+	if defs.Name != "Calculator" {
+		t.Errorf("Name = %q, want Calculator", defs.Name)
+	}
+	if defs.Types == nil || len(defs.Types.Schemas) != 1 {
+		t.Error("expected 1 schema in types")
+	}
+	if len(defs.Messages) != 2 {
+		t.Errorf("Messages = %d, want 2", len(defs.Messages))
+	}
+	if len(defs.Bindings) != 1 {
+		t.Errorf("Bindings = %d, want 1", len(defs.Bindings))
+	}
+	if len(defs.Services) != 1 || len(defs.Services[0].Ports) != 1 {
+		t.Error("expected 1 service with 1 port")
+	}
+}
+
+func TestParseWSDL_MalformedXML(t *testing.T) {
+	_, err := ParseWSDL([]byte(`<not valid xml`))
+	if err == nil {
+		t.Error("expected error for malformed XML")
+	}
+}
+
+func TestParseWSDL_EmptyInput(t *testing.T) {
+	_, err := ParseWSDL([]byte{})
+	if err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestGenerator_MultipleEndpoints(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "http://example.com/service",
+				Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+				Body:    []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetUser/></soap:Body></soap:Envelope>`),
+			},
+			APIType: "wsdl",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "http://example.com/service",
+				Headers: map[string]string{"SOAPAction": `"urn:ListUsers"`},
+				Body:    []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ListUsers/></soap:Body></soap:Envelope>`),
+			},
+			APIType: "wsdl",
+		},
+	}
+
+	result, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	defs, err := ParseWSDL(result)
+	if err != nil {
+		t.Fatalf("ParseWSDL() error: %v", err)
+	}
+	if len(defs.PortTypes[0].Operations) != 2 {
+		t.Errorf("operations = %d, want 2", len(defs.PortTypes[0].Operations))
+	}
+}
+
+func TestGenerator_Phase1_FirstValidWins(t *testing.T) {
+	validWSDL := []byte(`<definitions name="First" xmlns="http://schemas.xmlsoap.org/wsdl/"><portType name="PT"/></definitions>`)
+	secondWSDL := []byte(`<definitions name="Second" xmlns="http://schemas.xmlsoap.org/wsdl/"><portType name="PT2"/></definitions>`)
+
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "http://example.com/svc1"},
+			WSDLDocument:    validWSDL,
+			APIType:         "wsdl",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "http://example.com/svc2"},
+			WSDLDocument:    secondWSDL,
+			APIType:         "wsdl",
+		},
+	}
+
+	result, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+	if string(result) != string(validWSDL) {
+		t.Error("expected first valid WSDL to be returned")
+	}
+}

--- a/pkg/generate/wsdl/infer.go
+++ b/pkg/generate/wsdl/infer.go
@@ -38,25 +38,17 @@ func InferWSDL(endpoints []classify.ClassifiedRequest) (*Definitions, error) {
 
 	var operations []string
 	soapActions := make(map[string]string) // operation name -> SOAPAction URI
+	seen := make(map[string]bool)
 
 	for _, ep := range endpoints {
 		opName, soapAction := extractOperation(ep)
-		if opName == "" {
+		if opName == "" || seen[opName] {
 			continue
 		}
-		// Deduplicate
-		found := false
-		for _, existing := range operations {
-			if existing == opName {
-				found = true
-				break
-			}
-		}
-		if !found {
-			operations = append(operations, opName)
-			if soapAction != "" {
-				soapActions[opName] = soapAction
-			}
+		seen[opName] = true
+		operations = append(operations, opName)
+		if soapAction != "" {
+			soapActions[opName] = soapAction
 		}
 	}
 
@@ -170,12 +162,12 @@ func extractNameFromURI(uri string) string {
 	if strings.HasPrefix(uri, "urn:") {
 		return uri[4:]
 	}
-	// Handle URL-style: take last path segment
-	if idx := strings.LastIndex(uri, "/"); idx >= 0 && idx < len(uri)-1 {
+	// Handle fragment: http://example.com/ws#GetUser -> GetUser
+	if idx := strings.LastIndex(uri, "#"); idx >= 0 && idx < len(uri)-1 {
 		return uri[idx+1:]
 	}
-	// Handle fragment: #GetUser
-	if idx := strings.LastIndex(uri, "#"); idx >= 0 && idx < len(uri)-1 {
+	// Handle URL-style: take last path segment
+	if idx := strings.LastIndex(uri, "/"); idx >= 0 && idx < len(uri)-1 {
 		return uri[idx+1:]
 	}
 	return uri

--- a/pkg/generate/wsdl/infer.go
+++ b/pkg/generate/wsdl/infer.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wsdl
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"net/url"
+	"strings"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// InferWSDL builds a partial but valid WSDL from observed SOAP traffic.
+// It extracts operation names from SOAPAction headers or SOAP body first child elements.
+func InferWSDL(endpoints []classify.ClassifiedRequest) (*Definitions, error) {
+	if len(endpoints) == 0 {
+		return nil, errors.New("no endpoints to infer WSDL from")
+	}
+
+	// Determine service URL from first endpoint
+	serviceURL := endpoints[0].URL
+	serviceName := inferServiceName(serviceURL)
+	targetNS := inferTargetNamespace(serviceURL)
+
+	var operations []string
+	soapActions := make(map[string]string) // operation name -> SOAPAction URI
+
+	for _, ep := range endpoints {
+		opName, soapAction := extractOperation(ep)
+		if opName == "" {
+			continue
+		}
+		// Deduplicate
+		found := false
+		for _, existing := range operations {
+			if existing == opName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			operations = append(operations, opName)
+			if soapAction != "" {
+				soapActions[opName] = soapAction
+			}
+		}
+	}
+
+	if len(operations) == 0 {
+		return nil, errors.New("no SOAP operations found in traffic")
+	}
+
+	defs := &Definitions{
+		Name:      serviceName,
+		TargetNS:  targetNS,
+		XMLNS:     "http://schemas.xmlsoap.org/wsdl/",
+		XMLNSSOAP: "http://schemas.xmlsoap.org/wsdl/soap/",
+		XMLNSTNS:  targetNS,
+		XMLNSXSD:  "http://www.w3.org/2001/XMLSchema",
+	}
+
+	portTypeName := serviceName + "PortType"
+	bindingName := serviceName + "Binding"
+
+	// Build messages, portType operations, and binding operations
+	var messages []Message
+	var ptOps []Operation
+	var bindOps []BindingOperation
+
+	for _, opName := range operations {
+		// Input message
+		inputMsgName := opName + "Request"
+		messages = append(messages, Message{
+			Name:  inputMsgName,
+			Parts: []MessagePart{{Name: "parameters", Element: "tns:" + opName}},
+		})
+
+		// Output message
+		outputMsgName := opName + "Response"
+		messages = append(messages, Message{
+			Name:  outputMsgName,
+			Parts: []MessagePart{{Name: "parameters", Element: "tns:" + opName + "Response"}},
+		})
+
+		// PortType operation
+		ptOps = append(ptOps, Operation{
+			Name:   opName,
+			Input:  &IOMsg{Message: "tns:" + inputMsgName},
+			Output: &IOMsg{Message: "tns:" + outputMsgName},
+		})
+
+		// Binding operation
+		bop := BindingOperation{Name: opName}
+		if sa, ok := soapActions[opName]; ok {
+			bop.SOAPOperation = &SOAPOperation{SOAPAction: sa}
+		}
+		bindOps = append(bindOps, bop)
+	}
+
+	defs.Messages = messages
+	defs.PortTypes = []PortType{{
+		Name:       portTypeName,
+		Operations: ptOps,
+	}}
+	defs.Bindings = []Binding{{
+		Name: bindingName,
+		Type: "tns:" + portTypeName,
+		SOAPBinding: &SOAPBinding{
+			Style:     "document",
+			Transport: "http://schemas.xmlsoap.org/soap/http",
+		},
+		Operations: bindOps,
+	}}
+	defs.Services = []Service{{
+		Name: serviceName,
+		Ports: []Port{{
+			Name:        serviceName + "Port",
+			Binding:     "tns:" + bindingName,
+			SOAPAddress: &SOAPAddress{Location: serviceURL},
+		}},
+	}}
+
+	return defs, nil
+}
+
+// extractOperation extracts the operation name from a classified SOAP request.
+// First tries SOAPAction header, then falls back to SOAP body first child element.
+func extractOperation(ep classify.ClassifiedRequest) (opName string, soapAction string) {
+	// Try SOAPAction header (case-insensitive)
+	for k, v := range ep.Headers {
+		if strings.EqualFold(k, "soapaction") {
+			soapAction = strings.Trim(v, `"`)
+			// Extract operation name from URI: last path segment or after last /
+			opName = extractNameFromURI(soapAction)
+			if opName != "" {
+				return opName, soapAction
+			}
+		}
+	}
+
+	// Fall back to SOAP body first child element name
+	if len(ep.Body) > 0 {
+		opName = extractFirstBodyElement(ep.Body)
+		if opName != "" {
+			return opName, ""
+		}
+	}
+
+	return "", ""
+}
+
+// extractNameFromURI extracts the last segment from a URI or URN.
+func extractNameFromURI(uri string) string {
+	uri = strings.Trim(uri, `"`)
+	// Handle URN-style: urn:GetUser -> GetUser
+	if strings.HasPrefix(uri, "urn:") {
+		return uri[4:]
+	}
+	// Handle URL-style: take last path segment
+	if idx := strings.LastIndex(uri, "/"); idx >= 0 && idx < len(uri)-1 {
+		return uri[idx+1:]
+	}
+	// Handle fragment: #GetUser
+	if idx := strings.LastIndex(uri, "#"); idx >= 0 && idx < len(uri)-1 {
+		return uri[idx+1:]
+	}
+	return uri
+}
+
+// extractFirstBodyElement extracts the first child element name from within soap:Body.
+func extractFirstBodyElement(body []byte) string {
+	decoder := xml.NewDecoder(bytes.NewReader(body))
+	inBody := false
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			return ""
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			local := t.Name.Local
+			if strings.EqualFold(local, "body") {
+				inBody = true
+				continue
+			}
+			if inBody {
+				return local
+			}
+		}
+	}
+}
+
+// inferServiceName derives a service name from the URL.
+func inferServiceName(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "Service"
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		name := path[idx+1:]
+		// Strip common extensions
+		name = strings.TrimSuffix(name, ".php")
+		name = strings.TrimSuffix(name, ".asmx")
+		name = strings.TrimSuffix(name, ".svc")
+		if name != "" {
+			return name
+		}
+	}
+	return "Service"
+}
+
+// inferTargetNamespace derives a target namespace from the URL.
+func inferTargetNamespace(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "http://tempuri.org/"
+	}
+	return parsed.Scheme + "://" + parsed.Host + "/"
+}

--- a/pkg/generate/wsdl/infer_test.go
+++ b/pkg/generate/wsdl/infer_test.go
@@ -161,7 +161,7 @@ func TestExtractNameFromURI(t *testing.T) {
 	}{
 		{"urn:GetUser", "GetUser"},
 		{"http://example.com/ws/GetUser", "GetUser"},
-		{"http://example.com/ws#GetUser", "ws#GetUser"},
+		{"http://example.com/ws#GetUser", "GetUser"},
 		{`"urn:GetUser"`, "GetUser"},
 		{"GetUser", "GetUser"},
 		{"", ""},

--- a/pkg/generate/wsdl/infer_test.go
+++ b/pkg/generate/wsdl/infer_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wsdl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+func TestInferWSDL_FromSOAPAction(t *testing.T) {
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method:  "POST",
+			URL:     "http://example.com/calculator",
+			Headers: map[string]string{"SOAPAction": `"urn:Add"`},
+		},
+	}}
+
+	defs, err := InferWSDL(endpoints)
+	require.NoError(t, err)
+	require.Len(t, defs.PortTypes, 1)
+	require.Len(t, defs.PortTypes[0].Operations, 1)
+	assert.Equal(t, "Add", defs.PortTypes[0].Operations[0].Name)
+
+	require.Len(t, defs.Bindings, 1)
+	require.Len(t, defs.Bindings[0].Operations, 1)
+	require.NotNil(t, defs.Bindings[0].Operations[0].SOAPOperation)
+	assert.Equal(t, "urn:Add", defs.Bindings[0].Operations[0].SOAPOperation.SOAPAction)
+}
+
+func TestInferWSDL_FromBodyElement(t *testing.T) {
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method: "POST",
+			URL:    "http://example.com/service",
+			Body:   []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetWeather xmlns="http://example.com/"/></soap:Body></soap:Envelope>`),
+		},
+	}}
+
+	defs, err := InferWSDL(endpoints)
+	require.NoError(t, err)
+	require.Len(t, defs.PortTypes[0].Operations, 1)
+	assert.Equal(t, "GetWeather", defs.PortTypes[0].Operations[0].Name)
+}
+
+func TestInferWSDL_DeduplicatesOperations(t *testing.T) {
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "http://example.com/service",
+				Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+			},
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "http://example.com/service",
+				Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+			},
+		},
+	}
+
+	defs, err := InferWSDL(endpoints)
+	require.NoError(t, err)
+	assert.Len(t, defs.PortTypes[0].Operations, 1, "duplicate ops should be merged")
+}
+
+func TestInferWSDL_MultipleOperations(t *testing.T) {
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "http://example.com/service",
+				Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+			},
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "http://example.com/service",
+				Headers: map[string]string{"SOAPAction": `"urn:DeleteUser"`},
+			},
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "http://example.com/service",
+				Body:   []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ListUsers/></soap:Body></soap:Envelope>`),
+			},
+		},
+	}
+
+	defs, err := InferWSDL(endpoints)
+	require.NoError(t, err)
+	assert.Len(t, defs.PortTypes[0].Operations, 3)
+	assert.Equal(t, 6, len(defs.Messages), "2 messages per operation")
+}
+
+func TestInferWSDL_EmptyEndpoints(t *testing.T) {
+	_, err := InferWSDL(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no endpoints")
+}
+
+func TestInferWSDL_NoExtractableOperations(t *testing.T) {
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method: "POST",
+			URL:    "http://example.com/service",
+		},
+	}}
+
+	_, err := InferWSDL(endpoints)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no SOAP operations")
+}
+
+func TestInferServiceName(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"http://example.com/calculator", "calculator"},
+		{"http://example.com/ws/service.asmx", "service"},
+		{"http://example.com/api/v1/endpoint.svc", "endpoint"},
+		{"http://example.com/service.php", "service"},
+		{"http://example.com/", "Service"},
+		{"http://example.com", "Service"},
+		{"://invalid", "Service"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			assert.Equal(t, tt.want, inferServiceName(tt.url))
+		})
+	}
+}
+
+func TestExtractNameFromURI(t *testing.T) {
+	tests := []struct {
+		uri  string
+		want string
+	}{
+		{"urn:GetUser", "GetUser"},
+		{"http://example.com/ws/GetUser", "GetUser"},
+		{"http://example.com/ws#GetUser", "ws#GetUser"},
+		{`"urn:GetUser"`, "GetUser"},
+		{"GetUser", "GetUser"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.uri, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractNameFromURI(tt.uri))
+		})
+	}
+}
+
+func TestInferWSDL_StructureComplete(t *testing.T) {
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method:  "POST",
+			URL:     "http://example.com/calculator",
+			Headers: map[string]string{"SOAPAction": `"urn:Add"`},
+		},
+	}}
+
+	defs, err := InferWSDL(endpoints)
+	require.NoError(t, err)
+
+	assert.Equal(t, "calculator", defs.Name)
+	assert.Equal(t, "http://example.com/", defs.TargetNS)
+	assert.Len(t, defs.Messages, 2)
+	assert.Len(t, defs.PortTypes, 1)
+	assert.Len(t, defs.Bindings, 1)
+	require.NotNil(t, defs.Bindings[0].SOAPBinding)
+	assert.Equal(t, "document", defs.Bindings[0].SOAPBinding.Style)
+	assert.Len(t, defs.Services, 1)
+	assert.Len(t, defs.Services[0].Ports, 1)
+	require.NotNil(t, defs.Services[0].Ports[0].SOAPAddress)
+	assert.Equal(t, "http://example.com/calculator", defs.Services[0].Ports[0].SOAPAddress.Location)
+}

--- a/pkg/generate/wsdl/parse.go
+++ b/pkg/generate/wsdl/parse.go
@@ -38,8 +38,9 @@ func ParseWSDL(data []byte) (*Definitions, error) {
 }
 
 // charsetReader returns a reader that converts the named charset to UTF-8.
-// For ISO-8859-1/Latin-1, the bytes are already valid UTF-8 for the ASCII
-// range used in WSDL documents, so we pass through directly.
+// For ISO-8859-1/Latin-1, bytes 0-127 map directly to UTF-8. Bytes 128-255
+// are passed through unchanged, which is technically incorrect but sufficient
+// for WSDL element/attribute names that use only ASCII characters.
 func charsetReader(charset string, input io.Reader) (io.Reader, error) {
 	switch strings.ToLower(charset) {
 	case "iso-8859-1", "latin-1", "us-ascii", "ascii":

--- a/pkg/generate/wsdl/parse.go
+++ b/pkg/generate/wsdl/parse.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wsdl
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ParseWSDL unmarshals raw WSDL XML bytes into a Definitions struct.
+// Supports WSDL 1.1 (namespace http://schemas.xmlsoap.org/wsdl/).
+// Handles common non-UTF-8 encodings (ISO-8859-1, Latin-1) that appear
+// in real-world WSDL documents.
+func ParseWSDL(data []byte) (*Definitions, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	decoder.CharsetReader = charsetReader
+
+	var defs Definitions
+	if err := decoder.Decode(&defs); err != nil {
+		return nil, err
+	}
+	return &defs, nil
+}
+
+// charsetReader returns a reader that converts the named charset to UTF-8.
+// For ISO-8859-1/Latin-1, the bytes are already valid UTF-8 for the ASCII
+// range used in WSDL documents, so we pass through directly.
+func charsetReader(charset string, input io.Reader) (io.Reader, error) {
+	switch strings.ToLower(charset) {
+	case "iso-8859-1", "latin-1", "us-ascii", "ascii":
+		return input, nil
+	case "utf-8":
+		return input, nil
+	default:
+		return nil, fmt.Errorf("unsupported charset: %s", charset)
+	}
+}

--- a/pkg/generate/wsdl/parse_test.go
+++ b/pkg/generate/wsdl/parse_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wsdl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCharsetReader_SupportedCharsets(t *testing.T) {
+	supported := []string{
+		"iso-8859-1",
+		"latin-1",
+		"us-ascii",
+		"ascii",
+		"utf-8",
+		// Also verify case-insensitivity via the strings.ToLower in the implementation.
+		"ISO-8859-1",
+		"Latin-1",
+		"US-ASCII",
+		"ASCII",
+		"UTF-8",
+	}
+
+	for _, charset := range supported {
+		t.Run(charset, func(t *testing.T) {
+			input := strings.NewReader("hello")
+			reader, err := charsetReader(charset, input)
+			require.NoError(t, err, "charsetReader(%q) should not return an error", charset)
+			assert.NotNil(t, reader, "charsetReader(%q) should return a non-nil reader", charset)
+		})
+	}
+}
+
+func TestCharsetReader_UnsupportedCharset(t *testing.T) {
+	unsupported := []string{
+		"windows-1252",
+		"shift_jis",
+		"euc-kr",
+		"gb2312",
+		"unknown",
+	}
+
+	for _, charset := range unsupported {
+		t.Run(charset, func(t *testing.T) {
+			input := strings.NewReader("hello")
+			reader, err := charsetReader(charset, input)
+			assert.Error(t, err, "charsetReader(%q) should return an error", charset)
+			assert.Nil(t, reader, "charsetReader(%q) should return a nil reader", charset)
+			assert.Contains(t, err.Error(), "unsupported charset")
+		})
+	}
+}
+
+func TestParseWSDL_ISO88591Encoding(t *testing.T) {
+	wsdlXML := `<?xml version="1.0" encoding="ISO-8859-1"?>
+<definitions name="TestService" xmlns="http://schemas.xmlsoap.org/wsdl/">
+  <message name="Msg"><part name="p" type="xsd:string"/></message>
+  <portType name="TestPortType">
+    <operation name="GetUser">
+      <input message="tns:Msg"/>
+    </operation>
+  </portType>
+</definitions>`
+
+	defs, err := ParseWSDL([]byte(wsdlXML))
+	require.NoError(t, err, "ParseWSDL should handle ISO-8859-1 encoding declaration")
+	assert.Equal(t, "TestService", defs.Name)
+	require.Len(t, defs.Messages, 1)
+	require.Len(t, defs.PortTypes, 1)
+	assert.Equal(t, "GetUser", defs.PortTypes[0].Operations[0].Name)
+}
+
+func TestParseWSDL_UTF8Encoding(t *testing.T) {
+	wsdlXML := `<?xml version="1.0" encoding="UTF-8"?>
+<definitions name="UTF8Service" xmlns="http://schemas.xmlsoap.org/wsdl/">
+  <message name="PingRequest"><part name="p" type="xsd:string"/></message>
+  <portType name="UTF8PortType">
+    <operation name="Ping">
+      <input message="tns:PingRequest"/>
+    </operation>
+  </portType>
+</definitions>`
+
+	defs, err := ParseWSDL([]byte(wsdlXML))
+	require.NoError(t, err, "ParseWSDL should handle UTF-8 encoding declaration")
+	assert.Equal(t, "UTF8Service", defs.Name)
+	require.Len(t, defs.Messages, 1)
+	require.Len(t, defs.PortTypes, 1)
+	assert.Equal(t, "Ping", defs.PortTypes[0].Operations[0].Name)
+}

--- a/pkg/generate/wsdl/types.go
+++ b/pkg/generate/wsdl/types.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wsdl
+
+import "encoding/xml"
+
+// Definitions is the root WSDL 1.1 element.
+type Definitions struct {
+	XMLName   xml.Name   `xml:"definitions"`
+	Name      string     `xml:"name,attr,omitempty"`
+	TargetNS  string     `xml:"targetNamespace,attr,omitempty"`
+	XMLNS     string     `xml:"xmlns,attr,omitempty"`
+	XMLNSWSDL string     `xml:"xmlns:wsdl,attr,omitempty"`
+	XMLNSSOAP string     `xml:"xmlns:soap,attr,omitempty"`
+	XMLNSTNS  string     `xml:"xmlns:tns,attr,omitempty"`
+	XMLNSXSD  string     `xml:"xmlns:xsd,attr,omitempty"`
+	Types     *Types     `xml:"types,omitempty"`
+	Messages  []Message  `xml:"message"`
+	PortTypes []PortType `xml:"portType"`
+	Bindings  []Binding  `xml:"binding"`
+	Services  []Service  `xml:"service"`
+}
+
+// Types wraps XSD schemas.
+type Types struct {
+	Schemas []Schema `xml:"schema"`
+}
+
+// Schema represents an XSD schema embedded in WSDL.
+type Schema struct {
+	XMLName      xml.Name      `xml:"schema"`
+	TargetNS     string        `xml:"targetNamespace,attr,omitempty"`
+	XMLNS        string        `xml:"xmlns,attr,omitempty"`
+	Elements     []Element     `xml:"element"`
+	ComplexTypes []ComplexType `xml:"complexType"`
+}
+
+// Element represents an XSD element.
+type Element struct {
+	XMLName     xml.Name     `xml:"element"`
+	Name        string       `xml:"name,attr"`
+	Type        string       `xml:"type,attr,omitempty"`
+	ComplexType *ComplexType `xml:"complexType,omitempty"`
+}
+
+// ComplexType represents an XSD complex type.
+type ComplexType struct {
+	XMLName  xml.Name  `xml:"complexType"`
+	Name     string    `xml:"name,attr,omitempty"`
+	Sequence []Element `xml:"sequence>element"`
+}
+
+// Message represents a WSDL message.
+type Message struct {
+	XMLName xml.Name      `xml:"message"`
+	Name    string        `xml:"name,attr"`
+	Parts   []MessagePart `xml:"part"`
+}
+
+// MessagePart represents a part of a WSDL message.
+type MessagePart struct {
+	XMLName xml.Name `xml:"part"`
+	Name    string   `xml:"name,attr"`
+	Element string   `xml:"element,attr,omitempty"`
+	Type    string   `xml:"type,attr,omitempty"`
+}
+
+// PortType groups related operations.
+type PortType struct {
+	XMLName    xml.Name    `xml:"portType"`
+	Name       string      `xml:"name,attr"`
+	Operations []Operation `xml:"operation"`
+}
+
+// Operation represents a WSDL operation.
+type Operation struct {
+	XMLName xml.Name `xml:"operation"`
+	Name    string   `xml:"name,attr"`
+	Input   *IOMsg   `xml:"input,omitempty"`
+	Output  *IOMsg   `xml:"output,omitempty"`
+}
+
+// IOMsg references a message for input/output.
+type IOMsg struct {
+	Message string `xml:"message,attr"`
+}
+
+// Binding specifies protocol details for a port type.
+type Binding struct {
+	XMLName     xml.Name           `xml:"binding"`
+	Name        string             `xml:"name,attr"`
+	Type        string             `xml:"type,attr"`
+	SOAPBinding *SOAPBinding       `xml:"http://schemas.xmlsoap.org/wsdl/soap/ binding,omitempty"`
+	Operations  []BindingOperation `xml:"operation"`
+}
+
+// SOAPBinding specifies SOAP transport.
+type SOAPBinding struct {
+	Style     string `xml:"style,attr,omitempty"`
+	Transport string `xml:"transport,attr,omitempty"`
+}
+
+// BindingOperation specifies SOAP action for an operation.
+type BindingOperation struct {
+	XMLName       xml.Name       `xml:"operation"`
+	Name          string         `xml:"name,attr"`
+	SOAPOperation *SOAPOperation `xml:"http://schemas.xmlsoap.org/wsdl/soap/ operation,omitempty"`
+}
+
+// SOAPOperation specifies SOAPAction.
+type SOAPOperation struct {
+	SOAPAction string `xml:"soapAction,attr,omitempty"`
+}
+
+// Service groups related ports.
+type Service struct {
+	XMLName xml.Name `xml:"service"`
+	Name    string   `xml:"name,attr"`
+	Ports   []Port   `xml:"port"`
+}
+
+// Port associates a binding with a network address.
+type Port struct {
+	XMLName     xml.Name     `xml:"port"`
+	Name        string       `xml:"name,attr"`
+	Binding     string       `xml:"binding,attr"`
+	SOAPAddress *SOAPAddress `xml:"http://schemas.xmlsoap.org/wsdl/soap/ address,omitempty"`
+}
+
+// SOAPAddress specifies the endpoint URL.
+type SOAPAddress struct {
+	Location string `xml:"location,attr"`
+}

--- a/pkg/probe/wsdl.go
+++ b/pkg/probe/wsdl.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// maxWSDLBodySize limits the response body read for WSDL documents.
+const maxWSDLBodySize = 2 << 20 // 2 MB
+
+// WSDLProbe fetches WSDL documents from discovered SOAP endpoints.
+type WSDLProbe struct {
+	config Config
+}
+
+// NewWSDLProbe creates a WSDLProbe with the given configuration.
+func NewWSDLProbe(cfg Config) *WSDLProbe {
+	return &WSDLProbe{config: cfg.withDefaults()}
+}
+
+// Name returns the probe name.
+func (p *WSDLProbe) Name() string {
+	return "wsdl"
+}
+
+// Probe fetches WSDL documents for SOAP endpoints by appending ?wsdl to the URL.
+// Only endpoints with api_type=="wsdl" are probed. Endpoints are deduplicated
+// by base URL to avoid redundant requests.
+func (p *WSDLProbe) Probe(ctx context.Context, endpoints []classify.ClassifiedRequest) ([]classify.ClassifiedRequest, error) {
+	// Deduplicate: probe each unique base URL once
+	wsdlDocs := make(map[string][]byte)
+	seen := make(map[string]bool)
+
+	for _, ep := range endpoints {
+		if ep.APIType != "wsdl" {
+			continue
+		}
+
+		baseURL := stripWSDLSuffix(ep.URL)
+		if seen[baseURL] {
+			continue
+		}
+		if len(seen) >= p.config.MaxEndpoints {
+			break
+		}
+		seen[baseURL] = true
+
+		doc := p.fetchWSDL(ctx, baseURL)
+		if doc != nil {
+			wsdlDocs[baseURL] = doc
+		}
+	}
+
+	// Copy endpoints to avoid mutating the caller's slice
+	result := make([]classify.ClassifiedRequest, len(endpoints))
+	copy(result, endpoints)
+
+	for i := range result {
+		if result[i].APIType != "wsdl" {
+			continue
+		}
+		baseURL := stripWSDLSuffix(result[i].URL)
+		if doc, ok := wsdlDocs[baseURL]; ok {
+			result[i].WSDLDocument = doc
+		}
+	}
+
+	return result, nil
+}
+
+// fetchWSDL appends ?wsdl to the URL and fetches the WSDL document.
+func (p *WSDLProbe) fetchWSDL(ctx context.Context, baseURL string) []byte {
+	wsdlURL := baseURL + "?wsdl"
+
+	if err := p.config.URLValidator(wsdlURL); err != nil {
+		slog.DebugContext(ctx, "wsdl probe: URL validation failed", "url", wsdlURL, "error", err)
+		return nil
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, p.config.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, wsdlURL, nil)
+	if err != nil {
+		return nil
+	}
+
+	for k, v := range p.config.AuthHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := p.config.Client.Do(req)
+	if err != nil {
+		slog.DebugContext(ctx, "wsdl probe: request failed", "url", wsdlURL, "error", err)
+		return nil
+	}
+	defer func() {
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck // best-effort drain
+		resp.Body.Close()                                    //nolint:errcheck // best-effort close
+	}()
+
+	if resp.StatusCode >= 400 {
+		slog.DebugContext(ctx, "wsdl probe: non-success status", "url", wsdlURL, "status", resp.StatusCode)
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxWSDLBodySize))
+	if err != nil {
+		return nil
+	}
+
+	// Validate response looks like WSDL XML
+	if !isWSDLResponse(body) {
+		slog.DebugContext(ctx, "wsdl probe: response is not WSDL", "url", wsdlURL)
+		return nil
+	}
+
+	return body
+}
+
+// isWSDLResponse checks if the body looks like a WSDL document.
+func isWSDLResponse(body []byte) bool {
+	return bytes.Contains(body, []byte("definitions")) &&
+		(bytes.Contains(body, []byte("schemas.xmlsoap.org/wsdl")) ||
+			bytes.Contains(body, []byte("portType")) ||
+			bytes.Contains(body, []byte("message")))
+}
+
+// stripWSDLSuffix removes ?wsdl query parameter or /wsdl path suffix from a URL.
+func stripWSDLSuffix(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	// Remove ?wsdl query parameter
+	q := parsed.Query()
+	q.Del("wsdl")
+	parsed.RawQuery = q.Encode()
+
+	// Remove /wsdl path suffix
+	parsed.Path = strings.TrimSuffix(parsed.Path, "/wsdl")
+
+	return parsed.String()
+}

--- a/pkg/probe/wsdl_test.go
+++ b/pkg/probe/wsdl_test.go
@@ -1,0 +1,299 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+	"github.com/praetorian-inc/vespasian/pkg/probe"
+)
+
+func TestWSDLProbe_Name(t *testing.T) {
+	p := probe.NewWSDLProbe(probe.DefaultConfig())
+	if p.Name() != "wsdl" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "wsdl")
+	}
+}
+
+func TestWSDLProbe_ValidWSDL(t *testing.T) {
+	wsdlDoc := `<?xml version="1.0"?>
+<definitions name="TestService" xmlns="http://schemas.xmlsoap.org/wsdl/">
+  <message name="GetUserRequest"><part name="parameters" element="tns:GetUser"/></message>
+  <portType name="TestPortType">
+    <operation name="GetUser"/>
+  </portType>
+</definitions>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery == "wsdl" {
+			w.Header().Set("Content-Type", "text/xml")
+			w.Write([]byte(wsdlDoc))
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewWSDLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method: "POST",
+			URL:    srv.URL + "/service",
+		},
+		IsAPI:   true,
+		APIType: "wsdl",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if result[0].WSDLDocument == nil {
+		t.Fatal("WSDLDocument should not be nil")
+	}
+	if string(result[0].WSDLDocument) != wsdlDoc {
+		t.Errorf("WSDLDocument mismatch")
+	}
+}
+
+func TestWSDLProbe_404OnWSDL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewWSDLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/service"},
+		IsAPI:           true,
+		APIType:         "wsdl",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if result[0].WSDLDocument != nil {
+		t.Errorf("expected nil WSDLDocument for 404, got %d bytes", len(result[0].WSDLDocument))
+	}
+}
+
+func TestWSDLProbe_NoDoubleAppendWSDL(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		if r.URL.RawQuery == "wsdl" {
+			w.Header().Set("Content-Type", "text/xml")
+			w.Write([]byte(`<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"><portType name="PT"/></definitions>`))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewWSDLProbe(cfg)
+
+	// URL already has ?wsdl -- should not double-append
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: srv.URL + "/service?wsdl"},
+		IsAPI:           true,
+		APIType:         "wsdl",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if result[0].WSDLDocument == nil {
+		t.Fatal("WSDLDocument should not be nil")
+	}
+	// Should have made exactly 1 request, not 2
+	if requestCount.Load() != 1 {
+		t.Errorf("expected 1 request, got %d", requestCount.Load())
+	}
+}
+
+func TestWSDLProbe_SkipsNonSOAP(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewWSDLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: srv.URL + "/api/users"},
+		IsAPI:           true,
+		APIType:         "rest",
+	}}
+
+	_, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if requestCount.Load() != 0 {
+		t.Errorf("expected 0 requests for non-SOAP endpoint, got %d", requestCount.Load())
+	}
+}
+
+func TestWSDLProbe_MaxEndpointsRespected(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "text/xml")
+		w.Write([]byte(`<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"><portType name="PT"/></definitions>`))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{
+		Client:       srv.Client(),
+		Timeout:      5 * time.Second,
+		URLValidator: func(string) error { return nil },
+		MaxEndpoints: 2,
+	}
+	p := probe.NewWSDLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/svc1"}, IsAPI: true, APIType: "wsdl"},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/svc2"}, IsAPI: true, APIType: "wsdl"},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/svc3"}, IsAPI: true, APIType: "wsdl"},
+	}
+
+	_, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if requestCount.Load() > 2 {
+		t.Errorf("expected at most 2 requests (MaxEndpoints=2), got %d", requestCount.Load())
+	}
+}
+
+func TestWSDLProbe_DeduplicatesByBaseURL(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "text/xml")
+		w.Write([]byte(`<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"><portType name="PT"/></definitions>`))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewWSDLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     srv.URL + "/service",
+				Headers: map[string]string{"SOAPAction": `"urn:GetUser"`},
+			},
+			IsAPI: true, APIType: "wsdl",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     srv.URL + "/service",
+				Headers: map[string]string{"SOAPAction": `"urn:DeleteUser"`},
+			},
+			IsAPI: true, APIType: "wsdl",
+		},
+	}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if requestCount.Load() != 1 {
+		t.Errorf("expected 1 request (deduplicated by base URL), got %d", requestCount.Load())
+	}
+	if result[0].WSDLDocument == nil {
+		t.Error("result[0].WSDLDocument should not be nil")
+	}
+	if result[1].WSDLDocument == nil {
+		t.Error("result[1].WSDLDocument should not be nil")
+	}
+}
+
+func TestWSDLProbe_RejectsNonWSDLXML(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		w.Write([]byte(`<html><body>Not a WSDL</body></html>`))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewWSDLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/service"},
+		IsAPI: true, APIType: "wsdl",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+	if result[0].WSDLDocument != nil {
+		t.Error("expected nil WSDLDocument for non-WSDL response")
+	}
+}
+
+func TestWSDLProbe_DoesNotMutateInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		w.Write([]byte(`<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"><portType name="PT"/></definitions>`))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewWSDLProbe(cfg)
+
+	original := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/service"},
+		IsAPI: true, APIType: "wsdl",
+	}}
+
+	result, err := p.Probe(context.Background(), original)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+	if original[0].WSDLDocument != nil {
+		t.Error("original slice should not be mutated")
+	}
+	if result[0].WSDLDocument == nil {
+		t.Error("result slice should have WSDL")
+	}
+}

--- a/pkg/probe/wsdl_test.go
+++ b/pkg/probe/wsdl_test.go
@@ -259,7 +259,7 @@ func TestWSDLProbe_RejectsNonWSDLXML(t *testing.T) {
 
 	endpoints := []classify.ClassifiedRequest{{
 		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/service"},
-		IsAPI: true, APIType: "wsdl",
+		IsAPI:           true, APIType: "wsdl",
 	}}
 
 	result, err := p.Probe(context.Background(), endpoints)
@@ -283,7 +283,7 @@ func TestWSDLProbe_DoesNotMutateInput(t *testing.T) {
 
 	original := []classify.ClassifiedRequest{{
 		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/service"},
-		IsAPI: true, APIType: "wsdl",
+		IsAPI:           true, APIType: "wsdl",
 	}}
 
 	result, err := p.Probe(context.Background(), original)


### PR DESCRIPTION
## Summary

- Adds `WSDLClassifier` for SOAP/WSDL traffic detection (SOAPAction header, SOAP envelope, ?wsdl URL, soap content-type signals)
- Adds `WSDLProbe` to fetch authoritative WSDL documents via `?wsdl` endpoint
- Adds WSDL generator with hybrid approach: Phase 1 uses fetched/response WSDL, Phase 2 infers from observed traffic
- Fixes `Deduplicate()` to use SOAPAction-aware keys, preventing collapse of distinct SOAP operations on same URL
- Wires WSDL support into CLI `scan` and `generate` commands

## Test plan

- [x] 14 WSDLClassifier unit tests (all signals, negative signals, exclusions)
- [x] 5 SOAPAction dedup tests (preserve distinct, merge same, case-insensitive)
- [x] 9 InferWSDL tests (SOAPAction, body element, dedup, edge cases)
- [x] 14 generator tests (Phase 1/2, parse round-trip, malformed fallthrough)
- [x] 9 WSDLProbe tests (valid WSDL, 404, no double-append, skip non-SOAP, MaxEndpoints)
- [x] E2E: `scan` against VWS PHP (port 8081) discovers 4 SOAP operations
- [x] E2E: `generate wsdl` produces valid WSDL from scan capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)