### PR TITLE
fix: inject Bearer token into browser localStorage for SPA auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.13
 require (
 	github.com/alecthomas/kong v1.14.0
 	github.com/getkin/kin-openapi v0.133.0
+	github.com/go-rod/rod v0.116.2
 	github.com/projectdiscovery/goflags v0.1.74
 	github.com/projectdiscovery/katana v1.4.0
 	github.com/stretchr/testify v1.11.1
@@ -40,7 +41,6 @@ require (
 	github.com/gaissmai/bart v0.26.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-rod/rod v0.116.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/pkg/crawl/auth.go
+++ b/pkg/crawl/auth.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/go-rod/rod/lib/proto"
+)
+
+// commonAuthKeys are localStorage key names commonly used by SPAs to store
+// auth tokens. When a Bearer token is detected in the -H flag, the token
+// value is injected into all of these keys before crawling.
+var commonAuthKeys = []string{
+	"auth",
+	"token",
+	"access_token",
+	"accessToken",
+	"auth_token",
+	"authToken",
+	"jwt",
+	"jwt_token",
+	"jwtToken",
+	"bearer_token",
+	"bearerToken",
+	"id_token",
+	"idToken",
+}
+
+// extractBearerToken extracts a Bearer token from the headers map.
+// Returns the token value (without "Bearer " prefix) or empty string if not found.
+func extractBearerToken(headers map[string]string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, "Authorization") {
+			value = strings.TrimSpace(value)
+			if strings.HasPrefix(value, "Bearer ") {
+				return strings.TrimPrefix(value, "Bearer ")
+			}
+		}
+	}
+	return ""
+}
+
+// preSeedBrowserAuth creates a Chrome profile directory with auth tokens
+// pre-populated in localStorage for the given target origin. This enables
+// headless crawling of SPAs that gate API calls on localStorage auth tokens.
+//
+// The caller is responsible for cleaning up the returned directory.
+// Returns the path to the Chrome data directory, or an error.
+func preSeedBrowserAuth(targetURL string, token string) (string, error) {
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return "", fmt.Errorf("parse target URL: %w", err)
+	}
+	origin := u.Scheme + "://" + u.Host
+
+	dataDir, err := os.MkdirTemp("", "vespasian-chrome-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+
+	cleanup := true
+	defer func() {
+		if cleanup {
+			os.RemoveAll(dataDir)
+		}
+	}()
+
+	l := launcher.New().
+		UserDataDir(dataDir).
+		Headless(true).
+		Set("no-sandbox").
+		Set("disable-gpu")
+
+	browserURL, err := l.Launch()
+	if err != nil {
+		return "", fmt.Errorf("launch browser: %w", err)
+	}
+
+	browser := rod.New().ControlURL(browserURL)
+	if err := browser.Connect(); err != nil {
+		return "", fmt.Errorf("connect to browser: %w", err)
+	}
+	defer browser.MustClose()
+
+	page, err := browser.Page(proto.TargetCreateTarget{URL: origin})
+	if err != nil {
+		return "", fmt.Errorf("open page: %w", err)
+	}
+
+	if err := page.WaitLoad(); err != nil {
+		slog.Warn("page did not load during auth pre-seed", "url", origin, "error", err)
+		// Continue anyway — localStorage injection may still work.
+	}
+
+	// Inject the Bearer token into common localStorage key names.
+	// SPAs use various key names; injecting into all common ones maximizes
+	// compatibility without requiring app-specific configuration.
+	for _, key := range commonAuthKeys {
+		_, evalErr := page.Eval(`(key, val) => { try { localStorage.setItem(key, val); } catch(e) {} }`, key, token)
+		if evalErr != nil {
+			slog.Debug("failed to set localStorage key", "key", key, "error", evalErr)
+		}
+	}
+
+	// Also inject as "Bearer <token>" variants for apps that store the full header value.
+	bearerValue := "Bearer " + token
+	for _, key := range []string{"auth", "token", "authorization"} {
+		_, evalErr := page.Eval(`(key, val) => { try { localStorage.setItem(key, val); } catch(e) {} }`, key+"_header", bearerValue)
+		if evalErr != nil {
+			slog.Debug("failed to set localStorage header key", "key", key+"_header", "error", evalErr)
+		}
+	}
+
+	cleanup = false
+	return dataDir, nil
+}

--- a/pkg/crawl/auth_test.go
+++ b/pkg/crawl/auth_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExtractBearerToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{
+			name:    "standard bearer token",
+			headers: map[string]string{"Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.test"},
+			want:    "eyJhbGciOiJIUzI1NiJ9.test",
+		},
+		{
+			name:    "case-insensitive header name",
+			headers: map[string]string{"authorization": "Bearer my-token-123"},
+			want:    "my-token-123",
+		},
+		{
+			name:    "mixed case header name",
+			headers: map[string]string{"AUTHORIZATION": "Bearer TOKEN"},
+			want:    "TOKEN",
+		},
+		{
+			name:    "no authorization header",
+			headers: map[string]string{"Content-Type": "application/json"},
+			want:    "",
+		},
+		{
+			name:    "empty headers",
+			headers: map[string]string{},
+			want:    "",
+		},
+		{
+			name:    "nil headers",
+			headers: nil,
+			want:    "",
+		},
+		{
+			name:    "basic auth (not bearer)",
+			headers: map[string]string{"Authorization": "Basic dXNlcjpwYXNz"},
+			want:    "",
+		},
+		{
+			name:    "bearer with extra whitespace",
+			headers: map[string]string{"Authorization": "  Bearer   spaced-token"},
+			want:    "  spaced-token",
+		},
+		{
+			name: "bearer among multiple headers",
+			headers: map[string]string{
+				"Content-Type":  "application/json",
+				"Authorization": "Bearer multi-header-token",
+				"User-Agent":    "vespasian/1.0",
+			},
+			want: "multi-header-token",
+		},
+		{
+			name:    "empty bearer value",
+			headers: map[string]string{"Authorization": "Bearer "},
+			want:    "",
+		},
+		{
+			name:    "just Bearer keyword",
+			headers: map[string]string{"Authorization": "Bearer"},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractBearerToken(tt.headers)
+			if got != tt.want {
+				t.Errorf("extractBearerToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommonAuthKeys(t *testing.T) {
+	// Verify that commonAuthKeys is non-empty and contains expected keys.
+	if len(commonAuthKeys) == 0 {
+		t.Fatal("commonAuthKeys should not be empty")
+	}
+
+	expected := map[string]bool{
+		"auth":         true,
+		"token":        true,
+		"access_token": true,
+		"jwt":          true,
+	}
+	found := make(map[string]bool)
+	for _, key := range commonAuthKeys {
+		found[key] = true
+	}
+	for key := range expected {
+		if !found[key] {
+			t.Errorf("commonAuthKeys missing expected key %q", key)
+		}
+	}
+}
+
+// TestPreSeedBrowserAuth_CreatesDataDir verifies that preSeedBrowserAuth
+// creates a Chrome data directory and returns a valid path.
+// This test requires Chrome to be installed and launches a headless instance.
+func TestPreSeedBrowserAuth_CreatesDataDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping browser test in short mode")
+	}
+
+	dataDir, err := preSeedBrowserAuth("http://example.com", "test-token-123")
+	if err != nil {
+		t.Fatalf("preSeedBrowserAuth() error: %v", err)
+	}
+	defer os.RemoveAll(dataDir)
+
+	// Verify the directory exists.
+	info, err := os.Stat(dataDir)
+	if err != nil {
+		t.Fatalf("data dir stat error: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("data dir is not a directory: %s", dataDir)
+	}
+}
+
+// TestPreSeedBrowserAuth_InvalidURL verifies that an invalid URL returns an error.
+func TestPreSeedBrowserAuth_InvalidURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping browser test in short mode")
+	}
+
+	_, err := preSeedBrowserAuth("://invalid", "test-token")
+	if err == nil {
+		t.Error("expected error for invalid URL, got nil")
+	}
+}

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -17,7 +17,9 @@ package crawl
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -84,6 +86,25 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	var mu sync.Mutex
 	pageCount := 0
 
+	// When headless crawling with a Bearer token, pre-seed the browser's
+	// localStorage with the token. SPAs commonly gate API calls on
+	// localStorage auth tokens — without this, the browser's JavaScript
+	// won't make authenticated fetch/XHR requests even though Katana
+	// injects the -H header at the CDP network level.
+	var chromeDataDir string
+	if c.opts.Headless {
+		if bearerToken := extractBearerToken(c.opts.Headers); bearerToken != "" {
+			dataDir, seedErr := preSeedBrowserAuth(targetURL, bearerToken)
+			if seedErr != nil {
+				slog.Warn("failed to pre-seed browser auth, crawl will proceed without localStorage injection",
+					"error", seedErr)
+			} else {
+				chromeDataDir = dataDir
+				defer func() { _ = os.RemoveAll(chromeDataDir) }()
+			}
+		}
+	}
+
 	// Build Katana options
 	katanaOpts := &types.Options{
 		MaxDepth:          c.opts.Depth,
@@ -101,6 +122,8 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		ScrapeJSResponses: true,
 		XhrExtraction:     true,
 		Silent:            true,
+		ChromeDataDir:     chromeDataDir,
+		HeadlessNoIncognito: chromeDataDir != "",
 		OnResult: func(result output.Result) {
 			mu.Lock()
 			defer mu.Unlock()


### PR DESCRIPTION
## Summary

- When crawling in headless mode with `-H "Authorization: Bearer <token>"`, the Bearer token is now automatically injected into the browser's `localStorage` before crawling begins
- Targets common localStorage key names used by SPAs: `auth`, `token`, `access_token`, `jwt`, `accessToken`, `authToken`, etc.
- Uses a short-lived go-rod browser session to pre-seed a Chrome profile, which Katana then reuses via `ChromeDataDir`
- No new CLI flags required — enhances existing `-H` behavior automatically

## Problem

SPAs like DVAPI gate API calls on `localStorage` auth tokens. Even though Katana already injects `-H` headers at the CDP network level (`Network.setExtraHTTPHeaders`), the SPA's JavaScript checks `localStorage.getItem('auth')` before making fetch/XHR calls. If localStorage is empty, the JS redirects to login and never fires API requests — resulting in 0 API endpoints discovered during crawling.

## How it works

1. Detects `Authorization: Bearer <token>` in the `-H` headers
2. Before Katana starts, launches a headless Chrome with a temp profile directory
3. Navigates to the target origin and injects the token into common localStorage keys
4. Closes the pre-seed browser session
5. Passes the profile directory to Katana via `ChromeDataDir` + `HeadlessNoIncognito`
6. Katana's crawl inherits the pre-populated localStorage
7. Temp directory is cleaned up after crawl completes

## Test plan

- [x] `TestExtractBearerToken` — 11 cases covering standard, case-insensitive, missing, Basic auth, edge cases
- [x] `TestCommonAuthKeys` — verifies expected keys are present
- [x] `TestPreSeedBrowserAuth_CreatesDataDir` — integration test launching real headless Chrome
- [x] `TestPreSeedBrowserAuth_InvalidURL` — error handling for invalid URLs
- [x] Full test suite passes (`go test ./...`)