### PR TITLE
feat: add X-Vespasian-Request-Id middleware header

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -17,6 +17,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -50,6 +52,47 @@ var CLI struct {
 	Generate GenerateCmd `cmd:"" help:"Generate API specifications from captured traffic"`
 	Scan     ScanCmd     `cmd:"" help:"Full pipeline: crawl, classify, and generate specs"`
 	Version  VersionCmd  `cmd:"" help:"Show version information"`
+}
+
+// RequestIDHeader is the header name used for crawl session traceability.
+const RequestIDHeader = "X-Vespasian-Request-Id"
+
+// generateRequestID produces a 32-character hex string from 16 random bytes.
+func generateRequestID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate request ID: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// headerExistsCaseInsensitive checks whether a header name exists in the map
+// using a case-insensitive comparison, per RFC 7230.
+func headerExistsCaseInsensitive(headers map[string]string, name string) bool {
+	for k := range headers {
+		if strings.EqualFold(k, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// injectRequestID adds an auto-generated X-Vespasian-Request-Id header to the
+// map unless disabled or the user already supplied one via -H. Returns the
+// generated ID (empty if skipped or user-supplied).
+func injectRequestID(headers map[string]string, disabled bool) (string, error) {
+	if disabled {
+		return "", nil
+	}
+	if headerExistsCaseInsensitive(headers, RequestIDHeader) {
+		return "", nil
+	}
+	id, err := generateRequestID()
+	if err != nil {
+		return "", err
+	}
+	headers[RequestIDHeader] = id
+	return id, nil
 }
 
 // parseHeaders converts "Key: Value" strings to a map, validating header names
@@ -226,8 +269,9 @@ type CrawlOptions struct {
 	Timeout  time.Duration `default:"10m" help:"Maximum duration for the entire crawl"`
 	Scope    string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
 	Headless bool          `default:"true" help:"Use headless browser"`
-	Proxy    string        `help:"Proxy address for headless browser (e.g., http://127.0.0.1:8080). Note: TLS certificate verification is disabled during crawls."`
-	Verbose  bool          `short:"v" help:"Enable verbose logging"`
+	Proxy       string        `help:"Proxy address for headless browser (e.g., http://127.0.0.1:8080). Note: TLS certificate verification is disabled during crawls."`
+	NoRequestID bool          `name:"no-request-id" help:"Disable automatic X-Vespasian-Request-Id header"`
+	Verbose     bool          `short:"v" help:"Enable verbose logging"`
 }
 
 // setupForceExitHandler spawns a goroutine that waits for the first signal
@@ -270,23 +314,30 @@ func onForceExit(stderr io.Writer, cleanup func(), exitFn func(int)) {
 
 // browserSetupResult holds the resources created by setupBrowserAndSignals.
 type browserSetupResult struct {
-	opts    crawl.CrawlerOptions
-	ctx     context.Context
-	cleanup func() // caller must defer this
+	opts      crawl.CrawlerOptions
+	ctx       context.Context
+	cleanup   func() // caller must defer this
+	requestID string // auto-generated session ID; empty if disabled or user-supplied
 }
 
-// setupBrowserAndSignals validates headers, creates a BrowserManager (if
-// headless), wires up signal handling with force-exit support, and returns a
-// cancellable context. Headers are validated before launching Chrome so that
-// invalid headers fail fast without wasting browser startup time. The returned
-// cleanup function closes the browser and stops the signal handler; callers
-// must defer it.
+// setupBrowserAndSignals validates headers, injects the request ID header (if
+// enabled), creates a BrowserManager (if headless), wires up signal handling
+// with force-exit support, and returns a cancellable context. Headers are
+// validated before launching Chrome so that invalid headers fail fast without
+// wasting browser startup time. The returned cleanup function closes the
+// browser and stops the signal handler; callers must defer it.
 func setupBrowserAndSignals(rawHeaders []string, crawlOpts CrawlOptions, extraOpts crawl.CrawlerOptions) (browserSetupResult, error) {
 	// Validate headers before launching Chrome — fail fast on invalid input.
 	headers, err := parseHeaders(rawHeaders)
 	if err != nil {
 		return browserSetupResult{}, fmt.Errorf("invalid header: %w", err)
 	}
+
+	requestID, err := injectRequestID(headers, crawlOpts.NoRequestID)
+	if err != nil {
+		return browserSetupResult{}, err
+	}
+
 	extraOpts.Headers = headers
 
 	var browserMgr *crawl.BrowserManager
@@ -319,9 +370,10 @@ func setupBrowserAndSignals(rawHeaders []string, crawlOpts CrawlOptions, extraOp
 	}
 
 	return browserSetupResult{
-		opts:    extraOpts,
-		ctx:     ctx,
-		cleanup: cleanup,
+		opts:      extraOpts,
+		ctx:       ctx,
+		cleanup:   cleanup,
+		requestID: requestID,
 	}, nil
 }
 
@@ -362,6 +414,9 @@ func (c *CrawlCmd) Run() error {
 	}
 
 	if c.Verbose {
+		if bs.requestID != "" {
+			fmt.Fprintf(os.Stderr, "request-id: %s\n", bs.requestID)
+		}
 		fmt.Fprintf(os.Stderr, "captured %d requests\n", len(requests))
 	}
 
@@ -504,6 +559,9 @@ func (c *ScanCmd) Run() error {
 	}
 
 	if c.Verbose {
+		if bs.requestID != "" {
+			fmt.Fprintf(os.Stderr, "request-id: %s\n", bs.requestID)
+		}
 		fmt.Fprintf(os.Stderr, "captured %d requests\n", len(requests))
 		fmt.Fprintf(os.Stderr, "generating REST spec\n")
 	}

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -262,13 +262,13 @@ func writeOutput(path string, fn func(io.Writer) error) error {
 
 // CrawlOptions holds the shared crawl configuration fields used by CrawlCmd and ScanCmd.
 type CrawlOptions struct {
-	Header   []string      `short:"H" help:"Custom headers (repeatable)"`
-	Output   string        `short:"o" help:"Output file path"`
-	Depth    int           `default:"3" help:"Maximum crawl depth"`
-	MaxPages int           `default:"100" help:"Maximum pages to crawl"`
-	Timeout  time.Duration `default:"10m" help:"Maximum duration for the entire crawl"`
-	Scope    string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
-	Headless bool          `default:"true" help:"Use headless browser"`
+	Header      []string      `short:"H" help:"Custom headers (repeatable)"`
+	Output      string        `short:"o" help:"Output file path"`
+	Depth       int           `default:"3" help:"Maximum crawl depth"`
+	MaxPages    int           `default:"100" help:"Maximum pages to crawl"`
+	Timeout     time.Duration `default:"10m" help:"Maximum duration for the entire crawl"`
+	Scope       string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
+	Headless    bool          `default:"true" help:"Use headless browser"`
 	Proxy       string        `help:"Proxy address for headless browser (e.g., http://127.0.0.1:8080). Note: TLS certificate verification is disabled during crawls."`
 	NoRequestID bool          `name:"no-request-id" help:"Disable automatic X-Vespasian-Request-Id header"`
 	Verbose     bool          `short:"v" help:"Enable verbose logging"`

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -833,5 +834,159 @@ func TestSetupBrowserAndSignals_InvalidHeaderReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid header") {
 		t.Errorf("setupBrowserAndSignals() error = %q, want 'invalid header'", err.Error())
+	}
+}
+
+func TestGenerateRequestID(t *testing.T) {
+	t.Run("produces 32-char hex string", func(t *testing.T) {
+		id, err := generateRequestID()
+		if err != nil {
+			t.Fatalf("generateRequestID() error = %v", err)
+		}
+		if len(id) != 32 {
+			t.Errorf("generateRequestID() length = %d, want 32", len(id))
+		}
+		if _, err := hex.DecodeString(id); err != nil {
+			t.Errorf("generateRequestID() returned non-hex string: %q", id)
+		}
+	})
+
+	t.Run("produces unique values", func(t *testing.T) {
+		ids := make(map[string]bool)
+		for i := 0; i < 100; i++ {
+			id, err := generateRequestID()
+			if err != nil {
+				t.Fatalf("generateRequestID() error = %v", err)
+			}
+			if ids[id] {
+				t.Fatalf("generateRequestID() produced duplicate ID: %q", id)
+			}
+			ids[id] = true
+		}
+	})
+}
+
+func TestInjectRequestID(t *testing.T) {
+	t.Run("default injects header", func(t *testing.T) {
+		headers := map[string]string{}
+		id, err := injectRequestID(headers, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(id) != 32 {
+			t.Errorf("request ID length = %d, want 32", len(id))
+		}
+		if headers[RequestIDHeader] != id {
+			t.Errorf("header value = %q, want %q", headers[RequestIDHeader], id)
+		}
+	})
+
+	t.Run("disabled skips injection", func(t *testing.T) {
+		headers := map[string]string{}
+		id, err := injectRequestID(headers, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id != "" {
+			t.Errorf("expected empty ID when disabled, got %q", id)
+		}
+		if _, ok := headers[RequestIDHeader]; ok {
+			t.Error("expected no header when disabled")
+		}
+	})
+
+	t.Run("user-supplied value is preserved", func(t *testing.T) {
+		headers := map[string]string{RequestIDHeader: "my-custom-id"}
+		id, err := injectRequestID(headers, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id != "" {
+			t.Errorf("expected empty ID when user-supplied, got %q", id)
+		}
+		if headers[RequestIDHeader] != "my-custom-id" {
+			t.Errorf("user value overwritten: got %q", headers[RequestIDHeader])
+		}
+	})
+
+	t.Run("user-supplied value with different casing is preserved", func(t *testing.T) {
+		headers := map[string]string{"x-vespasian-request-id": "lowercase-id"}
+		id, err := injectRequestID(headers, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id != "" {
+			t.Errorf("expected empty ID when user-supplied, got %q", id)
+		}
+		// Should not inject canonical header when lowercase variant exists
+		if _, exists := headers[RequestIDHeader]; exists {
+			t.Error("should not inject canonical header when lowercase variant exists")
+		}
+		if headers["x-vespasian-request-id"] != "lowercase-id" {
+			t.Errorf("user value overwritten: got %q", headers["x-vespasian-request-id"])
+		}
+	})
+}
+
+// TestSetupBrowserAndSignals_InjectsRequestID verifies that setupBrowserAndSignals
+// injects the request ID header by default and returns it in the result.
+func TestSetupBrowserAndSignals_InjectsRequestID(t *testing.T) {
+	bs, err := setupBrowserAndSignals(
+		nil,
+		CrawlOptions{Headless: false},
+		crawl.CrawlerOptions{Depth: 1},
+	)
+	if err != nil {
+		t.Fatalf("setupBrowserAndSignals() error = %v", err)
+	}
+	defer bs.cleanup()
+
+	if len(bs.requestID) != 32 {
+		t.Errorf("requestID length = %d, want 32", len(bs.requestID))
+	}
+	if bs.opts.Headers[RequestIDHeader] != bs.requestID {
+		t.Errorf("header = %q, want %q", bs.opts.Headers[RequestIDHeader], bs.requestID)
+	}
+}
+
+// TestSetupBrowserAndSignals_NoRequestIDDisablesInjection verifies that
+// NoRequestID=true prevents the header from being injected.
+func TestSetupBrowserAndSignals_NoRequestIDDisablesInjection(t *testing.T) {
+	bs, err := setupBrowserAndSignals(
+		nil,
+		CrawlOptions{Headless: false, NoRequestID: true},
+		crawl.CrawlerOptions{Depth: 1},
+	)
+	if err != nil {
+		t.Fatalf("setupBrowserAndSignals() error = %v", err)
+	}
+	defer bs.cleanup()
+
+	if bs.requestID != "" {
+		t.Errorf("requestID = %q, want empty", bs.requestID)
+	}
+	if _, ok := bs.opts.Headers[RequestIDHeader]; ok {
+		t.Error("header should not be present when NoRequestID is true")
+	}
+}
+
+// TestSetupBrowserAndSignals_UserSuppliedRequestIDPreserved verifies that a
+// user-supplied X-Vespasian-Request-Id via -H takes precedence.
+func TestSetupBrowserAndSignals_UserSuppliedRequestIDPreserved(t *testing.T) {
+	bs, err := setupBrowserAndSignals(
+		[]string{"X-Vespasian-Request-Id: user-value"},
+		CrawlOptions{Headless: false},
+		crawl.CrawlerOptions{Depth: 1},
+	)
+	if err != nil {
+		t.Fatalf("setupBrowserAndSignals() error = %v", err)
+	}
+	defer bs.cleanup()
+
+	if bs.requestID != "" {
+		t.Errorf("requestID = %q, want empty (user-supplied)", bs.requestID)
+	}
+	if bs.opts.Headers[RequestIDHeader] != "user-value" {
+		t.Errorf("header = %q, want %q", bs.opts.Headers[RequestIDHeader], "user-value")
 	}
 }


### PR DESCRIPTION
## Summary

- Auto-injects an `X-Vespasian-Request-Id` header with a per-session UUID on every crawl request, enabling downstream middleware (WAFs, proxies, log aggregators) to correlate traffic back to a specific vespasian crawl session
- Enabled by default; disable with `--no-request-id`
- User-supplied `-H "X-Vespasian-Request-Id: ..."` values silently take precedence
- Uses `crypto/rand` (stdlib only, no new dependencies)

## Design decisions

Three approaches were considered for per-request unique IDs (unique header value on each individual HTTP request):

| Approach | Per-request? | Actually sent to server? | Effort |
|----------|:---:|:---:|--------|
| **A. `CustomHeaders` (per-session ID)** | No | Yes | ~30 lines |
| **B. Fork Katana to add request middleware** | Yes | Yes | Significant, throwaway |
| **C. Local MITM proxy that injects headers** | Yes | Yes | New component, overkill |

**Chose Option A** because:
- The header is actually sent to the server on every request — real traceability
- A session-level UUID is sufficient for log correlation (timestamps and URLs distinguish individual requests within a session)
- No throwaway Katana modifications required
- When Katana is replaced with a custom engine, the injection point moves to the transport layer, enabling per-request unique IDs with no other code changes — the flag, ID generation, conflict handling, and verbose output all carry forward unchanged

## Test plan

- [x] `TestGenerateRequestID` — validates 32-char hex format and uniqueness
- [x] `TestRequestIDInjection` — default injection, `--no-request-id` opt-out, user `-H` value preservation
- [x] Full test suite passes (`go test ./...`)