### PR TITLE
chore: crawl package hygiene — idempotent close, input validation

### DIFF
--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -66,7 +66,8 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		return nil, fmt.Errorf("depth must be non-negative, got %d", c.opts.Depth)
 	}
 
-	if _, err := url.Parse(targetURL); err != nil || targetURL == "" {
+	u, err := url.Parse(targetURL)
+	if err != nil || targetURL == "" || (u.Scheme != "http" && u.Scheme != "https") {
 		return nil, fmt.Errorf("invalid target URL: %q", targetURL)
 	}
 

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -16,6 +16,7 @@ package crawl
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sync"
 	"time"
@@ -59,6 +60,14 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	maxPages := c.opts.MaxPages
 	if maxPages <= 0 {
 		maxPages = DefaultMaxPages
+	}
+
+	if c.opts.Depth < 0 {
+		return nil, fmt.Errorf("depth must be non-negative, got %d", c.opts.Depth)
+	}
+
+	if _, err := url.Parse(targetURL); err != nil || targetURL == "" {
+		return nil, fmt.Errorf("invalid target URL: %q", targetURL)
 	}
 
 	// Create a cancellable context to stop Katana when MaxPages is reached.
@@ -125,7 +134,9 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = engine.Close() }()
+	var closeOnce sync.Once
+	closeEngine := func() { closeOnce.Do(func() { _ = engine.Close() }) }
+	defer closeEngine()
 
 	// Run crawl in goroutine with context cancellation
 	crawlErr := make(chan error, 1)
@@ -142,7 +153,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		// Context canceled (MaxPages reached or SIGINT/SIGTERM).
 		// Close the engine to unblock the goroutine, then drain it
 		// to avoid a goroutine leak.
-		_ = engine.Close()
+		closeEngine()
 		<-crawlErr
 
 		// If the parent context was canceled (SIGINT/SIGTERM), propagate that error

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -15,6 +15,8 @@
 package crawl
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/projectdiscovery/katana/pkg/navigation"
@@ -325,6 +327,34 @@ func TestNewCrawler(t *testing.T) {
 	}
 	if crawler.opts.Headers["User-Agent"] != "test" {
 		t.Errorf("crawler.opts.Headers[User-Agent] = %q, want %q", crawler.opts.Headers["User-Agent"], "test")
+	}
+}
+
+// TestCrawl_NegativeDepthReturnsError tests that negative depth is rejected
+func TestCrawl_NegativeDepthReturnsError(t *testing.T) {
+	crawler := NewCrawler(CrawlerOptions{
+		Depth: -1,
+	})
+	_, err := crawler.Crawl(context.Background(), "https://example.com")
+	if err == nil {
+		t.Fatal("expected error for negative depth, got nil")
+	}
+	if !strings.Contains(err.Error(), "depth must be non-negative") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestCrawl_EmptyURLReturnsError tests that empty URL is rejected
+func TestCrawl_EmptyURLReturnsError(t *testing.T) {
+	crawler := NewCrawler(CrawlerOptions{
+		Depth: 3,
+	})
+	_, err := crawler.Crawl(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid target URL") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -17,6 +17,7 @@ package crawl
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/projectdiscovery/katana/pkg/navigation"
@@ -355,6 +356,37 @@ func TestCrawl_EmptyURLReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid target URL") {
 		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestCrawl_SchemelessURLReturnsError tests that URLs without http/https scheme are rejected
+func TestCrawl_SchemelessURLReturnsError(t *testing.T) {
+	crawler := NewCrawler(CrawlerOptions{
+		Depth: 3,
+	})
+	_, err := crawler.Crawl(context.Background(), "not-a-url")
+	if err == nil {
+		t.Fatal("expected error for schemeless URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid target URL") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestCloseEngineOnce verifies the sync.Once wrapper prevents double-close.
+// This mirrors the closeEngine pattern in Crawl (crawler.go lines 143-145)
+// where engine.Close() can be called both explicitly on context cancellation
+// and via defer.
+func TestCloseEngineOnce(t *testing.T) {
+	var count int
+	var once sync.Once
+	closeEngine := func() { once.Do(func() { count++ }) }
+
+	closeEngine()
+	closeEngine()
+
+	if count != 1 {
+		t.Errorf("close called %d times, want 1", count)
 	}
 }
 

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -359,17 +359,28 @@ func TestCrawl_EmptyURLReturnsError(t *testing.T) {
 	}
 }
 
-// TestCrawl_SchemelessURLReturnsError tests that URLs without http/https scheme are rejected
-func TestCrawl_SchemelessURLReturnsError(t *testing.T) {
-	crawler := NewCrawler(CrawlerOptions{
-		Depth: 3,
-	})
-	_, err := crawler.Crawl(context.Background(), "not-a-url")
-	if err == nil {
-		t.Fatal("expected error for schemeless URL, got nil")
+// TestCrawl_InvalidSchemeReturnsError tests that URLs without http/https scheme
+// are rejected, including non-HTTP schemes that could be SSRF vectors.
+func TestCrawl_InvalidSchemeReturnsError(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"schemeless", "not-a-url"},
+		{"file scheme", "file:///etc/passwd"},
+		{"ftp scheme", "ftp://example.com"},
 	}
-	if !strings.Contains(err.Error(), "invalid target URL") {
-		t.Errorf("unexpected error message: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crawler := NewCrawler(CrawlerOptions{Depth: 3})
+			_, err := crawler.Crawl(context.Background(), tt.url)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tt.url)
+			}
+			if !strings.Contains(err.Error(), "invalid target URL") {
+				t.Errorf("unexpected error message: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Three small hygiene improvements to `pkg/crawl/`, no behavioral changes for valid inputs.

## Changes

**1. Idempotent engine close** — `engine.Close()` was called twice on the context cancellation path (explicit call + deferred close). Both Katana engines happen to be idempotent today, but this is an undocumented assumption. Wrapped with `sync.Once`.

**2. Negative depth validation** — `--depth=-1` silently produces zero results because Katana skips even the seed URL when `MaxDepth < 0`. Now returns a clear error. (`--depth=0` remains valid — it crawls only the seed page.)

**3. URL validation in library** — `Crawl()` accepted any string, relying on CLI-layer validation. Programmatic callers now get a clear error for empty/invalid URLs instead of opaque Katana failures.