### PR TITLE
fix: set TimeStable to prevent go-rod panic in headless crawl mode

### DIFF
--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -83,6 +83,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		Concurrency:       10,
 		Parallelism:       10,
 		RateLimit:         150,
+		TimeStable:        3, // seconds to wait for DOM stability; 0 causes go-rod panic in time.NewTicker
 		ScrapeJSResponses: true,
 		XhrExtraction:     true,
 		Silent:            true,


### PR DESCRIPTION
## Summary

- Building from the current repo with the default `make build` and running `vespasian crawl` or `vespasian scan` in headless mode triggers a runtime panic in go-rod's `WaitDOMStable`
- Sets `TimeStable: 3` in Katana options to provide a valid polling interval for DOM stability checks

## Root Cause

The Katana `TimeStable` option was unset (zero-value), causing:

1. Katana computes `timeStable = Duration(0) * Second = 0`
2. Katana calls `page.WaitStable(0)` on the go-rod Page
3. go-rod calls `WaitDOMStable(0, 0)` → `time.NewTicker(0)` → **panic**

```
goroutine 193 [running]:
time.NewTicker(0x14004222210?)
    time/tick.go:38 +0xc0
github.com/go-rod/rod.(*Page).WaitDOMStable(0x14004222210, 0x0, 0x0)
    github.com/go-rod/rod@v0.116.2/page.go:791 +0xa4
```

## Test plan

- [ ] `make build` succeeds
- [ ] `go test -race ./pkg/crawl/...` passes
- [ ] `vespasian crawl <url>` no longer panics in headless mode