### PR TITLE
feat: enable jsluice-based JS endpoint extraction

### DIFF
--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -132,15 +132,15 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		// Katana needs the full body for link extraction and JS parsing to maximize
 		// crawl coverage; we only retain MaxResponseBodySize for classification.
 		// Peak memory: up to Concurrency × BodyReadSize (100 MB with 10 workers).
-		BodyReadSize:      10 * 1024 * 1024,
-		Concurrency:       10,
-		Parallelism:       10,
-		RateLimit:         150,
-		TimeStable:        3, // seconds to wait for DOM stability; 0 causes go-rod panic in time.NewTicker
-		ScrapeJSResponses: true,
+		BodyReadSize:           10 * 1024 * 1024,
+		Concurrency:            10,
+		Parallelism:            10,
+		RateLimit:              150,
+		TimeStable:             3, // seconds to wait for DOM stability; 0 causes go-rod panic in time.NewTicker
+		ScrapeJSResponses:      true,
 		ScrapeJSLuiceResponses: true,
-		XhrExtraction:     true,
-		Silent:            true,
+		XhrExtraction:          true,
+		Silent:                 true,
 		OnResult: func(result output.Result) {
 			// Map result outside the lock — MapResult may do URL parsing
 			// and body truncation, which is wasted work under contention.

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -76,22 +76,22 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 
 	// Build Katana options
 	katanaOpts := &types.Options{
-		MaxDepth:          c.opts.Depth,
-		Timeout:           PageTimeout,
-		CrawlDuration:     c.opts.Timeout,
-		FieldScope:        MapScope(c.opts.Scope),
-		Headless:          c.opts.Headless,
-		CustomHeaders:     ToStringSlice(c.opts.Headers),
-		Strategy:          "depth-first",
-		BodyReadSize:      10 * 1024 * 1024, // 10 MB limit to prevent memory exhaustion from hostile targets
-		Concurrency:       10,
-		Parallelism:       10,
-		RateLimit:         150,
-		TimeStable:        3, // seconds to wait for DOM stability; 0 causes go-rod panic in time.NewTicker
+		MaxDepth:               c.opts.Depth,
+		Timeout:                PageTimeout,
+		CrawlDuration:          c.opts.Timeout,
+		FieldScope:             MapScope(c.opts.Scope),
+		Headless:               c.opts.Headless,
+		CustomHeaders:          ToStringSlice(c.opts.Headers),
+		Strategy:               "depth-first",
+		BodyReadSize:           10 * 1024 * 1024, // 10 MB limit to prevent memory exhaustion from hostile targets
+		Concurrency:            10,
+		Parallelism:            10,
+		RateLimit:              150,
+		TimeStable:             3, // seconds to wait for DOM stability; 0 causes go-rod panic in time.NewTicker
 		ScrapeJSResponses:      true,
 		ScrapeJSLuiceResponses: true,
-		XhrExtraction:     true,
-		Silent:            true,
+		XhrExtraction:          true,
+		Silent:                 true,
 		OnResult: func(result output.Result) {
 			mu.Lock()
 			defer mu.Unlock()

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -137,7 +137,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		RateLimit:         150,
 		TimeStable:        3, // seconds to wait for DOM stability; 0 causes go-rod panic in time.NewTicker
 		ScrapeJSResponses: true,
-    ScrapeJSLuiceResponses: true,
+		ScrapeJSLuiceResponses: true,
 		XhrExtraction:     true,
 		Silent:            true,
 		OnResult: func(result output.Result) {

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -181,6 +181,8 @@ func MapResult(r output.Result) ObservedRequest {
 			req.Body = req.Body[:MaxResponseBodySize]
 		}
 		req.Source = r.Request.Source
+		req.Tag = r.Request.Tag
+		req.Attribute = r.Request.Attribute
 	}
 
 	// Parse query params from URL

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -120,7 +120,6 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 
 	// Build Katana options
 	katanaOpts := &types.Options{
-
 		MaxDepth:      c.opts.Depth,
 		Timeout:       PageTimeout,
 		CrawlDuration: c.opts.Timeout,

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -88,7 +88,8 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		Parallelism:       10,
 		RateLimit:         150,
 		TimeStable:        3, // seconds to wait for DOM stability; 0 causes go-rod panic in time.NewTicker
-		ScrapeJSResponses: true,
+		ScrapeJSResponses:      true,
+		ScrapeJSLuiceResponses: true,
 		XhrExtraction:     true,
 		Silent:            true,
 		OnResult: func(result output.Result) {

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -591,7 +591,32 @@ func TestMapResult_JsluiceTagAndAttribute(t *testing.T) {
 			name:      "empty tag and attribute",
 			tag:       "",
 			attribute: "",
-		}
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := output.Result{
+				Request: &navigation.Request{
+					Method:    "GET",
+					URL:       "https://example.com/api/endpoint",
+					Source:    "crawler",
+					Tag:       tt.tag,
+					Attribute: tt.attribute,
+				},
+				Response: &navigation.Response{
+					StatusCode: 200,
+				},
+			}
+
+			observed := MapResult(result)
+			if observed.Tag != tt.tag {
+				t.Errorf("Tag = %q, want %q", observed.Tag, tt.tag)
+			}
+			if observed.Attribute != tt.attribute {
+				t.Errorf("Attribute = %q, want %q", observed.Attribute, tt.attribute)
+			}
+		})
 	}
 }
 
@@ -634,26 +659,19 @@ func TestMapResult_LowercaseContentType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := output.Result{
 				Request: &navigation.Request{
-					Method:    "GET",
-					URL:       "https://example.com/api/endpoint",
-					Source:    "crawler",
-					Tag:       tt.tag,
-					Attribute: tt.attribute,
+					Method: "GET",
+					URL:    "https://example.com/api/data",
 				},
 				Response: &navigation.Response{
 					StatusCode: 200,
-
+					Headers:    tt.headers,
+					Body:       "response",
 				},
 			}
 
 			observed := MapResult(result)
-			
-			if observed.Tag != tt.tag {
-				t.Errorf("Tag = %q, want %q", observed.Tag, tt.tag)
-			}
-			if observed.Attribute != tt.attribute {
-				t.Errorf("Attribute = %q, want %q", observed.Attribute, tt.attribute)
-
+			if observed.Response.ContentType != tt.wantContentType {
+				t.Errorf("ContentType = %q, want %q", observed.Response.ContentType, tt.wantContentType)
 			}
 		})
 	}

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -440,7 +440,7 @@ func TestCrawl_EmptyURLReturnsError(t *testing.T) {
 func TestPageTimeout(t *testing.T) {
 	if PageTimeout != 30 {
 		t.Errorf("PageTimeout = %d, want 30", PageTimeout)
-  }
+	}
 }
 
 // TestCrawl_InvalidSchemeReturnsError tests that URLs without http/https scheme
@@ -618,7 +618,7 @@ func TestMapResult_JsluiceTagAndAttribute(t *testing.T) {
 				t.Errorf("Attribute = %q, want %q", observed.Attribute, tt.attribute)
 			}
 		})
-  }
+	}
 }
 
 // TestCrawl_SignalPath_ReturnsContextCanceled verifies that when the parent

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -343,13 +343,13 @@ func TestMaxResponseBodySize(t *testing.T) {
 	}
 }
 
-
 // TestPageTimeout verifies the PageTimeout constant value
 func TestPageTimeout(t *testing.T) {
 	if PageTimeout != 30 {
 		t.Errorf("PageTimeout = %d, want 30", PageTimeout)
 	}
 }
+
 // TestMapResult_TruncatesLargeResponseBody tests that response bodies exceeding MaxResponseBodySize get truncated
 func TestMapResult_TruncatesLargeResponseBody(t *testing.T) {
 	largeBody := make([]byte, MaxResponseBodySize+1000) // 1000 bytes over limit
@@ -438,5 +438,66 @@ func TestMapResult_SmallBodyNotTruncated(t *testing.T) {
 
 	if string(observed.Response.Body) != string(smallResponseBody) {
 		t.Errorf("Response body = %q, want %q (should not be truncated)", string(observed.Response.Body), string(smallResponseBody))
+	}
+}
+
+// TestMapResult_JsluiceTagAndAttribute tests that jsluice Tag and Attribute fields are propagated
+func TestMapResult_JsluiceTagAndAttribute(t *testing.T) {
+	tests := []struct {
+		name      string
+		tag       string
+		attribute string
+	}{
+		{
+			name:      "jsluice fetch endpoint",
+			tag:       "script",
+			attribute: "jsluice-fetch",
+		},
+		{
+			name:      "jsluice xhr endpoint",
+			tag:       "script",
+			attribute: "jsluice-xhr",
+		},
+		{
+			name:      "htmx hx-get attribute",
+			tag:       "div",
+			attribute: "hx-get",
+		},
+		{
+			name:      "htmx hx-post attribute",
+			tag:       "form",
+			attribute: "hx-post",
+		},
+		{
+			name:      "empty tag and attribute",
+			tag:       "",
+			attribute: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := output.Result{
+				Request: &navigation.Request{
+					Method:    "GET",
+					URL:       "https://example.com/api/endpoint",
+					Source:    "crawler",
+					Tag:       tt.tag,
+					Attribute: tt.attribute,
+				},
+				Response: &navigation.Response{
+					StatusCode: 200,
+				},
+			}
+
+			observed := MapResult(result)
+
+			if observed.Tag != tt.tag {
+				t.Errorf("Tag = %q, want %q", observed.Tag, tt.tag)
+			}
+			if observed.Attribute != tt.attribute {
+				t.Errorf("Attribute = %q, want %q", observed.Attribute, tt.attribute)
+			}
+		})
 	}
 }

--- a/pkg/crawl/types.go
+++ b/pkg/crawl/types.go
@@ -24,6 +24,8 @@ type ObservedRequest struct {
 	Body        []byte            `json:"body,omitempty"`
 	Response    ObservedResponse  `json:"response"`
 	Source      string            `json:"source"`
+	Tag         string            `json:"tag,omitempty"`
+	Attribute   string            `json:"attribute,omitempty"`
 	PageURL     string            `json:"page_url,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- Enables `ScrapeJSLuiceResponses` in the Katana crawler configuration alongside the existing `ScrapeJSResponses` option.
- This leverages jsluice's tree-sitter-based JavaScript parser to extract endpoints from JS response bodies, improving API path discovery from JavaScript bundles.

## Caveat
jsluice integration is currently provided transitively through Katana's `ScrapeJSLuiceResponses` option. If we move away from Katana as our crawling engine in the future, we will need to re-introduce jsluice (or an equivalent JS endpoint extraction library) as a direct dependency.

## Test plan
- [x] Run both `vespasian-main` and `vespasian-jsluice` binaries against the same target and compare captured endpoints
- [x] Verify jsluice-discovered paths are valid API endpoints (not false positives from string literals)
- [x] Confirm no performance regression on large JS-heavy targets