### PR TITLE
feat: add --proxy flag for Burp Suite integration

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -207,6 +207,7 @@ type CrawlOptions struct {
 	Timeout  time.Duration `default:"10m" help:"Maximum duration for the entire crawl"`
 	Scope    string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
 	Headless bool          `default:"true" help:"Use headless browser"`
+	Proxy    string        `help:"Proxy address for headless browser (e.g., http://127.0.0.1:8080 for Burp Suite)"`
 	Verbose  bool          `short:"v" help:"Enable verbose logging"`
 }
 
@@ -272,7 +273,7 @@ func setupBrowserAndSignals(rawHeaders []string, crawlOpts CrawlOptions, extraOp
 	var browserMgr *crawl.BrowserManager
 
 	if crawlOpts.Headless {
-		browserMgr, err = crawl.NewBrowserManager(crawl.BrowserOptions{Headless: true})
+		browserMgr, err = crawl.NewBrowserManager(crawl.BrowserOptions{Headless: true, Proxy: crawlOpts.Proxy})
 		if err != nil {
 			return browserSetupResult{}, fmt.Errorf("launch browser: %w", err)
 		}
@@ -324,6 +325,7 @@ func (c *CrawlCmd) Run() error {
 		Timeout:  c.Timeout,
 		Scope:    c.Scope,
 		Headless: c.Headless,
+		Proxy:    c.Proxy,
 	})
 	if err != nil {
 		return err
@@ -465,6 +467,7 @@ func (c *ScanCmd) Run() error {
 		Timeout:  c.Timeout,
 		Scope:    c.Scope,
 		Headless: c.Headless,
+		Proxy:    c.Proxy,
 	})
 	if err != nil {
 		return err

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -129,6 +129,11 @@ const shutdownBackstop = 10 * time.Second
 func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, opts crawl.CrawlerOptions) ([]crawl.ObservedRequest, error) {
 	opts.Stderr = stderr
 
+	if opts.Proxy != "" && !opts.Headless {
+		fmt.Fprintf(stderr, "warning: --proxy is only supported with headless browser mode; ignoring proxy setting\n")
+		opts.Proxy = ""
+	}
+
 	crawler := crawl.NewCrawler(opts)
 
 	// Run Crawl in a goroutine so we can apply a backstop timeout after

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -212,7 +212,7 @@ type CrawlOptions struct {
 	Timeout  time.Duration `default:"10m" help:"Maximum duration for the entire crawl"`
 	Scope    string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
 	Headless bool          `default:"true" help:"Use headless browser"`
-	Proxy    string        `help:"Proxy address for headless browser (e.g., http://127.0.0.1:8080 for Burp Suite)"`
+	Proxy    string        `help:"Proxy address for headless browser (e.g., http://127.0.0.1:8080). Note: TLS certificate verification is disabled during crawls."`
 	Verbose  bool          `short:"v" help:"Enable verbose logging"`
 }
 

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -134,6 +134,16 @@ func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, opts crawl
 		opts.Proxy = ""
 	}
 
+	// Safety: opts.Proxy is printed below. All current callers (CrawlCmd.Run,
+	// ScanCmd.Run) validate via setupBrowserAndSignals → validateProxyAddr first,
+	// which rejects embedded credentials. If adding a new caller, ensure
+	// validateProxyAddr runs before reaching this point.
+	if opts.Proxy != "" {
+		if u, err := url.Parse(opts.Proxy); err == nil && u.Port() == "" {
+			fmt.Fprintf(stderr, "warning: --proxy address %q has no explicit port; most proxies require one (e.g., :8080)\n", opts.Proxy)
+		}
+	}
+
 	crawler := crawl.NewCrawler(opts)
 
 	// Run Crawl in a goroutine so we can apply a backstop timeout after
@@ -174,7 +184,11 @@ func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, opts crawl
 
 	if err != nil {
 		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && len(requests) > 0 {
-			fmt.Fprintf(stderr, "returning %d partial results\n", len(requests))
+			noun := "results"
+			if len(requests) == 1 {
+				noun = "result"
+			}
+			fmt.Fprintf(stderr, "returning %d partial %s\n", len(requests), noun)
 			return requests, nil
 		}
 		return nil, fmt.Errorf("crawl failed: %w", err)

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -626,7 +626,7 @@ func TestDoCrawl_ProxyIgnoredWithoutHeadless(t *testing.T) {
 	// doCrawl will warn and clear proxy before creating the crawler.
 	// It will then fail on the actual crawl (no valid URL), but we only
 	// care about the warning message.
-	_, _ = doCrawl(context.Background(), &buf, "https://example.com", nil, opts)
+	_, _ = doCrawl(context.Background(), &buf, "https://example.com", opts)
 	if !strings.Contains(buf.String(), "warning: --proxy is only supported with headless browser mode") {
 		t.Errorf("expected proxy warning on stderr, got %q", buf.String())
 	}

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -615,6 +615,32 @@ func TestCrawlOptions_Embedded(t *testing.T) {
 	}
 }
 
+// TestCrawlOptions_Proxy verifies that the --proxy flag is accessible on both
+// CrawlCmd and ScanCmd via the embedded CrawlOptions.
+func TestCrawlOptions_Proxy(t *testing.T) {
+	proxy := "http://127.0.0.1:8080"
+
+	c := &CrawlCmd{
+		URL: "https://example.com",
+		CrawlOptions: CrawlOptions{
+			Proxy: proxy,
+		},
+	}
+	if c.Proxy != proxy {
+		t.Errorf("CrawlCmd.Proxy = %q, want %q", c.Proxy, proxy)
+	}
+
+	s := &ScanCmd{
+		URL: "https://example.com",
+		CrawlOptions: CrawlOptions{
+			Proxy: proxy,
+		},
+	}
+	if s.Proxy != proxy {
+		t.Errorf("ScanCmd.Proxy = %q, want %q", s.Proxy, proxy)
+	}
+}
+
 // TestVersionVariable verifies the version variable is accessible and has a default.
 func TestVersionVariable(t *testing.T) {
 	if version == "" {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -632,6 +632,22 @@ func TestDoCrawl_ProxyIgnoredWithoutHeadless(t *testing.T) {
 	}
 }
 
+// TestDoCrawl_ProxyPortlessWarning verifies that doCrawl warns when the proxy
+// address has no explicit port.
+func TestDoCrawl_ProxyPortlessWarning(t *testing.T) {
+	var buf bytes.Buffer
+	opts := crawl.CrawlerOptions{
+		Headless: true,
+		Proxy:    "http://proxy.local",
+	}
+	// doCrawl will warn about the missing port, then fail on the actual crawl.
+	// We only care about the warning message.
+	_, _ = doCrawl(context.Background(), &buf, "https://example.com", opts)
+	if !strings.Contains(buf.String(), "has no explicit port") {
+		t.Errorf("expected port-less warning on stderr, got %q", buf.String())
+	}
+}
+
 // TestCrawlOptions_Proxy verifies that the --proxy flag is accessible on both
 // CrawlCmd and ScanCmd via the embedded CrawlOptions.
 func TestCrawlOptions_Proxy(t *testing.T) {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -615,6 +615,23 @@ func TestCrawlOptions_Embedded(t *testing.T) {
 	}
 }
 
+// TestDoCrawl_ProxyIgnoredWithoutHeadless verifies that doCrawl warns and clears
+// the proxy option when headless mode is disabled.
+func TestDoCrawl_ProxyIgnoredWithoutHeadless(t *testing.T) {
+	var buf bytes.Buffer
+	opts := crawl.CrawlerOptions{
+		Headless: false,
+		Proxy:    "http://127.0.0.1:8080",
+	}
+	// doCrawl will warn and clear proxy before creating the crawler.
+	// It will then fail on the actual crawl (no valid URL), but we only
+	// care about the warning message.
+	_, _ = doCrawl(context.Background(), &buf, "https://example.com", nil, opts)
+	if !strings.Contains(buf.String(), "warning: --proxy is only supported with headless browser mode") {
+		t.Errorf("expected proxy warning on stderr, got %q", buf.String())
+	}
+}
+
 // TestCrawlOptions_Proxy verifies that the --proxy flag is accessible on both
 // CrawlCmd and ScanCmd via the embedded CrawlOptions.
 func TestCrawlOptions_Proxy(t *testing.T) {

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -126,16 +126,22 @@ func (b *BrowserManager) PID() int {
 func validateProxyAddr(addr string) error {
 	u, err := url.Parse(addr)
 	if err != nil {
-		return fmt.Errorf("invalid proxy address %q: %w", addr, err)
+		return fmt.Errorf("invalid proxy address: %w", err)
+	}
+	// Check credentials first — later error messages include the address,
+	// so we must reject (and redact) credentials before reaching them.
+	if u.User != nil {
+		// Redact credentials manually — u.Redacted() preserves the username
+		// and shows the password as "xxxxx", but we want both fully masked
+		// so neither leaks into logs, CI output, or terminal scrollback.
+		u.User = url.UserPassword("xxxxx", "xxxxx")
+		return fmt.Errorf("invalid proxy address %q: embedded credentials are not supported (they would be visible in process listing); configure authentication in your proxy instead", u.String())
 	}
 	if u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5" {
 		return fmt.Errorf("invalid proxy address %q: scheme must be http, https, or socks5", addr)
 	}
 	if u.Host == "" {
 		return fmt.Errorf("invalid proxy address %q: missing host", addr)
-	}
-	if u.User != nil {
-		return fmt.Errorf("invalid proxy address %q: embedded credentials are not supported (they would be visible in process listing); configure authentication in your proxy instead", addr)
 	}
 	return nil
 }

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -15,6 +15,8 @@
 package crawl
 
 import (
+	"fmt"
+	"net/url"
 	"sync"
 
 	"github.com/go-rod/rod/lib/launcher"
@@ -63,6 +65,9 @@ func NewBrowserManager(opts BrowserOptions) (*BrowserManager, error) {
 		l = l.Bin(opts.ChromePath)
 	}
 	if opts.Proxy != "" {
+		if err := validateProxyAddr(opts.Proxy); err != nil {
+			return nil, err
+		}
 		l = l.Set("proxy-server", opts.Proxy)
 	}
 
@@ -113,4 +118,24 @@ func (b *BrowserManager) Close() {
 // PID returns the Chrome process ID, useful for testing.
 func (b *BrowserManager) PID() int {
 	return b.launcher.PID()
+}
+
+// validateProxyAddr checks that the proxy address is a valid HTTP/HTTPS URL
+// with a host and port. This prevents typos from producing confusing Chrome
+// launch errors and ensures no credentials are embedded in the URL.
+func validateProxyAddr(addr string) error {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return fmt.Errorf("invalid proxy address %q: %w", addr, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5" {
+		return fmt.Errorf("invalid proxy address %q: scheme must be http, https, or socks5", addr)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid proxy address %q: missing host", addr)
+	}
+	if u.User != nil {
+		return fmt.Errorf("invalid proxy address %q: embedded credentials are not supported (they would be visible in process listing); configure authentication in your proxy instead", addr)
+	}
+	return nil
 }

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -34,6 +34,10 @@ type BrowserOptions struct {
 	// is passed directly to exec.Command — it must be a trusted, hardcoded
 	// path. Never populate from user-controlled input.
 	ChromePath string
+
+	// Proxy sets the Chrome --proxy-server flag, routing all browser traffic
+	// through the given address (e.g., "http://127.0.0.1:8080" for Burp Suite).
+	Proxy string
 }
 
 // BrowserManager owns the Chrome process lifecycle. It launches Chrome via
@@ -57,6 +61,9 @@ func NewBrowserManager(opts BrowserOptions) (*BrowserManager, error) {
 	}
 	if opts.ChromePath != "" {
 		l = l.Bin(opts.ChromePath)
+	}
+	if opts.Proxy != "" {
+		l = l.Set("proxy-server", opts.Proxy)
 	}
 
 	wsURL, err := l.Launch()

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -56,6 +56,7 @@ type CrawlerOptions struct {
 	Scope    string
 	Headless bool
 	Headers  map[string]string
+	Proxy    string    // optional: proxy address for Chrome (e.g., "http://127.0.0.1:8080")
 	Stderr   io.Writer // user-facing status messages; nil disables output
 
 	// BrowserMgr provides a caller-owned Chrome instance. When set, Crawl()
@@ -101,7 +102,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		browserMgr = c.opts.BrowserMgr
 		// Caller owns lifecycle — don't defer Close here.
 	} else if c.opts.Headless {
-		browserMgr, err = NewBrowserManager(BrowserOptions{Headless: true})
+		browserMgr, err = NewBrowserManager(BrowserOptions{Headless: true, Proxy: c.opts.Proxy})
 		if err != nil {
 			return nil, fmt.Errorf("launch browser: %w", err)
 		}

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -235,7 +235,9 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			}
 			timer.Stop()
 
-			closeEngine()
+			// Close engine with a bounded wait — engine.Close() may block
+			// if the killed Chrome process left the engine in a bad state.
+			boundedRun(closeEngine, DrainTimeout)
 
 			if timerExpired {
 				// engine.Close() causes engine.Crawl() to return shortly.
@@ -257,9 +259,10 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			return snapshot, ctx.Err()
 		}
 
-		// MaxPages reached — close engine and drain goroutine with a bounded wait
-		// to match the signal path's timeout discipline.
-		closeEngine()
+		// MaxPages reached — close engine with bounded wait, then drain
+		// crawl goroutine to match the signal path's timeout discipline.
+		boundedRun(closeEngine, DrainTimeout)
+
 		drainTimer := time.NewTimer(ShutdownGracePeriod)
 		select {
 		case <-crawlErr:
@@ -342,4 +345,21 @@ func ToStringSlice(headers map[string]string) goflags.StringSlice {
 		result = append(result, key+": "+value)
 	}
 	return result
+}
+
+// boundedRun executes fn in a goroutine and waits up to timeout for it to
+// complete. If fn doesn't finish in time, boundedRun returns and the goroutine
+// remains alive until fn eventually returns.
+func boundedRun(fn func(), timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+	t := time.NewTimer(timeout)
+	select {
+	case <-done:
+	case <-t.C:
+	}
+	t.Stop()
 }

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -387,6 +387,32 @@ func TestValidateProxyAddr(t *testing.T) {
 			}
 		})
 	}
+
+	// Verify credentials are never echoed in error messages, even when
+	// other validation (e.g., scheme) would also fail.
+	credentialLeakCases := []struct {
+		name string
+		addr string
+	}{
+		{"http with creds", "http://admin:s3cret@proxy:8080"},
+		{"wrong scheme with creds", "ftp://admin:s3cret@proxy:21"},
+		{"user only", "http://admin@proxy:8080"},
+	}
+	for _, tt := range credentialLeakCases {
+		t.Run("redacted/"+tt.name, func(t *testing.T) {
+			err := validateProxyAddr(tt.addr)
+			if err == nil {
+				t.Fatal("expected error for embedded credentials")
+			}
+			msg := err.Error()
+			if strings.Contains(msg, "admin") || strings.Contains(msg, "s3cret") {
+				t.Errorf("error message leaks credentials: %s", msg)
+			}
+			if !strings.Contains(msg, "xxxxx") {
+				t.Errorf("error message should contain redacted placeholder 'xxxxx': %s", msg)
+			}
+		})
+	}
 }
 
 // TestDefaultMaxPages verifies the DefaultMaxPages constant value

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -309,6 +309,7 @@ func TestNewCrawler(t *testing.T) {
 		MaxPages: 100,
 		Scope:    "same-domain",
 		Headless: true,
+		Proxy:    "http://127.0.0.1:8080",
 		Headers: map[string]string{
 			"User-Agent": "test",
 		},
@@ -331,6 +332,9 @@ func TestNewCrawler(t *testing.T) {
 	}
 	if !crawler.opts.Headless {
 		t.Errorf("crawler.opts.Headless = false, want true")
+	}
+	if crawler.opts.Proxy != "http://127.0.0.1:8080" {
+		t.Errorf("crawler.opts.Proxy = %q, want %q", crawler.opts.Proxy, "http://127.0.0.1:8080")
 	}
 	if crawler.opts.Headers["User-Agent"] != "test" {
 		t.Errorf("crawler.opts.Headers[User-Agent] = %q, want %q", crawler.opts.Headers["User-Agent"], "test")

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -355,6 +355,47 @@ func TestCrawl_NegativeDepthReturnsError(t *testing.T) {
 	}
 }
 
+// TestValidateProxyAddr tests the proxy address validation.
+func TestValidateProxyAddr(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr bool
+		errMsg  string
+	}{
+		{"valid http", "http://127.0.0.1:8080", false, ""},
+		{"valid https", "https://proxy.example.com:8443", false, ""},
+		{"valid socks5", "socks5://127.0.0.1:1080", false, ""},
+		{"valid http no port", "http://proxy.local", false, ""},
+		{"missing scheme", "127.0.0.1:8080", true, "invalid proxy address"},
+		{"ftp scheme", "ftp://proxy:21", true, "scheme must be"},
+		{"empty host", "http://", true, "missing host"},
+		{"embedded credentials", "http://user:pass@127.0.0.1:8080", true, "embedded credentials"},
+		{"embedded user only", "http://user@127.0.0.1:8080", true, "embedded credentials"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProxyAddr(tt.addr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateProxyAddr(%q) error = %v, wantErr %v", tt.addr, err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errMsg != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("validateProxyAddr(%q) error = %q, want containing %q", tt.addr, err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+// TestDefaultMaxPages verifies the DefaultMaxPages constant value
+func TestDefaultMaxPages(t *testing.T) {
+	if DefaultMaxPages != 1000 {
+		t.Errorf("DefaultMaxPages = %d, want 1000", DefaultMaxPages)
+	}
+}
+
 // TestCrawl_EmptyURLReturnsError tests that empty URL is rejected
 func TestCrawl_EmptyURLReturnsError(t *testing.T) {
 	crawler := NewCrawler(CrawlerOptions{


### PR DESCRIPTION
## Summary

- Adds `--proxy` flag to `crawl` and `scan` commands, routing all headless browser traffic through a proxy (e.g., `http://127.0.0.1:8080` for Burp Suite)
- Plumbs the proxy address through `CrawlOptions` → `CrawlerOptions` → `BrowserOptions` → Chrome's `--proxy-server` launch flag
- No behavior change when `--proxy` is not specified

### Usage

```sh
vespasian crawl https://target.com --proxy http://127.0.0.1:8080
```

### Notes

- Chrome's `--proxy-server` routes ALL browser traffic through the proxy
- SSL interception works because Katana's launcher already sets `--ignore-certificate-errors`
- Only applies to headless (browser) crawls — the standard HTTP engine uses Katana's own HTTP client

> **Depends on PR #28** (`logan/browser-ownership`) being merged first — this PR builds on vespasian owning the Chrome lifecycle.

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Manual: `vespasian crawl <url> --proxy http://127.0.0.1:8080` with Burp listening — verify traffic appears in Burp
- [x] Manual: `vespasian crawl <url>` without `--proxy` — verify no behavior change