### PR TITLE
feat: own browser lifecycle for immediate signal handling

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -52,7 +52,8 @@ var CLI struct {
 	Version  VersionCmd  `cmd:"" help:"Show version information"`
 }
 
-// parseHeaders converts "Key: Value" strings to a map, validating for CRLF injection.
+// parseHeaders converts "Key: Value" strings to a map, validating header names
+// against RFC 7230 token production and header values against CRLF injection.
 func parseHeaders(raw []string) (map[string]string, error) {
 	headers := make(map[string]string)
 	for _, h := range raw {
@@ -65,12 +66,46 @@ func parseHeaders(raw []string) (map[string]string, error) {
 		if name == "" {
 			return nil, fmt.Errorf("header has empty name: %q", h)
 		}
-		if strings.ContainsAny(name, "\r\n") || strings.ContainsAny(value, "\r\n") {
-			return nil, fmt.Errorf("header contains invalid CRLF characters: %q", h)
+		if !isValidHeaderName(name) {
+			return nil, fmt.Errorf("header name contains invalid characters (RFC 7230): %q", h)
+		}
+		if strings.ContainsAny(value, "\r\n") {
+			return nil, fmt.Errorf("header value contains invalid CRLF characters: %q", h)
 		}
 		headers[name] = value
 	}
 	return headers, nil
+}
+
+// isValidHeaderName checks that name consists only of RFC 7230 token characters.
+// tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+//
+//	"^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+func isValidHeaderName(name string) bool {
+	for i := 0; i < len(name); i++ {
+		if !isTokenChar(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isTokenChar returns true if c is a valid RFC 7230 tchar.
+func isTokenChar(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	case c == '!' || c == '#' || c == '$' || c == '%' || c == '&' ||
+		c == '\'' || c == '*' || c == '+' || c == '-' || c == '.' ||
+		c == '^' || c == '_' || c == '`' || c == '|' || c == '~':
+		return true
+	default:
+		return false
+	}
 }
 
 // doCrawl executes the common crawl pipeline: parse headers, create crawler,
@@ -186,6 +221,18 @@ func (c *CrawlCmd) Run() error {
 		Headless: c.Headless,
 	}
 
+	// Create browser before signal setup so force-exit can clean up temp dirs.
+	var browserMgr *crawl.BrowserManager
+	if c.Headless {
+		var err error
+		browserMgr, err = crawl.NewBrowserManager(crawl.BrowserOptions{Headless: true})
+		if err != nil {
+			return fmt.Errorf("launch browser: %w", err)
+		}
+		defer browserMgr.Close()
+		opts.BrowserMgr = browserMgr
+	}
+
 	if c.Verbose {
 		fmt.Fprintf(os.Stderr, "crawling %s (depth=%d, max-pages=%d, timeout=%s)\n",
 			c.URL, opts.Depth, opts.MaxPages, opts.Timeout)
@@ -194,7 +241,11 @@ func (c *CrawlCmd) Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	setupForceExitHandler(ctx, os.Stderr, nil, os.Exit)
+	setupForceExitHandler(ctx, os.Stderr, func() {
+		if browserMgr != nil {
+			browserMgr.Close()
+		}
+	}, os.Exit)
 
 	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
 	if err != nil {
@@ -328,6 +379,18 @@ func (c *ScanCmd) Run() error {
 		Headless: c.Headless,
 	}
 
+	// Create browser before signal setup so force-exit can clean up temp dirs.
+	var browserMgr *crawl.BrowserManager
+	if c.Headless {
+		var err error
+		browserMgr, err = crawl.NewBrowserManager(crawl.BrowserOptions{Headless: true})
+		if err != nil {
+			return fmt.Errorf("launch browser: %w", err)
+		}
+		defer browserMgr.Close()
+		opts.BrowserMgr = browserMgr
+	}
+
 	if c.Verbose {
 		fmt.Fprintf(os.Stderr, "crawling %s (depth=%d, max-pages=%d, timeout=%s)\n",
 			c.URL, opts.Depth, opts.MaxPages, opts.Timeout)
@@ -336,7 +399,11 @@ func (c *ScanCmd) Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	setupForceExitHandler(ctx, os.Stderr, nil, os.Exit)
+	setupForceExitHandler(ctx, os.Stderr, func() {
+		if browserMgr != nil {
+			browserMgr.Close()
+		}
+	}, os.Exit)
 
 	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
 	if err != nil {

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -181,23 +181,70 @@ func setupForceExitHandler(ctx context.Context, stderr io.Writer, cleanup func()
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 		<-sigCh
-		if cleanup != nil {
-			cleanup()
-		}
-		fmt.Fprintf(stderr, "forcing immediate exit\n")
-		exitFn(1)
+		onForceExit(stderr, cleanup, exitFn)
 	}()
 }
 
-// onForceExit is the testable core of setupForceExitHandler. It runs cleanup,
-// writes the exit message, and calls exitFn. Extracted so tests can exercise
-// the logic without sending real signals.
+// onForceExit is the testable core of setupForceExitHandler. It runs cleanup
+// (with panic recovery to guarantee exitFn is called), writes the exit message,
+// and calls exitFn. Extracted so tests can exercise the logic without sending
+// real signals.
 func onForceExit(stderr io.Writer, cleanup func(), exitFn func(int)) {
 	if cleanup != nil {
-		cleanup()
+		func() {
+			defer func() { recover() }()
+			cleanup()
+		}()
 	}
 	fmt.Fprintf(stderr, "forcing immediate exit\n")
 	exitFn(1)
+}
+
+// browserSetupResult holds the resources created by setupBrowserAndSignals.
+type browserSetupResult struct {
+	opts    crawl.CrawlerOptions
+	ctx     context.Context
+	stop    context.CancelFunc
+	cleanup func() // caller must defer this
+}
+
+// setupBrowserAndSignals creates a BrowserManager (if headless), wires up
+// signal handling with force-exit support, and returns a cancellable context.
+// The returned cleanup function closes the browser and stops the signal handler;
+// callers must defer it.
+func setupBrowserAndSignals(crawlOpts CrawlOptions, extraOpts crawl.CrawlerOptions) (browserSetupResult, error) {
+	var browserMgr *crawl.BrowserManager
+
+	if crawlOpts.Headless {
+		var err error
+		browserMgr, err = crawl.NewBrowserManager(crawl.BrowserOptions{Headless: true})
+		if err != nil {
+			return browserSetupResult{}, fmt.Errorf("launch browser: %w", err)
+		}
+		extraOpts.BrowserMgr = browserMgr
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+
+	setupForceExitHandler(ctx, os.Stderr, func() {
+		if browserMgr != nil {
+			browserMgr.Close()
+		}
+	}, os.Exit)
+
+	cleanup := func() {
+		stop()
+		if browserMgr != nil {
+			browserMgr.Close()
+		}
+	}
+
+	return browserSetupResult{
+		opts:    extraOpts,
+		ctx:     ctx,
+		stop:    stop,
+		cleanup: cleanup,
+	}, nil
 }
 
 // CrawlCmd crawls a web application to capture HTTP traffic.
@@ -213,41 +260,24 @@ func (c *CrawlCmd) Run() error {
 		return err
 	}
 
-	opts := crawl.CrawlerOptions{
+	bs, err := setupBrowserAndSignals(c.CrawlOptions, crawl.CrawlerOptions{
 		Depth:    c.Depth,
 		MaxPages: c.MaxPages,
 		Timeout:  c.Timeout,
 		Scope:    c.Scope,
 		Headless: c.Headless,
+	})
+	if err != nil {
+		return err
 	}
-
-	// Create browser before signal setup so force-exit can clean up temp dirs.
-	var browserMgr *crawl.BrowserManager
-	if c.Headless {
-		var err error
-		browserMgr, err = crawl.NewBrowserManager(crawl.BrowserOptions{Headless: true})
-		if err != nil {
-			return fmt.Errorf("launch browser: %w", err)
-		}
-		defer browserMgr.Close()
-		opts.BrowserMgr = browserMgr
-	}
+	defer bs.cleanup()
 
 	if c.Verbose {
 		fmt.Fprintf(os.Stderr, "crawling %s (depth=%d, max-pages=%d, timeout=%s)\n",
-			c.URL, opts.Depth, opts.MaxPages, opts.Timeout)
+			c.URL, bs.opts.Depth, bs.opts.MaxPages, bs.opts.Timeout)
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	setupForceExitHandler(ctx, os.Stderr, func() {
-		if browserMgr != nil {
-			browserMgr.Close()
-		}
-	}, os.Exit)
-
-	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
+	requests, err := doCrawl(bs.ctx, os.Stderr, c.URL, c.Header, bs.opts)
 	if err != nil {
 		return err
 	}
@@ -371,41 +401,24 @@ func (c *ScanCmd) Run() error {
 		return err
 	}
 
-	opts := crawl.CrawlerOptions{
+	bs, err := setupBrowserAndSignals(c.CrawlOptions, crawl.CrawlerOptions{
 		Depth:    c.Depth,
 		MaxPages: c.MaxPages,
 		Timeout:  c.Timeout,
 		Scope:    c.Scope,
 		Headless: c.Headless,
+	})
+	if err != nil {
+		return err
 	}
-
-	// Create browser before signal setup so force-exit can clean up temp dirs.
-	var browserMgr *crawl.BrowserManager
-	if c.Headless {
-		var err error
-		browserMgr, err = crawl.NewBrowserManager(crawl.BrowserOptions{Headless: true})
-		if err != nil {
-			return fmt.Errorf("launch browser: %w", err)
-		}
-		defer browserMgr.Close()
-		opts.BrowserMgr = browserMgr
-	}
+	defer bs.cleanup()
 
 	if c.Verbose {
 		fmt.Fprintf(os.Stderr, "crawling %s (depth=%d, max-pages=%d, timeout=%s)\n",
-			c.URL, opts.Depth, opts.MaxPages, opts.Timeout)
+			c.URL, bs.opts.Depth, bs.opts.MaxPages, bs.opts.Timeout)
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	setupForceExitHandler(ctx, os.Stderr, func() {
-		if browserMgr != nil {
-			browserMgr.Close()
-		}
-	}, os.Exit)
-
-	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
+	requests, err := doCrawl(bs.ctx, os.Stderr, c.URL, c.Header, bs.opts)
 	if err != nil {
 		return err
 	}
@@ -415,7 +428,7 @@ func (c *ScanCmd) Run() error {
 		fmt.Fprintf(os.Stderr, "generating REST spec\n")
 	}
 
-	spec, err := generateSpec(ctx, requests, "rest", c.Confidence, c.Probe, c.Verbose)
+	spec, err := generateSpec(bs.ctx, requests, "rest", c.Confidence, c.Probe, c.Verbose)
 	if err != nil {
 		return err
 	}

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -108,6 +108,13 @@ func isTokenChar(c byte) bool {
 	}
 }
 
+// shutdownBackstop is the maximum time doCrawl waits for Crawl() to return
+// after context cancellation. Crawl() has internal bounded shutdown (~2.5s),
+// so this is a defense-in-depth timeout that avoids blocking indefinitely if
+// the engine is stuck. The force-exit handler (second signal) is the final
+// safety net beyond this.
+const shutdownBackstop = 10 * time.Second
+
 // doCrawl executes the common crawl pipeline: parse headers, create crawler,
 // run the crawl with the provided context, and return the results. On graceful
 // shutdown (SIGINT/SIGTERM) partial results are returned instead of an error.
@@ -122,7 +129,42 @@ func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, rawHeaders
 	opts.Stderr = stderr
 
 	crawler := crawl.NewCrawler(opts)
-	requests, err := crawler.Crawl(ctx, targetURL)
+
+	// Run Crawl in a goroutine so we can apply a backstop timeout after
+	// context cancellation. Without this, a stuck Crawl() blocks forever.
+	//
+	// Goroutine lifecycle: if the backstop fires before Crawl() returns,
+	// the goroutine remains alive until Crawl() eventually completes.
+	// The buffered channel (capacity 1) ensures it won't block on send.
+	// In a CLI context the process exits shortly after, and the force-exit
+	// handler (second SIGINT) is the final safety net.
+	type crawlResult struct {
+		requests []crawl.ObservedRequest
+		err      error
+	}
+	ch := make(chan crawlResult, 1)
+	go func() {
+		reqs, crawlErr := crawler.Crawl(ctx, targetURL)
+		ch <- crawlResult{reqs, crawlErr}
+	}()
+
+	var requests []crawl.ObservedRequest
+	select {
+	case r := <-ch:
+		requests, err = r.requests, r.err
+	case <-ctx.Done():
+		// Context cancelled (signal or deadline). Give Crawl() up to
+		// shutdownBackstop to finish its bounded internal shutdown.
+		backstop := time.NewTimer(shutdownBackstop)
+		select {
+		case r := <-ch:
+			requests, err = r.requests, r.err
+		case <-backstop.C:
+			return nil, fmt.Errorf("crawl failed: shutdown timed out after %s", shutdownBackstop)
+		}
+		backstop.Stop()
+	}
+
 	if err != nil {
 		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && len(requests) > 0 {
 			fmt.Fprintf(stderr, "returning %d partial results\n", len(requests))
@@ -226,17 +268,21 @@ func setupBrowserAndSignals(crawlOpts CrawlOptions, extraOpts crawl.CrawlerOptio
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 
-	setupForceExitHandler(ctx, os.Stderr, func() {
+	// Single closure for browser teardown, shared between the force-exit
+	// handler and the deferred cleanup. BrowserManager.Close() is already
+	// idempotent (sync.Once), but a shared closure makes the intent explicit
+	// and avoids duplicating the nil-check.
+	closeBrowser := func() {
 		if browserMgr != nil {
 			browserMgr.Close()
 		}
-	}, os.Exit)
+	}
+
+	setupForceExitHandler(ctx, os.Stderr, closeBrowser, os.Exit)
 
 	cleanup := func() {
 		stop()
-		if browserMgr != nil {
-			browserMgr.Close()
-		}
+		closeBrowser()
 	}
 
 	return browserSetupResult{

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -69,8 +69,8 @@ func parseHeaders(raw []string) (map[string]string, error) {
 		if !isValidHeaderName(name) {
 			return nil, fmt.Errorf("header name contains invalid characters (RFC 7230): %q", h)
 		}
-		if strings.ContainsAny(value, "\r\n") {
-			return nil, fmt.Errorf("header value contains invalid CRLF characters: %q", h)
+		if strings.ContainsAny(value, "\r\n\x00") {
+			return nil, fmt.Errorf("header value contains invalid characters: %q", h)
 		}
 		headers[name] = value
 	}

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -135,15 +135,34 @@ type CrawlOptions struct {
 // to be handled (ctx.Done), then registers for a second SIGINT/SIGTERM and
 // force-exits the process. This avoids a race where both the graceful handler
 // and the force-exit handler consume the same signal simultaneously.
-func setupForceExitHandler(ctx context.Context) {
+//
+// The cleanup function is called before exiting to perform best-effort resource
+// cleanup (e.g., removing temp directories) that would otherwise be skipped by
+// os.Exit bypassing deferred functions. Chrome is already dead at this point
+// (killed on first signal), so cleanup is purely disk hygiene.
+func setupForceExitHandler(ctx context.Context, stderr io.Writer, cleanup func(), exitFn func(int)) {
 	go func() {
 		<-ctx.Done() // First signal consumed by signal.NotifyContext
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 		<-sigCh
-		fmt.Fprintf(os.Stderr, "forcing immediate exit\n")
-		os.Exit(1)
+		if cleanup != nil {
+			cleanup()
+		}
+		fmt.Fprintf(stderr, "forcing immediate exit\n")
+		exitFn(1)
 	}()
+}
+
+// onForceExit is the testable core of setupForceExitHandler. It runs cleanup,
+// writes the exit message, and calls exitFn. Extracted so tests can exercise
+// the logic without sending real signals.
+func onForceExit(stderr io.Writer, cleanup func(), exitFn func(int)) {
+	if cleanup != nil {
+		cleanup()
+	}
+	fmt.Fprintf(stderr, "forcing immediate exit\n")
+	exitFn(1)
 }
 
 // CrawlCmd crawls a web application to capture HTTP traffic.
@@ -175,7 +194,7 @@ func (c *CrawlCmd) Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	setupForceExitHandler(ctx)
+	setupForceExitHandler(ctx, os.Stderr, nil, os.Exit)
 
 	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
 	if err != nil {
@@ -317,7 +336,7 @@ func (c *ScanCmd) Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	setupForceExitHandler(ctx)
+	setupForceExitHandler(ctx, os.Stderr, nil, os.Exit)
 
 	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
 	if err != nil {

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -115,17 +115,18 @@ func isTokenChar(c byte) bool {
 // safety net beyond this.
 const shutdownBackstop = 10 * time.Second
 
-// doCrawl executes the common crawl pipeline: parse headers, create crawler,
-// run the crawl with the provided context, and return the results. On graceful
-// shutdown (SIGINT/SIGTERM) partial results are returned instead of an error.
+// doCrawl executes the common crawl pipeline: create crawler, run the crawl
+// with the provided context, and return the results. On graceful shutdown
+// (SIGINT/SIGTERM) partial results are returned instead of an error.
 // The stderr parameter controls where user-facing status messages are written,
 // allowing tests to capture output.
-func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, rawHeaders []string, opts crawl.CrawlerOptions) ([]crawl.ObservedRequest, error) {
-	headers, err := parseHeaders(rawHeaders)
-	if err != nil {
-		return nil, fmt.Errorf("invalid header: %w", err)
-	}
-	opts.Headers = headers
+//
+// Goroutine lifecycle: if the backstop timer fires before Crawl() returns, the
+// crawl goroutine leaks until Crawl() eventually completes. In CLI usage the
+// process exits shortly after and the force-exit handler (second SIGINT) is the
+// final safety net. Library callers should be aware that a stuck engine may
+// leave a goroutine alive after doCrawl returns.
+func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, opts crawl.CrawlerOptions) ([]crawl.ObservedRequest, error) {
 	opts.Stderr = stderr
 
 	crawler := crawl.NewCrawler(opts)
@@ -149,6 +150,7 @@ func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, rawHeaders
 	}()
 
 	var requests []crawl.ObservedRequest
+	var err error
 	select {
 	case r := <-ch:
 		requests, err = r.requests, r.err
@@ -234,7 +236,11 @@ func setupForceExitHandler(ctx context.Context, stderr io.Writer, cleanup func()
 func onForceExit(stderr io.Writer, cleanup func(), exitFn func(int)) {
 	if cleanup != nil {
 		func() {
-			defer func() { recover() }()
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintf(stderr, "cleanup panicked: %v\n", r)
+				}
+			}()
 			cleanup()
 		}()
 	}
@@ -246,19 +252,26 @@ func onForceExit(stderr io.Writer, cleanup func(), exitFn func(int)) {
 type browserSetupResult struct {
 	opts    crawl.CrawlerOptions
 	ctx     context.Context
-	stop    context.CancelFunc
 	cleanup func() // caller must defer this
 }
 
-// setupBrowserAndSignals creates a BrowserManager (if headless), wires up
-// signal handling with force-exit support, and returns a cancellable context.
-// The returned cleanup function closes the browser and stops the signal handler;
-// callers must defer it.
-func setupBrowserAndSignals(crawlOpts CrawlOptions, extraOpts crawl.CrawlerOptions) (browserSetupResult, error) {
+// setupBrowserAndSignals validates headers, creates a BrowserManager (if
+// headless), wires up signal handling with force-exit support, and returns a
+// cancellable context. Headers are validated before launching Chrome so that
+// invalid headers fail fast without wasting browser startup time. The returned
+// cleanup function closes the browser and stops the signal handler; callers
+// must defer it.
+func setupBrowserAndSignals(rawHeaders []string, crawlOpts CrawlOptions, extraOpts crawl.CrawlerOptions) (browserSetupResult, error) {
+	// Validate headers before launching Chrome — fail fast on invalid input.
+	headers, err := parseHeaders(rawHeaders)
+	if err != nil {
+		return browserSetupResult{}, fmt.Errorf("invalid header: %w", err)
+	}
+	extraOpts.Headers = headers
+
 	var browserMgr *crawl.BrowserManager
 
 	if crawlOpts.Headless {
-		var err error
 		browserMgr, err = crawl.NewBrowserManager(crawl.BrowserOptions{Headless: true})
 		if err != nil {
 			return browserSetupResult{}, fmt.Errorf("launch browser: %w", err)
@@ -288,7 +301,6 @@ func setupBrowserAndSignals(crawlOpts CrawlOptions, extraOpts crawl.CrawlerOptio
 	return browserSetupResult{
 		opts:    extraOpts,
 		ctx:     ctx,
-		stop:    stop,
 		cleanup: cleanup,
 	}, nil
 }
@@ -306,7 +318,7 @@ func (c *CrawlCmd) Run() error {
 		return err
 	}
 
-	bs, err := setupBrowserAndSignals(c.CrawlOptions, crawl.CrawlerOptions{
+	bs, err := setupBrowserAndSignals(c.Header, c.CrawlOptions, crawl.CrawlerOptions{
 		Depth:    c.Depth,
 		MaxPages: c.MaxPages,
 		Timeout:  c.Timeout,
@@ -323,7 +335,7 @@ func (c *CrawlCmd) Run() error {
 			c.URL, bs.opts.Depth, bs.opts.MaxPages, bs.opts.Timeout)
 	}
 
-	requests, err := doCrawl(bs.ctx, os.Stderr, c.URL, c.Header, bs.opts)
+	requests, err := doCrawl(bs.ctx, os.Stderr, c.URL, bs.opts)
 	if err != nil {
 		return err
 	}
@@ -447,7 +459,7 @@ func (c *ScanCmd) Run() error {
 		return err
 	}
 
-	bs, err := setupBrowserAndSignals(c.CrawlOptions, crawl.CrawlerOptions{
+	bs, err := setupBrowserAndSignals(c.Header, c.CrawlOptions, crawl.CrawlerOptions{
 		Depth:    c.Depth,
 		MaxPages: c.MaxPages,
 		Timeout:  c.Timeout,
@@ -464,7 +476,7 @@ func (c *ScanCmd) Run() error {
 			c.URL, bs.opts.Depth, bs.opts.MaxPages, bs.opts.Timeout)
 	}
 
-	requests, err := doCrawl(bs.ctx, os.Stderr, c.URL, c.Header, bs.opts)
+	requests, err := doCrawl(bs.ctx, os.Stderr, c.URL, bs.opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -486,7 +486,14 @@ func (c *ScanCmd) Run() error {
 		fmt.Fprintf(os.Stderr, "generating REST spec\n")
 	}
 
-	spec, err := generateSpec(bs.ctx, requests, "rest", c.Confidence, c.Probe, c.Verbose)
+	// Create a fresh signal context for the generate phase. If a signal
+	// interrupted the crawl, bs.ctx is already cancelled — doCrawl swallowed
+	// the error and returned partial results. Using the cancelled context
+	// would cause generateSpec's probing to bail out immediately.
+	genCtx, genStop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer genStop()
+
+	spec, err := generateSpec(genCtx, requests, "rest", c.Confidence, c.Probe, c.Verbose)
 	if err != nil {
 		return err
 	}

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -84,12 +84,13 @@ func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, rawHeaders
 		return nil, fmt.Errorf("invalid header: %w", err)
 	}
 	opts.Headers = headers
+	opts.Stderr = stderr
 
 	crawler := crawl.NewCrawler(opts)
 	requests, err := crawler.Crawl(ctx, targetURL)
 	if err != nil {
 		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && len(requests) > 0 {
-			fmt.Fprintf(stderr, "interrupt received, returning %d partial results\n", len(requests))
+			fmt.Fprintf(stderr, "returning %d partial results\n", len(requests))
 			return requests, nil
 		}
 		return nil, fmt.Errorf("crawl failed: %w", err)

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -76,7 +76,9 @@ func parseHeaders(raw []string) (map[string]string, error) {
 // doCrawl executes the common crawl pipeline: parse headers, create crawler,
 // run the crawl with the provided context, and return the results. On graceful
 // shutdown (SIGINT/SIGTERM) partial results are returned instead of an error.
-func doCrawl(ctx context.Context, targetURL string, rawHeaders []string, opts crawl.CrawlerOptions) ([]crawl.ObservedRequest, error) {
+// The stderr parameter controls where user-facing status messages are written,
+// allowing tests to capture output.
+func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, rawHeaders []string, opts crawl.CrawlerOptions) ([]crawl.ObservedRequest, error) {
 	headers, err := parseHeaders(rawHeaders)
 	if err != nil {
 		return nil, fmt.Errorf("invalid header: %w", err)
@@ -87,7 +89,7 @@ func doCrawl(ctx context.Context, targetURL string, rawHeaders []string, opts cr
 	requests, err := crawler.Crawl(ctx, targetURL)
 	if err != nil {
 		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && len(requests) > 0 {
-			// Graceful shutdown or timeout — return partial results.
+			fmt.Fprintf(stderr, "interrupt received, returning %d partial results\n", len(requests))
 			return requests, nil
 		}
 		return nil, fmt.Errorf("crawl failed: %w", err)
@@ -128,6 +130,19 @@ type CrawlOptions struct {
 	Verbose  bool          `short:"v" help:"Enable verbose logging"`
 }
 
+// setupForceExitHandler spawns a goroutine that listens for a second
+// SIGINT/SIGTERM and force-exits the process. The first signal is consumed
+// by signal.NotifyContext; this catches the second one.
+func setupForceExitHandler() {
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		<-sigCh
+		fmt.Fprintf(os.Stderr, "forcing immediate exit\n")
+		os.Exit(1)
+	}()
+}
+
 // CrawlCmd crawls a web application to capture HTTP traffic.
 type CrawlCmd struct {
 	URL    string `arg:"" help:"Target URL to crawl"`
@@ -157,7 +172,9 @@ func (c *CrawlCmd) Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	requests, err := doCrawl(ctx, c.URL, c.Header, opts)
+	setupForceExitHandler()
+
+	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
 	if err != nil {
 		return err
 	}
@@ -297,7 +314,9 @@ func (c *ScanCmd) Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	requests, err := doCrawl(ctx, c.URL, c.Header, opts)
+	setupForceExitHandler()
+
+	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -130,11 +130,13 @@ type CrawlOptions struct {
 	Verbose  bool          `short:"v" help:"Enable verbose logging"`
 }
 
-// setupForceExitHandler spawns a goroutine that listens for a second
-// SIGINT/SIGTERM and force-exits the process. The first signal is consumed
-// by signal.NotifyContext; this catches the second one.
-func setupForceExitHandler() {
+// setupForceExitHandler spawns a goroutine that waits for the first signal
+// to be handled (ctx.Done), then registers for a second SIGINT/SIGTERM and
+// force-exits the process. This avoids a race where both the graceful handler
+// and the force-exit handler consume the same signal simultaneously.
+func setupForceExitHandler(ctx context.Context) {
 	go func() {
+		<-ctx.Done() // First signal consumed by signal.NotifyContext
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 		<-sigCh
@@ -172,7 +174,7 @@ func (c *CrawlCmd) Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	setupForceExitHandler()
+	setupForceExitHandler(ctx)
 
 	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
 	if err != nil {
@@ -314,7 +316,7 @@ func (c *ScanCmd) Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	setupForceExitHandler()
+	setupForceExitHandler(ctx)
 
 	requests, err := doCrawl(ctx, os.Stderr, c.URL, c.Header, opts)
 	if err != nil {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -582,7 +582,7 @@ func TestVersionVariable(t *testing.T) {
 func returnPartialOnGraceful(stderr io.Writer, err error, requests []crawl.ObservedRequest) ([]crawl.ObservedRequest, error) {
 	if err != nil {
 		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && len(requests) > 0 {
-			fmt.Fprintf(stderr, "interrupt received, returning %d partial results\n", len(requests))
+			fmt.Fprintf(stderr, "returning %d partial results\n", len(requests))
 			return requests, nil
 		}
 		return nil, fmt.Errorf("crawl failed: %w", err)
@@ -617,7 +617,7 @@ func TestDoCrawl_gracefulShutdownCondition(t *testing.T) {
 			requests:    partialRequests,
 			wantResults: partialRequests,
 			wantErr:     false,
-			wantStderr:  "interrupt received, returning 1 partial results\n",
+			wantStderr:  "returning 1 partial results\n",
 		},
 		{
 			name:        "context.DeadlineExceeded with partial results — returns partial, no error",
@@ -625,7 +625,7 @@ func TestDoCrawl_gracefulShutdownCondition(t *testing.T) {
 			requests:    partialRequests,
 			wantResults: partialRequests,
 			wantErr:     false,
-			wantStderr:  "interrupt received, returning 1 partial results\n",
+			wantStderr:  "returning 1 partial results\n",
 		},
 		{
 			name:     "context.DeadlineExceeded with no results — returns error",

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -17,13 +17,15 @@ package main
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
 )
@@ -662,102 +664,55 @@ func TestOnForceExit_NilCleanup(t *testing.T) {
 	}
 }
 
-// returnPartialOnGraceful mirrors the error-handling condition in doCrawl.
-// It returns (requests, nil) if err indicates a graceful shutdown with partial
-// results, or (nil, err) otherwise.  The stderr writer receives the interrupt
-// message when partial results are returned.
-func returnPartialOnGraceful(stderr io.Writer, err error, requests []crawl.ObservedRequest) ([]crawl.ObservedRequest, error) {
-	if err != nil {
-		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && len(requests) > 0 {
-			fmt.Fprintf(stderr, "returning %d partial results\n", len(requests))
-			return requests, nil
-		}
-		return nil, fmt.Errorf("crawl failed: %w", err)
+// TestDoCrawl_GracefulShutdownReturnsPartialResults exercises the real doCrawl
+// function with a pre-canceled context against a live httptest server. The
+// crawler returns context.Canceled with partial results, and doCrawl should
+// convert that to (results, nil) with a "returning N partial results" message.
+func TestDoCrawl_GracefulShutdownReturnsPartialResults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><a href="/page2">link</a></body></html>`)
+	}))
+	defer srv.Close()
+
+	// Cancel context before calling doCrawl — triggers signal path in Crawl(),
+	// which returns (partial, context.Canceled). doCrawl should return (partial, nil).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var stderr bytes.Buffer
+	opts := crawl.CrawlerOptions{
+		Depth:    1,
+		MaxPages: 100,
+		Timeout:  30 * time.Second,
+		Headless: false,
 	}
-	return requests, nil
+
+	results, err := doCrawl(ctx, &stderr, srv.URL, nil, opts)
+	if err != nil {
+		t.Fatalf("doCrawl() returned error %v, want nil (graceful shutdown)", err)
+	}
+	// The crawler may or may not collect results before context fires.
+	// The key assertion: doCrawl did NOT return an error, proving the
+	// graceful-shutdown condition (lines 127-129 of main.go) activated.
+	if !strings.Contains(stderr.String(), "interrupt received") && !strings.Contains(stderr.String(), "returning") {
+		t.Errorf("stderr = %q, want interrupt or partial-results message", stderr.String())
+	}
+	t.Logf("doCrawl returned %d partial results", len(results))
 }
 
-// TestDoCrawl_gracefulShutdownCondition verifies that the graceful-shutdown
-// condition inside doCrawl accepts both context.Canceled (SIGINT/SIGTERM) and
-// context.DeadlineExceeded (Katana CrawlDuration timeout) when partial results
-// are present.
-//
-// The condition being tested lives in doCrawl (main.go lines 88-97).  Because
-// doCrawl creates its own Crawler internally, the condition logic is extracted
-// into returnPartialOnGraceful above so it can be exercised in isolation.
-func TestDoCrawl_gracefulShutdownCondition(t *testing.T) {
-	partialRequests := []crawl.ObservedRequest{
-		{Method: "GET", URL: "https://example.com/api/users"},
-	}
+// TestDoCrawl_InvalidHeaderReturnsError verifies doCrawl rejects invalid headers
+// before creating a crawler.
+func TestDoCrawl_InvalidHeaderReturnsError(t *testing.T) {
+	var stderr bytes.Buffer
+	opts := crawl.CrawlerOptions{Depth: 1, Headless: false}
 
-	tests := []struct {
-		name        string
-		err         error
-		requests    []crawl.ObservedRequest
-		wantResults []crawl.ObservedRequest
-		wantErr     bool
-		wantStderr  string
-	}{
-		{
-			name:        "context.Canceled with partial results — returns partial, no error",
-			err:         context.Canceled,
-			requests:    partialRequests,
-			wantResults: partialRequests,
-			wantErr:     false,
-			wantStderr:  "returning 1 partial results\n",
-		},
-		{
-			name:        "context.DeadlineExceeded with partial results — returns partial, no error",
-			err:         context.DeadlineExceeded,
-			requests:    partialRequests,
-			wantResults: partialRequests,
-			wantErr:     false,
-			wantStderr:  "returning 1 partial results\n",
-		},
-		{
-			name:     "context.DeadlineExceeded with no results — returns error",
-			err:      context.DeadlineExceeded,
-			requests: nil,
-			wantErr:  true,
-		},
-		{
-			name:     "context.Canceled with no results — returns error",
-			err:      context.Canceled,
-			requests: nil,
-			wantErr:  true,
-		},
-		{
-			name:     "other error with partial results — returns error",
-			err:      fmt.Errorf("network error"),
-			requests: partialRequests,
-			wantErr:  true,
-		},
-		{
-			name:        "nil error — returns results as-is",
-			err:         nil,
-			requests:    partialRequests,
-			wantResults: partialRequests,
-			wantErr:     false,
-		},
+	_, err := doCrawl(context.Background(), &stderr, "https://example.com", []string{"bad header"}, opts)
+	if err == nil {
+		t.Fatal("doCrawl() expected error for invalid header, got nil")
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			gotResults, gotErr := returnPartialOnGraceful(&buf, tt.err, tt.requests)
-			if (gotErr != nil) != tt.wantErr {
-				t.Errorf("returnPartialOnGraceful() error = %v, wantErr %v", gotErr, tt.wantErr)
-			}
-			if !tt.wantErr && len(gotResults) != len(tt.wantResults) {
-				t.Errorf("returnPartialOnGraceful() returned %d results, want %d",
-					len(gotResults), len(tt.wantResults))
-			}
-			if tt.wantStderr != "" && buf.String() != tt.wantStderr {
-				t.Errorf("stderr = %q, want %q", buf.String(), tt.wantStderr)
-			}
-			if tt.wantStderr == "" && buf.Len() > 0 {
-				t.Errorf("unexpected stderr output: %q", buf.String())
-			}
-		})
+	if !strings.Contains(err.Error(), "invalid header") {
+		t.Errorf("doCrawl() error = %q, want 'invalid header'", err.Error())
 	}
 }

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -664,6 +664,24 @@ func TestOnForceExit_NilCleanup(t *testing.T) {
 	}
 }
 
+// TestOnForceExit_CleanupPanicRecovery verifies that if cleanup() panics,
+// exitFn is still called (process doesn't get stuck).
+func TestOnForceExit_CleanupPanicRecovery(t *testing.T) {
+	var stderr bytes.Buffer
+	var exitCode int
+
+	cleanup := func() { panic("cleanup exploded") }
+
+	onForceExit(&stderr, cleanup, func(code int) { exitCode = code })
+
+	if exitCode != 1 {
+		t.Errorf("exitFn called with code %d, want 1", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "forcing immediate exit") {
+		t.Errorf("stderr = %q, want message containing 'forcing immediate exit'", stderr.String())
+	}
+}
+
 // TestDoCrawl_GracefulShutdownReturnsPartialResults exercises the real doCrawl
 // function with a pre-canceled context against a live httptest server. The
 // crawler returns context.Canceled with partial results, and doCrawl should
@@ -700,6 +718,39 @@ func TestDoCrawl_GracefulShutdownReturnsPartialResults(t *testing.T) {
 		t.Errorf("stderr = %q, want interrupt or partial-results message", stderr.String())
 	}
 	t.Logf("doCrawl returned %d partial results", len(results))
+}
+
+// TestDoCrawl_DeadlineExceededReturnsPartialResults exercises doCrawl with a
+// context that hits its deadline. The crawler returns context.DeadlineExceeded
+// with partial results, and doCrawl should convert that to (results, nil).
+func TestDoCrawl_DeadlineExceededReturnsPartialResults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><a href="/page2">link</a></body></html>`)
+	}))
+	defer srv.Close()
+
+	// Use a very short deadline so the crawl times out quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	// Let the deadline expire before calling doCrawl.
+	time.Sleep(5 * time.Millisecond)
+
+	var stderr bytes.Buffer
+	opts := crawl.CrawlerOptions{
+		Depth:    1,
+		MaxPages: 100,
+		Timeout:  30 * time.Second,
+		Headless: false,
+	}
+
+	results, err := doCrawl(ctx, &stderr, srv.URL, nil, opts)
+	if err != nil {
+		t.Fatalf("doCrawl() returned error %v, want nil (graceful shutdown on deadline)", err)
+	}
+	t.Logf("doCrawl returned %d partial results on DeadlineExceeded", len(results))
 }
 
 // TestDoCrawl_InvalidHeaderReturnsError verifies doCrawl rejects invalid headers

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -665,7 +665,7 @@ func TestOnForceExit_NilCleanup(t *testing.T) {
 }
 
 // TestOnForceExit_CleanupPanicRecovery verifies that if cleanup() panics,
-// exitFn is still called (process doesn't get stuck).
+// exitFn is still called and the panic value is logged.
 func TestOnForceExit_CleanupPanicRecovery(t *testing.T) {
 	var stderr bytes.Buffer
 	var exitCode int
@@ -677,8 +677,12 @@ func TestOnForceExit_CleanupPanicRecovery(t *testing.T) {
 	if exitCode != 1 {
 		t.Errorf("exitFn called with code %d, want 1", exitCode)
 	}
-	if !strings.Contains(stderr.String(), "forcing immediate exit") {
-		t.Errorf("stderr = %q, want message containing 'forcing immediate exit'", stderr.String())
+	output := stderr.String()
+	if !strings.Contains(output, "cleanup panicked: cleanup exploded") {
+		t.Errorf("stderr = %q, want message containing panic value", output)
+	}
+	if !strings.Contains(output, "forcing immediate exit") {
+		t.Errorf("stderr = %q, want message containing 'forcing immediate exit'", output)
 	}
 }
 
@@ -707,7 +711,7 @@ func TestDoCrawl_GracefulShutdownReturnsPartialResults(t *testing.T) {
 		Headless: false,
 	}
 
-	results, err := doCrawl(ctx, &stderr, srv.URL, nil, opts)
+	results, err := doCrawl(ctx, &stderr, srv.URL, opts)
 	if err != nil {
 		t.Fatalf("doCrawl() returned error %v, want nil (graceful shutdown)", err)
 	}
@@ -746,24 +750,25 @@ func TestDoCrawl_DeadlineExceededReturnsPartialResults(t *testing.T) {
 		Headless: false,
 	}
 
-	results, err := doCrawl(ctx, &stderr, srv.URL, nil, opts)
+	results, err := doCrawl(ctx, &stderr, srv.URL, opts)
 	if err != nil {
 		t.Fatalf("doCrawl() returned error %v, want nil (graceful shutdown on deadline)", err)
 	}
 	t.Logf("doCrawl returned %d partial results on DeadlineExceeded", len(results))
 }
 
-// TestDoCrawl_InvalidHeaderReturnsError verifies doCrawl rejects invalid headers
-// before creating a crawler.
-func TestDoCrawl_InvalidHeaderReturnsError(t *testing.T) {
-	var stderr bytes.Buffer
-	opts := crawl.CrawlerOptions{Depth: 1, Headless: false}
-
-	_, err := doCrawl(context.Background(), &stderr, "https://example.com", []string{"bad header"}, opts)
+// TestSetupBrowserAndSignals_InvalidHeaderReturnsError verifies that invalid
+// headers are rejected before launching Chrome.
+func TestSetupBrowserAndSignals_InvalidHeaderReturnsError(t *testing.T) {
+	_, err := setupBrowserAndSignals(
+		[]string{"bad header"},
+		CrawlOptions{Headless: false},
+		crawl.CrawlerOptions{Depth: 1},
+	)
 	if err == nil {
-		t.Fatal("doCrawl() expected error for invalid header, got nil")
+		t.Fatal("setupBrowserAndSignals() expected error for invalid header, got nil")
 	}
 	if !strings.Contains(err.Error(), "invalid header") {
-		t.Errorf("doCrawl() error = %q, want 'invalid header'", err.Error())
+		t.Errorf("setupBrowserAndSignals() error = %q, want 'invalid header'", err.Error())
 	}
 }

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -161,6 +161,10 @@ func TestParseHeaders_CRLFInjection(t *testing.T) {
 			name:  "multiple CRLF in value",
 			input: []string{"X-Custom: normal\r\n\r\ninjected"},
 		},
+		{
+			name:  "null byte in header value",
+			input: []string{"X-Custom: before\x00after"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -171,6 +171,49 @@ func TestParseHeaders_CRLFInjection(t *testing.T) {
 	}
 }
 
+// TestParseHeaders_RFC7230InvalidNames tests that header names with characters
+// outside the RFC 7230 token production are rejected.
+func TestParseHeaders_RFC7230InvalidNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+	}{
+		{
+			name:  "space in header name",
+			input: []string{"Content Type: application/json"},
+		},
+		{
+			name:  "parenthesis in header name",
+			input: []string{"Content(Type): application/json"},
+		},
+		{
+			name:  "slash in header name",
+			input: []string{"Content/Type: application/json"},
+		},
+		{
+			name:  "equals in header name",
+			input: []string{"Content=Type: application/json"},
+		},
+		{
+			name:  "at sign in header name",
+			input: []string{"Content@Type: application/json"},
+		},
+		{
+			name:  "bracket in header name",
+			input: []string{"Content[Type]: application/json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseHeaders(tt.input)
+			if err == nil {
+				t.Error("parseHeaders() expected error for invalid header name, got nil")
+			}
+		})
+	}
+}
+
 func TestParseHeaders_InvalidFormat(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -576,12 +577,12 @@ func TestVersionVariable(t *testing.T) {
 
 // returnPartialOnGraceful mirrors the error-handling condition in doCrawl.
 // It returns (requests, nil) if err indicates a graceful shutdown with partial
-// results, or (nil, err) otherwise.  This is the function under test — its
-// behaviour changes after the bug fix.
-func returnPartialOnGraceful(err error, requests []crawl.ObservedRequest) ([]crawl.ObservedRequest, error) {
+// results, or (nil, err) otherwise.  The stderr writer receives the interrupt
+// message when partial results are returned.
+func returnPartialOnGraceful(stderr io.Writer, err error, requests []crawl.ObservedRequest) ([]crawl.ObservedRequest, error) {
 	if err != nil {
 		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && len(requests) > 0 {
-			// Graceful shutdown or timeout — return partial results.
+			fmt.Fprintf(stderr, "interrupt received, returning %d partial results\n", len(requests))
 			return requests, nil
 		}
 		return nil, fmt.Errorf("crawl failed: %w", err)
@@ -594,7 +595,7 @@ func returnPartialOnGraceful(err error, requests []crawl.ObservedRequest) ([]cra
 // context.DeadlineExceeded (Katana CrawlDuration timeout) when partial results
 // are present.
 //
-// The condition being tested lives in doCrawl (main.go lines 88-94).  Because
+// The condition being tested lives in doCrawl (main.go lines 88-97).  Because
 // doCrawl creates its own Crawler internally, the condition logic is extracted
 // into returnPartialOnGraceful above so it can be exercised in isolation.
 func TestDoCrawl_gracefulShutdownCondition(t *testing.T) {
@@ -608,6 +609,7 @@ func TestDoCrawl_gracefulShutdownCondition(t *testing.T) {
 		requests    []crawl.ObservedRequest
 		wantResults []crawl.ObservedRequest
 		wantErr     bool
+		wantStderr  string
 	}{
 		{
 			name:        "context.Canceled with partial results — returns partial, no error",
@@ -615,6 +617,7 @@ func TestDoCrawl_gracefulShutdownCondition(t *testing.T) {
 			requests:    partialRequests,
 			wantResults: partialRequests,
 			wantErr:     false,
+			wantStderr:  "interrupt received, returning 1 partial results\n",
 		},
 		{
 			name:        "context.DeadlineExceeded with partial results — returns partial, no error",
@@ -622,6 +625,7 @@ func TestDoCrawl_gracefulShutdownCondition(t *testing.T) {
 			requests:    partialRequests,
 			wantResults: partialRequests,
 			wantErr:     false,
+			wantStderr:  "interrupt received, returning 1 partial results\n",
 		},
 		{
 			name:     "context.DeadlineExceeded with no results — returns error",
@@ -652,13 +656,20 @@ func TestDoCrawl_gracefulShutdownCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotResults, gotErr := returnPartialOnGraceful(tt.err, tt.requests)
+			var buf bytes.Buffer
+			gotResults, gotErr := returnPartialOnGraceful(&buf, tt.err, tt.requests)
 			if (gotErr != nil) != tt.wantErr {
 				t.Errorf("returnPartialOnGraceful() error = %v, wantErr %v", gotErr, tt.wantErr)
 			}
 			if !tt.wantErr && len(gotResults) != len(tt.wantResults) {
 				t.Errorf("returnPartialOnGraceful() returned %d results, want %d",
 					len(gotResults), len(tt.wantResults))
+			}
+			if tt.wantStderr != "" && buf.String() != tt.wantStderr {
+				t.Errorf("stderr = %q, want %q", buf.String(), tt.wantStderr)
+			}
+			if tt.wantStderr == "" && buf.Len() > 0 {
+				t.Errorf("unexpected stderr output: %q", buf.String())
 			}
 		})
 	}

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -575,6 +575,50 @@ func TestVersionVariable(t *testing.T) {
 	t.Logf("version = %q", version)
 }
 
+// TestOnForceExit_WritesMessageAndExits verifies that the force-exit logic
+// writes the expected message to stderr and calls exitFn with code 1.
+func TestOnForceExit_WritesMessageAndExits(t *testing.T) {
+	var stderr bytes.Buffer
+	var exitCode int
+
+	onForceExit(&stderr, nil, func(code int) { exitCode = code })
+
+	if exitCode != 1 {
+		t.Errorf("exitFn called with code %d, want 1", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "forcing immediate exit") {
+		t.Errorf("stderr = %q, want message containing 'forcing immediate exit'", stderr.String())
+	}
+}
+
+// TestOnForceExit_CallsCleanupBeforeExit verifies that the cleanup function
+// is called before the exit message and exitFn.
+func TestOnForceExit_CallsCleanupBeforeExit(t *testing.T) {
+	var stderr bytes.Buffer
+	var order []string
+
+	cleanup := func() { order = append(order, "cleanup") }
+	exitFn := func(code int) { order = append(order, "exit") }
+
+	onForceExit(&stderr, cleanup, exitFn)
+
+	if len(order) != 2 || order[0] != "cleanup" || order[1] != "exit" {
+		t.Errorf("call order = %v, want [cleanup exit]", order)
+	}
+}
+
+// TestOnForceExit_NilCleanup verifies that nil cleanup does not panic.
+func TestOnForceExit_NilCleanup(t *testing.T) {
+	var stderr bytes.Buffer
+	called := false
+
+	onForceExit(&stderr, nil, func(code int) { called = true })
+
+	if !called {
+		t.Error("exitFn was not called")
+	}
+}
+
 // returnPartialOnGraceful mirrors the error-handling condition in doCrawl.
 // It returns (requests, nil) if err indicates a graceful shutdown with partial
 // results, or (nil, err) otherwise.  The stderr writer receives the interrupt

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.13
 require (
 	github.com/alecthomas/kong v1.14.0
 	github.com/getkin/kin-openapi v0.133.0
+	github.com/go-rod/rod v0.116.2
 	github.com/projectdiscovery/goflags v0.1.74
 	github.com/projectdiscovery/katana v1.4.0
 	github.com/stretchr/testify v1.11.1
@@ -40,7 +41,6 @@ require (
 	github.com/gaissmai/bart v0.26.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-rod/rod v0.116.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -64,6 +64,9 @@ func NewBrowserManager(opts BrowserOptions) (*BrowserManager, error) {
 // WSURL returns the Chrome DevTools Protocol WebSocket URL. Pass this to
 // Katana's ChromeWSUrl option so it connects to our browser instead of
 // launching its own.
+//
+// Security: this URL grants full control of the browser session. Do not
+// log it or expose it to untrusted callers.
 func (b *BrowserManager) WSURL() string {
 	return b.wsURL
 }

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -22,9 +22,18 @@ import (
 
 // BrowserOptions configures Chrome launch parameters.
 type BrowserOptions struct {
-	Headless   bool
-	NoSandbox  bool
-	ChromePath string // optional: path to system Chrome binary
+	Headless bool
+
+	// NoSandbox disables Chrome's OS-level sandbox. This removes a primary
+	// exploit mitigation barrier and should only be set in containerized or
+	// CI environments where the sandbox cannot be enabled (e.g., Docker
+	// without --cap-add SYS_ADMIN).
+	NoSandbox bool
+
+	// ChromePath overrides the Chrome binary used by the launcher. This value
+	// is passed directly to exec.Command — it must be a trusted, hardcoded
+	// path. Never populate from user-controlled input.
+	ChromePath string
 }
 
 // BrowserManager owns the Chrome process lifecycle. It launches Chrome via

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -41,7 +41,7 @@ type BrowserOptions struct {
 // immediately on signal, stopping all outbound requests.
 type BrowserManager struct {
 	launcher    *launcher.Launcher
-	wsURL       string
+	wsEndpoint  string
 	killOnce    sync.Once
 	cleanupOnce sync.Once
 }
@@ -65,19 +65,19 @@ func NewBrowserManager(opts BrowserOptions) (*BrowserManager, error) {
 	}
 
 	return &BrowserManager{
-		launcher: l,
-		wsURL:    wsURL,
+		launcher:   l,
+		wsEndpoint: wsURL,
 	}, nil
 }
 
-// WSURL returns the Chrome DevTools Protocol WebSocket URL. Pass this to
+// wsURL returns the Chrome DevTools Protocol WebSocket URL. Pass this to
 // Katana's ChromeWSUrl option so it connects to our browser instead of
 // launching its own.
 //
 // Security: this URL grants full control of the browser session. Do not
 // log it or expose it to untrusted callers.
-func (b *BrowserManager) WSURL() string {
-	return b.wsURL
+func (b *BrowserManager) wsURL() string {
+	return b.wsEndpoint
 }
 
 // Kill immediately terminates the Chrome process. This stops all outbound

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"sync"
+
+	"github.com/go-rod/rod/lib/launcher"
+)
+
+// BrowserOptions configures Chrome launch parameters.
+type BrowserOptions struct {
+	Headless   bool
+	NoSandbox  bool
+	ChromePath string // optional: path to system Chrome binary
+}
+
+// BrowserManager owns the Chrome process lifecycle. It launches Chrome via
+// go-rod's launcher and retains the handle so vespasian can kill the browser
+// immediately on signal, stopping all outbound requests.
+type BrowserManager struct {
+	launcher *launcher.Launcher
+	wsURL    string
+	killOnce sync.Once
+}
+
+// NewBrowserManager launches a Chrome instance with the given options and
+// returns a manager that owns its lifecycle.
+func NewBrowserManager(opts BrowserOptions) (*BrowserManager, error) {
+	l := launcher.New().
+		Headless(opts.Headless)
+
+	if opts.NoSandbox {
+		l = l.NoSandbox(true)
+	}
+	if opts.ChromePath != "" {
+		l = l.Bin(opts.ChromePath)
+	}
+
+	wsURL, err := l.Launch()
+	if err != nil {
+		return nil, err
+	}
+
+	return &BrowserManager{
+		launcher: l,
+		wsURL:    wsURL,
+	}, nil
+}
+
+// WSURL returns the Chrome DevTools Protocol WebSocket URL. Pass this to
+// Katana's ChromeWSUrl option so it connects to our browser instead of
+// launching its own.
+func (b *BrowserManager) WSURL() string {
+	return b.wsURL
+}
+
+// Kill immediately terminates the Chrome process. This stops all outbound
+// network requests. Safe to call multiple times.
+func (b *BrowserManager) Kill() {
+	b.killOnce.Do(func() {
+		b.launcher.Kill()
+	})
+}
+
+// Cleanup waits for Chrome to exit and removes the temporary user data
+// directory. Call this after Kill to ensure full cleanup.
+func (b *BrowserManager) Cleanup() {
+	b.launcher.Cleanup()
+}
+
+// Close kills Chrome (if still running) and cleans up resources. Intended
+// for use with defer in the normal (non-signal) path.
+func (b *BrowserManager) Close() {
+	b.Kill()
+	b.Cleanup()
+}
+
+// PID returns the Chrome process ID, useful for testing.
+func (b *BrowserManager) PID() int {
+	return b.launcher.PID()
+}

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -31,9 +31,10 @@ type BrowserOptions struct {
 // go-rod's launcher and retains the handle so vespasian can kill the browser
 // immediately on signal, stopping all outbound requests.
 type BrowserManager struct {
-	launcher *launcher.Launcher
-	wsURL    string
-	killOnce sync.Once
+	launcher    *launcher.Launcher
+	wsURL       string
+	killOnce    sync.Once
+	cleanupOnce sync.Once
 }
 
 // NewBrowserManager launches a Chrome instance with the given options and
@@ -75,17 +76,19 @@ func (b *BrowserManager) Kill() {
 	})
 }
 
-// Cleanup waits for Chrome to exit and removes the temporary user data
-// directory. Call this after Kill to ensure full cleanup.
-func (b *BrowserManager) Cleanup() {
-	b.launcher.Cleanup()
+// cleanup waits for Chrome to exit and removes the temporary user data
+// directory. Safe to call multiple times.
+func (b *BrowserManager) cleanup() {
+	b.cleanupOnce.Do(func() {
+		b.launcher.Cleanup()
+	})
 }
 
 // Close kills Chrome (if still running) and cleans up resources. Intended
 // for use with defer in the normal (non-signal) path.
 func (b *BrowserManager) Close() {
 	b.Kill()
-	b.Cleanup()
+	b.cleanup()
 }
 
 // PID returns the Chrome process ID, useful for testing.

--- a/pkg/crawl/browser_test.go
+++ b/pkg/crawl/browser_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package crawl
+
+import (
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// processAlive checks if a process with the given PID is running.
+// Uses POSIX signal 0 which checks for process existence without
+// actually sending a signal.
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+// TestBrowserManager_LaunchAndKill verifies that NewBrowserManager launches
+// Chrome successfully, returns a valid WS URL, and Kill terminates the process.
+func TestBrowserManager_LaunchAndKill(t *testing.T) {
+	mgr, err := NewBrowserManager(BrowserOptions{Headless: true})
+	if err != nil {
+		t.Fatalf("NewBrowserManager() error = %v", err)
+	}
+
+	// Verify WS URL looks valid
+	wsURL := mgr.WSURL()
+	if wsURL == "" {
+		t.Fatal("WSURL() returned empty string")
+	}
+	if !strings.HasPrefix(wsURL, "ws://") {
+		t.Errorf("WSURL() = %q, want ws:// prefix", wsURL)
+	}
+
+	// Verify Chrome is running
+	pid := mgr.PID()
+	if pid == 0 {
+		t.Fatal("PID() returned 0, expected running Chrome process")
+	}
+
+	if !processAlive(pid) {
+		t.Errorf("Chrome process %d not running before Kill", pid)
+	}
+
+	// Kill and verify Chrome is dead
+	mgr.Kill()
+
+	// Give the OS a moment to reap the process
+	time.Sleep(500 * time.Millisecond)
+
+	if processAlive(pid) {
+		t.Errorf("Chrome process %d still running after Kill", pid)
+	}
+
+	// Cleanup temp dir
+	mgr.Cleanup()
+}
+
+// TestBrowserManager_KillIdempotent verifies that calling Kill multiple times
+// does not panic or error.
+func TestBrowserManager_KillIdempotent(t *testing.T) {
+	mgr, err := NewBrowserManager(BrowserOptions{Headless: true})
+	if err != nil {
+		t.Fatalf("NewBrowserManager() error = %v", err)
+	}
+	defer mgr.Close()
+
+	// Kill twice — should not panic
+	mgr.Kill()
+	mgr.Kill()
+}
+
+// TestBrowserManager_Close verifies that Close kills Chrome and cleans up
+// the temporary user data directory.
+func TestBrowserManager_Close(t *testing.T) {
+	mgr, err := NewBrowserManager(BrowserOptions{Headless: true})
+	if err != nil {
+		t.Fatalf("NewBrowserManager() error = %v", err)
+	}
+
+	pid := mgr.PID()
+	if pid == 0 {
+		t.Fatal("PID() returned 0")
+	}
+
+	mgr.Close()
+
+	// Give the OS a moment to reap the process
+	time.Sleep(500 * time.Millisecond)
+
+	if processAlive(pid) {
+		t.Errorf("Chrome process %d still running after Close", pid)
+	}
+}
+
+// TestBrowserManager_CloseIdempotent verifies that calling Close multiple
+// times does not panic.
+func TestBrowserManager_CloseIdempotent(t *testing.T) {
+	mgr, err := NewBrowserManager(BrowserOptions{Headless: true})
+	if err != nil {
+		t.Fatalf("NewBrowserManager() error = %v", err)
+	}
+
+	mgr.Close()
+	// Second close should not panic — Kill is protected by sync.Once
+	// and Cleanup waits on an already-closed channel.
+	mgr.Close()
+}

--- a/pkg/crawl/browser_test.go
+++ b/pkg/crawl/browser_test.go
@@ -45,12 +45,12 @@ func TestBrowserManager_LaunchAndKill(t *testing.T) {
 	}
 
 	// Verify WS URL looks valid
-	wsURL := mgr.WSURL()
+	wsURL := mgr.wsURL()
 	if wsURL == "" {
-		t.Fatal("WSURL() returned empty string")
+		t.Fatal("wsURL() returned empty string")
 	}
 	if !strings.HasPrefix(wsURL, "ws://") {
-		t.Errorf("WSURL() = %q, want ws:// prefix", wsURL)
+		t.Errorf("wsURL() = %q, want ws:// prefix", wsURL)
 	}
 
 	// Verify Chrome is running

--- a/pkg/crawl/browser_test.go
+++ b/pkg/crawl/browser_test.go
@@ -74,7 +74,7 @@ func TestBrowserManager_LaunchAndKill(t *testing.T) {
 	}
 
 	// Cleanup temp dir
-	mgr.Cleanup()
+	mgr.cleanup()
 }
 
 // TestBrowserManager_KillIdempotent verifies that calling Kill multiple times
@@ -123,7 +123,7 @@ func TestBrowserManager_CloseIdempotent(t *testing.T) {
 	}
 
 	mgr.Close()
-	// Second close should not panic — Kill is protected by sync.Once
-	// and Cleanup waits on an already-closed channel.
+	// Second close should not panic — both Kill and cleanup are
+	// protected by sync.Once.
 	mgr.Close()
 }

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -46,13 +46,14 @@ const (
 
 // CrawlerOptions configures the crawler behavior.
 type CrawlerOptions struct {
-	Depth    int
-	MaxPages int
-	Timeout  time.Duration
-	Scope    string
-	Headless bool
-	Headers  map[string]string
-	Stderr   io.Writer // user-facing status messages; nil disables output
+	Depth      int
+	MaxPages   int
+	Timeout    time.Duration
+	Scope      string
+	Headless   bool
+	Headers    map[string]string
+	Stderr     io.Writer       // user-facing status messages; nil disables output
+	BrowserMgr *BrowserManager // if set, Crawl() uses this browser; caller owns lifecycle
 }
 
 // Crawler performs web crawling to capture HTTP traffic.
@@ -77,15 +78,18 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	}
 
 	u, err := url.Parse(targetURL)
-	if err != nil || targetURL == "" || (u.Scheme != "http" && u.Scheme != "https") {
+	if err != nil || targetURL == "" || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
 		return nil, fmt.Errorf("invalid target URL: %q", targetURL)
 	}
 
-	// Launch Chrome under vespasian's control when in headless mode.
+	// Use caller-provided browser or launch Chrome under vespasian's control.
 	// This lets us kill the browser immediately on signal, stopping all
 	// outbound requests — Katana's internal context is disconnected from ours.
 	var browserMgr *BrowserManager
-	if c.opts.Headless {
+	if c.opts.BrowserMgr != nil {
+		browserMgr = c.opts.BrowserMgr
+		// Caller owns lifecycle — don't defer Close here.
+	} else if c.opts.Headless {
 		browserMgr, err = NewBrowserManager(BrowserOptions{Headless: true})
 		if err != nil {
 			return nil, fmt.Errorf("launch browser: %w", err)
@@ -111,7 +115,11 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		Headless:          c.opts.Headless,
 		CustomHeaders:     ToStringSlice(c.opts.Headers),
 		Strategy:          "depth-first",
-		BodyReadSize:      10 * 1024 * 1024, // 10 MB limit to prevent memory exhaustion from hostile targets
+		// BodyReadSize (10 MB) is intentionally larger than MaxResponseBodySize (1 MB).
+		// Katana needs the full body for link extraction and JS parsing to maximize
+		// crawl coverage; we only retain MaxResponseBodySize for classification.
+		// Peak memory: up to Concurrency × BodyReadSize (100 MB with 10 workers).
+		BodyReadSize: 10 * 1024 * 1024,
 		Concurrency:       10,
 		Parallelism:       10,
 		RateLimit:         150,
@@ -177,7 +185,11 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	select {
 	case err := <-crawlErr:
 		if err != nil {
-			return results, err
+			mu.Lock()
+			snapshot := make([]ObservedRequest, len(results))
+			copy(snapshot, results)
+			mu.Unlock()
+			return snapshot, err
 		}
 	case <-crawlCtx.Done():
 		// crawlCtx fires for both MaxPages (crawlCancel in OnResult) and
@@ -198,20 +210,35 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			// Chrome is dead — no network activity — we're just collecting
 			// already-buffered results.
 			timer := time.NewTimer(ShutdownGracePeriod)
-			defer timer.Stop()
+			var timerExpired bool
 			select {
 			case <-crawlErr:
 				// Crawl goroutine exited cleanly.
 			case <-timer.C:
-				// Goroutine still running — Chrome is dead so no network activity.
-				// engine.Close() below will cause engine.Crawl() to return shortly,
-				// at which point the goroutine exits. In a long-lived process calling
-				// Crawl() repeatedly after interrupts, callers should be aware of
-				// this brief overlap.
+				timerExpired = true
 			}
+			timer.Stop()
 
 			closeEngine()
-			return results, ctx.Err()
+
+			if timerExpired {
+				// engine.Close() causes engine.Crawl() to return shortly.
+				// Wait briefly to prevent goroutine leak.
+				drainTimer := time.NewTimer(500 * time.Millisecond)
+				select {
+				case <-crawlErr:
+				case <-drainTimer.C:
+				}
+				drainTimer.Stop()
+			}
+
+			// Snapshot results under lock — Katana's internal goroutines
+			// may still be calling OnResult during shutdown.
+			mu.Lock()
+			snapshot := make([]ObservedRequest, len(results))
+			copy(snapshot, results)
+			mu.Unlock()
+			return snapshot, ctx.Err()
 		}
 
 		// MaxPages reached — close engine and drain goroutine.
@@ -219,7 +246,11 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		<-crawlErr
 	}
 
-	return results, nil
+	mu.Lock()
+	snapshot := make([]ObservedRequest, len(results))
+	copy(snapshot, results)
+	mu.Unlock()
+	return snapshot, nil
 }
 
 // MapResult converts Katana output.Result to ObservedRequest.

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -184,7 +184,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			// Signal received (SIGINT/SIGTERM or programmatic cancel).
 			// Notify the user immediately before any cleanup.
 			if c.opts.Stderr != nil {
-				fmt.Fprintf(c.opts.Stderr, "interrupt received, stopping crawl...\n")
+				fmt.Fprintf(c.opts.Stderr, "\ninterrupt received, stopping crawl...\n")
 			}
 
 			// Kill Chrome immediately to stop all outbound requests.

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -52,8 +52,15 @@ type CrawlerOptions struct {
 	Scope      string
 	Headless   bool
 	Headers    map[string]string
-	Stderr     io.Writer       // user-facing status messages; nil disables output
-	BrowserMgr *BrowserManager // if set, Crawl() uses this browser; caller owns lifecycle
+	Stderr io.Writer // user-facing status messages; nil disables output
+
+	// BrowserMgr provides a caller-owned Chrome instance. When set, Crawl()
+	// connects to this browser instead of launching its own. Callers who want
+	// immediate signal-based browser termination (force-exit killing Chrome on
+	// second SIGINT) MUST provide their own BrowserManager and wire it into
+	// their signal handler. The internal fallback (BrowserMgr == nil) launches
+	// a browser that lacks force-exit integration.
+	BrowserMgr *BrowserManager
 }
 
 // Crawler performs web crawling to capture HTTP traffic.

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -163,7 +163,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	// When vespasian owns the browser, pass the WS URL to Katana so it
 	// connects to our Chrome instance instead of launching its own.
 	if browserMgr != nil {
-		katanaOpts.ChromeWSUrl = browserMgr.WSURL()
+		katanaOpts.ChromeWSUrl = browserMgr.wsURL()
 	}
 
 	// Initialize crawler options

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -135,6 +135,10 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		XhrExtraction:     true,
 		Silent:            true,
 		OnResult: func(result output.Result) {
+			// Map result outside the lock — MapResult may do URL parsing
+			// and body truncation, which is wasted work under contention.
+			mapped := MapResult(result)
+
 			mu.Lock()
 			defer mu.Unlock()
 
@@ -144,7 +148,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			}
 			pageCount++
 
-			results = append(results, MapResult(result))
+			results = append(results, mapped)
 			// Stop Katana once MaxPages is reached to avoid wasting resources.
 			if pageCount >= maxPages {
 				crawlCancel()

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -17,6 +17,7 @@ package crawl
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"sync"
 	"time"
@@ -51,6 +52,7 @@ type CrawlerOptions struct {
 	Scope    string
 	Headless bool
 	Headers  map[string]string
+	Stderr   io.Writer // user-facing status messages; nil disables output
 }
 
 // Crawler performs web crawling to capture HTTP traffic.
@@ -180,6 +182,11 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		// signal (parent ctx canceled). Check which case we're in.
 		if ctx.Err() != nil {
 			// Signal received (SIGINT/SIGTERM or programmatic cancel).
+			// Notify the user immediately before any cleanup.
+			if c.opts.Stderr != nil {
+				fmt.Fprintf(c.opts.Stderr, "interrupt received, stopping crawl...\n")
+			}
+
 			// Kill Chrome immediately to stop all outbound requests.
 			if browserMgr != nil {
 				browserMgr.Kill()

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -17,6 +17,7 @@ package crawl
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"sync"
 	"time"
@@ -78,6 +79,18 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	u, err := url.Parse(targetURL)
 	if err != nil || targetURL == "" || (u.Scheme != "http" && u.Scheme != "https") {
 		return nil, fmt.Errorf("invalid target URL: %q", targetURL)
+	}
+
+	// Launch Chrome under vespasian's control when in headless mode.
+	// This lets us kill the browser immediately on signal, stopping all
+	// outbound requests — Katana's internal context is disconnected from ours.
+	var browserMgr *BrowserManager
+	if c.opts.Headless {
+		browserMgr, err = NewBrowserManager(BrowserOptions{Headless: true})
+		if err != nil {
+			return nil, fmt.Errorf("launch browser: %w", err)
+		}
+		defer browserMgr.Close()
 	}
 
 	// Create a cancellable context to stop Katana when MaxPages is reached.
@@ -167,14 +180,8 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			return results, err
 		}
 	case <-crawlCtx.Done():
-		// Context canceled (MaxPages reached or SIGINT/SIGTERM).
-		// Close the engine to unblock the goroutine, then drain it
-		// to avoid a goroutine leak.
-		closeEngine()
-		<-crawlErr
-
-		// If the parent context was canceled (SIGINT/SIGTERM), propagate that error
-		// so the caller can decide whether to save partial results.
+		// crawlCtx fires for both MaxPages (crawlCancel in OnResult) and
+		// signal (parent ctx canceled). Check which case we're in.
 		if ctx.Err() != nil {
 			// Signal received (SIGINT/SIGTERM or programmatic cancel).
 			// Notify the user immediately before any cleanup.
@@ -203,12 +210,12 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 				// this brief overlap.
 			}
 
-			_ = engine.Close()
+			closeEngine()
 			return results, ctx.Err()
 		}
 
 		// MaxPages reached — close engine and drain goroutine.
-		_ = engine.Close()
+		closeEngine()
 		<-crawlErr
 	}
 

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -42,17 +42,21 @@ const (
 	// internal result buffer to drain. Chrome is dead at this point — no network
 	// activity — we're just collecting already-buffered results.
 	ShutdownGracePeriod = 2 * time.Second
+	// DrainTimeout is the secondary bounded wait after engine.Close() for the
+	// crawl goroutine to exit. Prevents goroutine leaks when the engine is slow
+	// to shut down.
+	DrainTimeout = 500 * time.Millisecond
 )
 
 // CrawlerOptions configures the crawler behavior.
 type CrawlerOptions struct {
-	Depth      int
-	MaxPages   int
-	Timeout    time.Duration
-	Scope      string
-	Headless   bool
-	Headers    map[string]string
-	Stderr io.Writer // user-facing status messages; nil disables output
+	Depth    int
+	MaxPages int
+	Timeout  time.Duration
+	Scope    string
+	Headless bool
+	Headers  map[string]string
+	Stderr   io.Writer // user-facing status messages; nil disables output
 
 	// BrowserMgr provides a caller-owned Chrome instance. When set, Crawl()
 	// connects to this browser instead of launching its own. Callers who want
@@ -115,18 +119,18 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 
 	// Build Katana options
 	katanaOpts := &types.Options{
-		MaxDepth:          c.opts.Depth,
-		Timeout:           PageTimeout,
-		CrawlDuration:     c.opts.Timeout,
-		FieldScope:        MapScope(c.opts.Scope),
-		Headless:          c.opts.Headless,
-		CustomHeaders:     ToStringSlice(c.opts.Headers),
-		Strategy:          "depth-first",
+		MaxDepth:      c.opts.Depth,
+		Timeout:       PageTimeout,
+		CrawlDuration: c.opts.Timeout,
+		FieldScope:    MapScope(c.opts.Scope),
+		Headless:      c.opts.Headless,
+		CustomHeaders: ToStringSlice(c.opts.Headers),
+		Strategy:      "depth-first",
 		// BodyReadSize (10 MB) is intentionally larger than MaxResponseBodySize (1 MB).
 		// Katana needs the full body for link extraction and JS parsing to maximize
 		// crawl coverage; we only retain MaxResponseBodySize for classification.
 		// Peak memory: up to Concurrency × BodyReadSize (100 MB with 10 workers).
-		BodyReadSize: 10 * 1024 * 1024,
+		BodyReadSize:      10 * 1024 * 1024,
 		Concurrency:       10,
 		Parallelism:       10,
 		RateLimit:         150,
@@ -235,7 +239,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			if timerExpired {
 				// engine.Close() causes engine.Crawl() to return shortly.
 				// Wait briefly to prevent goroutine leak.
-				drainTimer := time.NewTimer(500 * time.Millisecond)
+				drainTimer := time.NewTimer(DrainTimeout)
 				select {
 				case <-crawlErr:
 				case <-drainTimer.C:
@@ -252,9 +256,15 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			return snapshot, ctx.Err()
 		}
 
-		// MaxPages reached — close engine and drain goroutine.
+		// MaxPages reached — close engine and drain goroutine with a bounded wait
+		// to match the signal path's timeout discipline.
 		closeEngine()
-		<-crawlErr
+		drainTimer := time.NewTimer(ShutdownGracePeriod)
+		select {
+		case <-crawlErr:
+		case <-drainTimer.C:
+		}
+		drainTimer.Stop()
 	}
 
 	mu.Lock()

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -16,6 +16,7 @@ package crawl
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sync"
 	"time"
@@ -36,6 +37,10 @@ const (
 	// This is an internal constant, not user-configurable — it prevents a single
 	// unresponsive page from blocking the sequential headless crawl.
 	PageTimeout = 30
+	// ShutdownGracePeriod is the bounded wait after killing Chrome for Katana's
+	// internal result buffer to drain. Chrome is dead at this point — no network
+	// activity — we're just collecting already-buffered results.
+	ShutdownGracePeriod = 2 * time.Second
 )
 
 // CrawlerOptions configures the crawler behavior.
@@ -63,6 +68,27 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	maxPages := c.opts.MaxPages
 	if maxPages <= 0 {
 		maxPages = DefaultMaxPages
+	}
+
+	if c.opts.Depth < 0 {
+		return nil, fmt.Errorf("depth must be non-negative, got %d", c.opts.Depth)
+	}
+
+	u, err := url.Parse(targetURL)
+	if err != nil || targetURL == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return nil, fmt.Errorf("invalid target URL: %q", targetURL)
+	}
+
+	// Launch Chrome under vespasian's control when in headless mode.
+	// This lets us kill the browser immediately on signal, stopping all
+	// outbound requests — Katana's internal context is disconnected from ours.
+	var browserMgr *BrowserManager
+	if c.opts.Headless {
+		browserMgr, err = NewBrowserManager(BrowserOptions{Headless: true})
+		if err != nil {
+			return nil, fmt.Errorf("launch browser: %w", err)
+		}
+		defer browserMgr.Close()
 	}
 
 	// Create a cancellable context to stop Katana when MaxPages is reached.
@@ -109,6 +135,12 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		},
 	}
 
+	// When vespasian owns the browser, pass the WS URL to Katana so it
+	// connects to our Chrome instance instead of launching its own.
+	if browserMgr != nil {
+		katanaOpts.ChromeWSUrl = browserMgr.WSURL()
+	}
+
 	// Initialize crawler options
 	crawlerOpts, err := types.NewCrawlerOptions(katanaOpts)
 	if err != nil {
@@ -144,18 +176,34 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			return results, err
 		}
 	case <-crawlCtx.Done():
-		// Context canceled (MaxPages reached or SIGINT/SIGTERM).
-		// Close the engine to unblock the goroutine, then drain it
-		// to avoid a goroutine leak.
-		_ = engine.Close()
-		<-crawlErr
-
-		// If the parent context was canceled (SIGINT/SIGTERM), propagate that error
-		// so the caller can decide whether to save partial results.
+		// crawlCtx fires for both MaxPages (crawlCancel in OnResult) and
+		// signal (parent ctx canceled). Check which case we're in.
 		if ctx.Err() != nil {
+			// Signal received (SIGINT/SIGTERM or programmatic cancel).
+			// Kill Chrome immediately to stop all outbound requests.
+			if browserMgr != nil {
+				browserMgr.Kill()
+			}
+
+			// Bounded wait: drain Katana's internal result buffer.
+			// Chrome is dead — no network activity — we're just collecting
+			// already-buffered results.
+			timer := time.NewTimer(ShutdownGracePeriod)
+			defer timer.Stop()
+			select {
+			case <-crawlErr:
+				// Crawl goroutine exited cleanly.
+			case <-timer.C:
+				// Goroutine leaked but Chrome is dead — no network activity.
+			}
+
+			_ = engine.Close()
 			return results, ctx.Err()
 		}
-		// MaxPages reached — not an error.
+
+		// MaxPages reached — close engine and drain goroutine.
+		_ = engine.Close()
+		<-crawlErr
 	}
 
 	return results, nil

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -201,7 +201,11 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			case <-crawlErr:
 				// Crawl goroutine exited cleanly.
 			case <-timer.C:
-				// Goroutine leaked but Chrome is dead — no network activity.
+				// Goroutine still running — Chrome is dead so no network activity.
+				// engine.Close() below will cause engine.Crawl() to return shortly,
+				// at which point the goroutine exits. In a long-lived process calling
+				// Crawl() repeatedly after interrupts, callers should be aware of
+				// this brief overlap.
 			}
 
 			_ = engine.Close()

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -375,6 +375,7 @@ func TestCrawl_InvalidSchemeReturnsError(t *testing.T) {
 		{"schemeless", "not-a-url"},
 		{"file scheme", "file:///etc/passwd"},
 		{"ftp scheme", "ftp://example.com"},
+		{"empty host", "http:///path"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -391,45 +391,6 @@ func TestCrawl_InvalidSchemeReturnsError(t *testing.T) {
 	}
 }
 
-// TestCloseEngineOnce verifies the sync.Once wrapper prevents double-close.
-// This mirrors the closeEngine pattern in Crawl (crawler.go lines 143-145)
-// where engine.Close() can be called both explicitly on context cancellation
-// and via defer.
-func TestCloseEngineOnce(t *testing.T) {
-	var count int
-	var once sync.Once
-	closeEngine := func() { once.Do(func() { count++ }) }
-
-	closeEngine()
-	closeEngine()
-
-	if count != 1 {
-		t.Errorf("close called %d times, want 1", count)
-	}
-}
-
-// TestDefaultMaxPages verifies the DefaultMaxPages constant value
-func TestDefaultMaxPages(t *testing.T) {
-	if DefaultMaxPages != 1000 {
-		t.Errorf("DefaultMaxPages = %d, want 1000", DefaultMaxPages)
-	}
-}
-
-// TestMaxResponseBodySize verifies the MaxResponseBodySize constant value
-func TestMaxResponseBodySize(t *testing.T) {
-	expected := 1 * 1024 * 1024 // 1 MB
-	if MaxResponseBodySize != expected {
-		t.Errorf("MaxResponseBodySize = %d, want %d", MaxResponseBodySize, expected)
-	}
-}
-
-
-// TestPageTimeout verifies the PageTimeout constant value
-func TestPageTimeout(t *testing.T) {
-	if PageTimeout != 30 {
-		t.Errorf("PageTimeout = %d, want 30", PageTimeout)
-	}
-}
 // TestMapResult_TruncatesLargeResponseBody tests that response bodies exceeding MaxResponseBodySize get truncated
 func TestMapResult_TruncatesLargeResponseBody(t *testing.T) {
 	largeBody := make([]byte, MaxResponseBodySize+1000) // 1000 bytes over limit

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -15,10 +15,16 @@
 package crawl
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/projectdiscovery/katana/pkg/navigation"
 	"github.com/projectdiscovery/katana/pkg/output"
@@ -511,5 +517,103 @@ func TestMapResult_SmallBodyNotTruncated(t *testing.T) {
 
 	if string(observed.Response.Body) != string(smallResponseBody) {
 		t.Errorf("Response body = %q, want %q (should not be truncated)", string(observed.Response.Body), string(smallResponseBody))
+	}
+}
+
+// TestCrawl_SignalPath_ReturnsContextCanceled verifies that when the parent
+// context is canceled (simulating SIGINT/SIGTERM), Crawl() returns
+// context.Canceled and writes an interrupt message to Stderr.
+func TestCrawl_SignalPath_ReturnsContextCanceled(t *testing.T) {
+	// Slow server to ensure the crawl is still running when we cancel.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><a href="/page2">link</a></body></html>`)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var stderr bytes.Buffer
+
+	crawler := NewCrawler(CrawlerOptions{
+		Depth:    1,
+		MaxPages: 100,
+		Timeout:  30 * time.Second,
+		Headless: false,
+		Stderr:   &stderr,
+	})
+
+	// Cancel context immediately to trigger signal path.
+	cancel()
+
+	_, err := crawler.Crawl(ctx, srv.URL)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Crawl() error = %v, want context.Canceled", err)
+	}
+	if !strings.Contains(stderr.String(), "interrupt received") {
+		t.Errorf("stderr = %q, want message containing 'interrupt received'", stderr.String())
+	}
+}
+
+// TestCrawl_SignalPath_NilStderr verifies that Crawl() does not panic
+// when Stderr is nil on the signal path.
+func TestCrawl_SignalPath_NilStderr(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body>hello</body></html>`)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	crawler := NewCrawler(CrawlerOptions{
+		Depth:    1,
+		MaxPages: 100,
+		Timeout:  30 * time.Second,
+		Headless: false,
+		Stderr:   nil, // explicitly nil
+	})
+
+	_, err := crawler.Crawl(ctx, srv.URL)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Crawl() error = %v, want context.Canceled", err)
+	}
+}
+
+// TestCrawl_MaxPagesPath_ReturnsNoError verifies that when MaxPages is reached,
+// Crawl() returns results without an error.
+func TestCrawl_MaxPagesPath_ReturnsNoError(t *testing.T) {
+	// Server that returns pages with links, generating enough results to hit MaxPages.
+	var requestCount int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestCount++
+		n := requestCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/html")
+		// Each page links to the next, up to a high number.
+		fmt.Fprintf(w, `<html><body><a href="/page%d">next</a></body></html>`, n+1)
+	}))
+	defer srv.Close()
+
+	crawler := NewCrawler(CrawlerOptions{
+		Depth:    10,
+		MaxPages: 2,
+		Timeout:  30 * time.Second,
+		Headless: false,
+	})
+
+	results, err := crawler.Crawl(context.Background(), srv.URL)
+	if err != nil {
+		t.Errorf("Crawl() unexpected error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("Crawl() returned 0 results, want at least 1")
+	}
+	if len(results) > 2 {
+		t.Errorf("Crawl() returned %d results, want at most 2 (MaxPages)", len(results))
 	}
 }


### PR DESCRIPTION
## Summary

- **Vespasian now owns the Chrome process** via `go-rod/rod/lib/launcher`, passing the WebSocket URL to Katana's `ChromeWSUrl` option. Katana connects to our browser instead of launching its own.
- **Single `^C` (SIGINT/SIGTERM)**: kills Chrome immediately (stops all outbound requests), drains Katana's internal result buffer for 2s, returns partial results with stderr message: `"interrupt received, returning N partial results"`.
- **Double `^C`**: force-exits via `os.Exit(1)` with stderr message: `"forcing immediate exit"`.
- **Programmatic callers** (agentic workflows): canceling `context.Context` triggers the same graceful shutdown — no terminal-specific semantics leak into the library.

### Why this matters

Previously, `^C` was effectively ignored. Katana's internal context (`context.Background()`) was disconnected from vespasian's signal context, so Chrome kept crawling for up to `CrawlDuration` (default 10min) after the operator requested a stop — a safety issue for a security tool.

### Files changed

| File | Change |
|------|--------|
| `pkg/crawl/browser.go` | New `BrowserManager` type: launches Chrome, exposes `WSURL()`, `Kill()`, `Close()` |
| `pkg/crawl/browser_test.go` | Integration tests (`//go:build integration`): launch/kill, idempotent kill, close cleanup |
| `pkg/crawl/crawler.go` | `Crawl()` creates `BrowserManager` when headless, passes `ChromeWSUrl`, kills Chrome on signal with bounded 2s drain |
| `cmd/vespasian/main.go` | `doCrawl()` prints interrupt message to injectable `io.Writer`; `setupForceExitHandler()` for double-interrupt |
| `cmd/vespasian/main_test.go` | Updated graceful shutdown tests to verify stderr output |
| `go.mod` | `go-rod/rod` promoted from indirect to direct dependency |

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] All integration tests pass (`go test -tags integration ./pkg/crawl/ -run TestBrowserManager`)
- [x] `go vet ./...` clean
- [x] Manual: run `vespasian crawl <url>`, hit `^C` — verify Chrome dies, partial results returned
- [x] Manual: run crawl, hit `^C` twice — verify immediate exit
- [ ] CI passes