### PR TITLE
fix: decouple per-page timeout from crawl duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ vespasian scan <url> [flags]
   -o, --output       Output spec file (default: stdout)
   --depth            Max crawl depth (default: 3)
   --max-pages        Max pages to visit (default: 100)
-  --timeout          Maximum duration for the entire crawl (default: 10m)
+  --timeout          Maximum duration for the entire scan (default: 10m)
   --scope            same-origin or same-domain (default: same-origin)
   --headless         Browser mode (default: true)
   --confidence       Min classification confidence (default: 0.5)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ vespasian scan <url> [flags]
   -o, --output       Output spec file (default: stdout)
   --depth            Max crawl depth (default: 3)
   --max-pages        Max pages to visit (default: 100)
-  --timeout          Scan timeout (default: 30s)
+  --timeout          Maximum duration for the entire crawl (default: 10m)
   --scope            same-origin or same-domain (default: same-origin)
   --headless         Browser mode (default: true)
   --confidence       Min classification confidence (default: 0.5)
@@ -145,7 +145,7 @@ vespasian crawl <url> [flags]
   --format           Capture format: json, yaml (default: json)
   --depth            Max crawl depth (default: 3)
   --max-pages        Max pages to visit (default: 100)
-  --timeout          Scan timeout (default: 30s)
+  --timeout          Maximum duration for the entire crawl (default: 10m)
   --scope            same-origin or same-domain (default: same-origin)
   --headless         Browser mode (default: true)
   -v, --verbose      Show requests in real-time

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -122,7 +122,7 @@ type CrawlOptions struct {
 	Output   string        `short:"o" help:"Output file path"`
 	Depth    int           `default:"3" help:"Maximum crawl depth"`
 	MaxPages int           `default:"100" help:"Maximum pages to crawl"`
-	Timeout  time.Duration `default:"30s" help:"Request timeout"`
+	Timeout  time.Duration `default:"10m" help:"Maximum duration for the entire crawl"`
 	Scope    string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
 	Headless bool          `default:"true" help:"Use headless browser"`
 	Verbose  bool          `short:"v" help:"Enable verbose logging"`

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -32,6 +32,10 @@ const (
 	DefaultMaxPages = 1000
 	// MaxResponseBodySize is the maximum response body size to retain for classification (1 MB).
 	MaxResponseBodySize = 1 * 1024 * 1024
+	// PageTimeout is the per-page timeout in seconds for go-rod and HTTP requests.
+	// This is an internal constant, not user-configurable — it prevents a single
+	// unresponsive page from blocking the sequential headless crawl.
+	PageTimeout = 30
 )
 
 // CrawlerOptions configures the crawler behavior.
@@ -73,7 +77,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	// Build Katana options
 	katanaOpts := &types.Options{
 		MaxDepth:          c.opts.Depth,
-		Timeout:           int(c.opts.Timeout.Seconds()),
+		Timeout:           PageTimeout,
 		CrawlDuration:     c.opts.Timeout,
 		FieldScope:        MapScope(c.opts.Scope),
 		Headless:          c.opts.Headless,

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -343,6 +343,13 @@ func TestMaxResponseBodySize(t *testing.T) {
 	}
 }
 
+
+// TestPageTimeout verifies the PageTimeout constant value
+func TestPageTimeout(t *testing.T) {
+	if PageTimeout != 30 {
+		t.Errorf("PageTimeout = %d, want 30", PageTimeout)
+	}
+}
 // TestMapResult_TruncatesLargeResponseBody tests that response bodies exceeding MaxResponseBodySize get truncated
 func TestMapResult_TruncatesLargeResponseBody(t *testing.T) {
 	largeBody := make([]byte, MaxResponseBodySize+1000) // 1000 bytes over limit


### PR DESCRIPTION
## Bug

`--timeout` (default `30s`) was passed to both Katana's `Timeout` (per-page go-rod/HTTP timeout) and `CrawlDuration` (absolute wall-clock cap). This hard-capped the entire crawl at 30 seconds, silently returning partial results regardless of `--max-pages`.

Traced through Katana source to confirm:
- `Timeout` → `hybrid/crawl.go:186` (per-page `page.Timeout()`) and `common/http.go:55` (`http.Client.Timeout`)
- `CrawlDuration` → `common/base.go:215` (`context.WithTimeout` on entire crawl session)

Additionally, headless mode (Vespasian's default) is single-threaded — Katana's hybrid engine overrides `Do()` to process pages sequentially since Chrome DevTools Protocol cannot safely handle concurrent page operations.

## Fix

- Add `PageTimeout = 30` internal constant → Katana `Timeout` (per-page)
- `--timeout` now controls only `CrawlDuration`, default raised to `10m`

No idle-timeout mechanism was added. In single-threaded headless mode, a stalled page is already handled by the per-page timeout unblocking the sequential loop. An idle detector would add complexity for no practical benefit.