### PR TITLE
fix: use case-insensitive header lookup for Content-Type

### DIFF
--- a/pkg/classify/rest.go
+++ b/pkg/classify/rest.go
@@ -98,6 +98,14 @@ func (c *RESTClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, float6
 
 	// Rule 2: Content-type filter.
 	ct := strings.ToLower(req.Response.ContentType)
+	if ct == "" {
+		for k, v := range req.Response.Headers {
+			if strings.EqualFold(k, "content-type") {
+				ct = strings.ToLower(v)
+				break
+			}
+		}
+	}
 	// Strip charset parameters (e.g., "application/json; charset=utf-8").
 	if idx := strings.Index(ct, ";"); idx != -1 {
 		ct = strings.TrimSpace(ct[:idx])

--- a/pkg/classify/rest_test.go
+++ b/pkg/classify/rest_test.go
@@ -373,3 +373,103 @@ func TestRESTClassifier_ImplementsDetailedClassifier(t *testing.T) {
 	var c APIClassifier = &RESTClassifier{}
 	assert.Implements(t, (*DetailedClassifier)(nil), c)
 }
+
+// TestClassifyDetail_FallbackToHeaders verifies the classifier falls back to
+// Response.Headers when ContentType is empty, as happens when headers have
+// non-standard casing and ContentType wasn't populated by the crawler.
+func TestClassifyDetail_FallbackToHeaders(t *testing.T) {
+	c := &RESTClassifier{}
+
+	tests := []struct {
+		name          string
+		req           crawl.ObservedRequest
+		wantIsAPI     bool
+		wantMinConf   float64
+		wantReasonSub string
+	}{
+		{
+			name: "empty ContentType with lowercase content-type in Headers",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "",
+					Headers:     map[string]string{"content-type": "application/json"},
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   ContentTypeConfidence,
+			wantReasonSub: "content-type",
+		},
+		{
+			name: "empty ContentType with mixed-case Content-Type in Headers",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "",
+					Headers:     map[string]string{"Content-Type": "application/xml"},
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   ContentTypeConfidence,
+			wantReasonSub: "content-type",
+		},
+		{
+			name: "empty ContentType with no content-type in Headers",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "",
+					Headers:     map[string]string{"X-Request-Id": "abc123"},
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+		},
+		{
+			name: "empty ContentType with content-type charset in Headers",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "",
+					Headers:     map[string]string{"content-type": "application/json; charset=utf-8"},
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   ContentTypeConfidence,
+			wantReasonSub: "content-type",
+		},
+		{
+			name: "empty ContentType and nil Headers",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/data",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "",
+					Headers:     nil,
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isAPI, confidence, reason := c.ClassifyDetail(tt.req)
+			assert.Equal(t, tt.wantIsAPI, isAPI, "isAPI")
+			assert.GreaterOrEqual(t, confidence, tt.wantMinConf, "confidence lower bound")
+			if tt.wantReasonSub != "" {
+				assert.Contains(t, reason, tt.wantReasonSub, "reason")
+			}
+		})
+	}
+}

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -17,6 +17,7 @@ package crawl
 import (
 	"context"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -202,7 +203,7 @@ func MapResult(r output.Result) ObservedRequest {
 			StatusCode:  r.Response.StatusCode,
 			Headers:     map[string]string(r.Response.Headers),
 			Body:        []byte(r.Response.Body),
-			ContentType: r.Response.Headers["Content-Type"],
+			ContentType: getHeader(r.Response.Headers, "Content-Type"),
 		}
 		// Truncate response body if it exceeds MaxResponseBodySize
 		if len(req.Response.Body) > MaxResponseBodySize {
@@ -211,6 +212,16 @@ func MapResult(r output.Result) ObservedRequest {
 	}
 
 	return req
+}
+
+// getHeader performs a case-insensitive lookup of a header name in a map.
+func getHeader(headers map[string]string, name string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return v
+		}
+	}
+	return ""
 }
 
 // MapScope converts scope string to Katana FieldScope.

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -343,13 +343,13 @@ func TestMaxResponseBodySize(t *testing.T) {
 	}
 }
 
-
 // TestPageTimeout verifies the PageTimeout constant value
 func TestPageTimeout(t *testing.T) {
 	if PageTimeout != 30 {
 		t.Errorf("PageTimeout = %d, want 30", PageTimeout)
 	}
 }
+
 // TestMapResult_TruncatesLargeResponseBody tests that response bodies exceeding MaxResponseBodySize get truncated
 func TestMapResult_TruncatesLargeResponseBody(t *testing.T) {
 	largeBody := make([]byte, MaxResponseBodySize+1000) // 1000 bytes over limit
@@ -438,5 +438,63 @@ func TestMapResult_SmallBodyNotTruncated(t *testing.T) {
 
 	if string(observed.Response.Body) != string(smallResponseBody) {
 		t.Errorf("Response body = %q, want %q (should not be truncated)", string(observed.Response.Body), string(smallResponseBody))
+	}
+}
+
+// TestMapResult_LowercaseContentType tests that MapResult extracts ContentType
+// from lowercase header keys, as Katana normalizes response headers to lowercase.
+func TestMapResult_LowercaseContentType(t *testing.T) {
+	tests := []struct {
+		name            string
+		headers         navigation.Headers
+		wantContentType string
+	}{
+		{
+			name:            "lowercase content-type from Katana",
+			headers:         navigation.Headers{"content-type": "application/json"},
+			wantContentType: "application/json",
+		},
+		{
+			name:            "title-case Content-Type",
+			headers:         navigation.Headers{"Content-Type": "text/html"},
+			wantContentType: "text/html",
+		},
+		{
+			name:            "uppercase CONTENT-TYPE",
+			headers:         navigation.Headers{"CONTENT-TYPE": "application/xml"},
+			wantContentType: "application/xml",
+		},
+		{
+			name:            "no content-type header",
+			headers:         navigation.Headers{"X-Custom": "value"},
+			wantContentType: "",
+		},
+		{
+			name:            "empty headers",
+			headers:         navigation.Headers{},
+			wantContentType: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := output.Result{
+				Request: &navigation.Request{
+					Method: "GET",
+					URL:    "https://example.com/api/data",
+				},
+				Response: &navigation.Response{
+					StatusCode: 200,
+					Headers:    tt.headers,
+					Body:       "response",
+				},
+			}
+
+			observed := MapResult(result)
+
+			if observed.Response.ContentType != tt.wantContentType {
+				t.Errorf("ContentType = %q, want %q", observed.Response.ContentType, tt.wantContentType)
+			}
+		})
 	}
 }

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -436,12 +436,13 @@ func TestCrawl_EmptyURLReturnsError(t *testing.T) {
 	}
 }
 
-<<<<<<< fix/content-type-header-case
 // TestPageTimeout verifies the PageTimeout constant value
 func TestPageTimeout(t *testing.T) {
 	if PageTimeout != 30 {
 		t.Errorf("PageTimeout = %d, want 30", PageTimeout)
-=======
+	}
+}
+
 // TestCrawl_InvalidSchemeReturnsError tests that URLs without http/https scheme
 // are rejected, including non-HTTP schemes that could be SSRF vectors.
 func TestCrawl_InvalidSchemeReturnsError(t *testing.T) {
@@ -465,7 +466,6 @@ func TestCrawl_InvalidSchemeReturnsError(t *testing.T) {
 				t.Errorf("unexpected error message: %v", err)
 			}
 		})
->>>>>>> main
 	}
 }
 
@@ -560,7 +560,6 @@ func TestMapResult_SmallBodyNotTruncated(t *testing.T) {
 	}
 }
 
-<<<<<<< fix/content-type-header-case
 // TestMapResult_LowercaseContentType tests that MapResult extracts ContentType
 // from lowercase header keys, as Katana normalizes response headers to lowercase.
 func TestMapResult_LowercaseContentType(t *testing.T) {
@@ -616,7 +615,9 @@ func TestMapResult_LowercaseContentType(t *testing.T) {
 				t.Errorf("ContentType = %q, want %q", observed.Response.ContentType, tt.wantContentType)
 			}
 		})
-=======
+	}
+}
+
 // TestCrawl_SignalPath_ReturnsContextCanceled verifies that when the parent
 // context is canceled (simulating SIGINT/SIGTERM), Crawl() returns
 // context.Canceled and writes an interrupt message to Stderr.
@@ -712,6 +713,5 @@ func TestCrawl_MaxPagesPath_ReturnsNoError(t *testing.T) {
 	}
 	if len(results) > 2 {
 		t.Errorf("Crawl() returned %d results, want at most 2 (MaxPages)", len(results))
->>>>>>> main
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes a bug where `MapResult` reads `r.Response.Headers["Content-Type"]` (title-case) but Katana normalizes headers to lowercase (`content-type`), causing `ContentType` to always be empty
- Adds a `getHeader` helper for case-insensitive header lookup in `pkg/crawl/crawler.go`
- Adds a fallback in the REST classifier (`pkg/classify/rest.go`) to check `response.Headers` when `ContentType` is empty, ensuring backward compatibility with capture files generated before this fix

## Impact
Without this fix, the `generate rest` command produces empty output for most capture files — the content-type heuristic (confidence 0.8) never fires, and the path heuristic alone (0.15) falls below the default 0.5 threshold. In testing, this caused 0/28 requests to be classified from a valid capture containing 11 API endpoints.

## Test plan
- [x] `gofmt` and `go vet` pass with no issues
- [x] All existing unit tests pass (`go test ./pkg/crawl/... ./pkg/classify/...`)
- [x] `generate rest capture-jsluice.json -v` now classifies 11 API requests (was 0)
- [x] Verify with additional capture files from different crawl targets

Resolves LAB-1412.