### PR TITLE
feat: add --deduplicate flag to generate and scan commands

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -466,12 +466,13 @@ func (c *ImportCmd) Run() error {
 
 // GenerateCmd generates API specifications from captured traffic.
 type GenerateCmd struct {
-	APIType    string  `arg:"" enum:"rest,wsdl" help:"API type to generate"`
-	Capture    string  `arg:"" help:"Capture file path"`
-	Output     string  `short:"o" help:"Output file path"`
-	Confidence float64 `default:"0.5" help:"Minimum confidence threshold"`
-	Probe      bool    `default:"true" help:"Enable endpoint probing"`
-	Verbose    bool    `short:"v" help:"Enable verbose logging"`
+	APIType     string  `arg:"" enum:"rest,wsdl" help:"API type to generate"`
+	Capture     string  `arg:"" help:"Capture file path"`
+	Output      string  `short:"o" help:"Output file path"`
+	Confidence  float64 `default:"0.5" help:"Minimum confidence threshold"`
+	Probe       bool    `default:"true" help:"Enable endpoint probing"`
+	Deduplicate bool    `default:"true" help:"Deduplicate classified endpoints before probing (default: true)"`
+	Verbose     bool    `short:"v" help:"Enable verbose logging"`
 }
 
 // maxCaptureSize is the maximum capture file size (100MB).
@@ -510,7 +511,7 @@ func (c *GenerateCmd) Run() (err error) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	spec, err := generateSpec(ctx, requests, c.APIType, c.Confidence, c.Probe, c.Verbose)
+	spec, err := generateSpec(ctx, requests, c.APIType, c.Confidence, c.Probe, c.Deduplicate, c.Verbose)
 	if err != nil {
 		return err
 	}
@@ -523,9 +524,10 @@ func (c *GenerateCmd) Run() (err error) {
 
 // ScanCmd runs the full pipeline: crawl, classify, and generate.
 type ScanCmd struct {
-	URL        string  `arg:"" help:"Target URL to scan"`
-	Confidence float64 `default:"0.5" help:"Minimum confidence threshold"`
-	Probe      bool    `default:"true" help:"Enable endpoint probing"`
+	URL         string  `arg:"" help:"Target URL to scan"`
+	Confidence  float64 `default:"0.5" help:"Minimum confidence threshold"`
+	Probe       bool    `default:"true" help:"Enable endpoint probing"`
+	Deduplicate bool    `default:"true" help:"Deduplicate classified endpoints before probing (default: true)"`
 	CrawlOptions
 }
 
@@ -573,7 +575,7 @@ func (c *ScanCmd) Run() error {
 	genCtx, genStop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer genStop()
 
-	spec, err := generateSpec(genCtx, requests, "rest", c.Confidence, c.Probe, c.Verbose)
+	spec, err := generateSpec(genCtx, requests, "rest", c.Confidence, c.Probe, c.Deduplicate, c.Verbose)
 	if err != nil {
 		return err
 	}
@@ -604,12 +606,15 @@ func main() {
 }
 
 // generateSpec runs the classify → probe → generate pipeline.
-func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, apiType string, confidence float64, doProbe bool, verbose bool) ([]byte, error) {
+func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, apiType string, confidence float64, doProbe bool, deduplicate bool, verbose bool) ([]byte, error) {
 	classifiers := classifiersForType(apiType)
 	if classifiers == nil {
 		return nil, fmt.Errorf("unsupported API type: %q", apiType)
 	}
-	classified := classify.Deduplicate(classify.RunClassifiers(classifiers, requests, confidence))
+	classified := classify.RunClassifiers(classifiers, requests, confidence)
+	if deduplicate {
+		classified = classify.Deduplicate(classified)
+	}
 
 	if verbose {
 		fmt.Fprintf(os.Stderr, "classified %d API requests (threshold=%.2f)\n", len(classified), confidence)

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -471,7 +471,7 @@ type GenerateCmd struct {
 	Output      string  `short:"o" help:"Output file path"`
 	Confidence  float64 `default:"0.5" help:"Minimum confidence threshold"`
 	Probe       bool    `default:"true" help:"Enable endpoint probing"`
-	Deduplicate bool    `default:"true" help:"Deduplicate classified endpoints before probing (default: true)"`
+	Deduplicate bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
 	Verbose     bool    `short:"v" help:"Enable verbose logging"`
 }
 
@@ -527,7 +527,7 @@ type ScanCmd struct {
 	URL         string  `arg:"" help:"Target URL to scan"`
 	Confidence  float64 `default:"0.5" help:"Minimum confidence threshold"`
 	Probe       bool    `default:"true" help:"Enable endpoint probing"`
-	Deduplicate bool    `default:"true" help:"Deduplicate classified endpoints before probing (default: true)"`
+	Deduplicate bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
 	CrawlOptions
 }
 

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -435,18 +435,20 @@ func TestGenerateSpec(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		apiType    string
-		probe      bool
-		verbose    bool
-		wantErrStr string
-		wantErr    bool
+		name        string
+		apiType     string
+		probe       bool
+		deduplicate bool
+		verbose     bool
+		wantErrStr  string
+		wantErr     bool
 	}{
 		{
-			name:    "rest with valid requests, probe disabled",
-			apiType: "rest",
-			probe:   false,
-			wantErr: false,
+			name:        "rest with valid requests, probe disabled",
+			apiType:     "rest",
+			probe:       false,
+			deduplicate: true,
+			wantErr:     false,
 		},
 		{
 			name:       "unknown api type",
@@ -456,23 +458,32 @@ func TestGenerateSpec(t *testing.T) {
 			wantErrStr: "unsupported API type",
 		},
 		{
-			name:    "probe enabled with real implementations",
-			apiType: "rest",
-			probe:   true,
-			wantErr: false,
+			name:        "probe enabled with real implementations",
+			apiType:     "rest",
+			probe:       true,
+			deduplicate: true,
+			wantErr:     false,
 		},
 		{
-			name:    "verbose logging",
-			apiType: "rest",
-			probe:   false,
-			verbose: true,
-			wantErr: false,
+			name:        "verbose logging",
+			apiType:     "rest",
+			probe:       false,
+			deduplicate: true,
+			verbose:     true,
+			wantErr:     false,
+		},
+		{
+			name:        "rest without deduplication",
+			apiType:     "rest",
+			probe:       false,
+			deduplicate: false,
+			wantErr:     false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := generateSpec(context.Background(), requests, tt.apiType, 0.5, tt.probe, true, tt.verbose)
+			_, err := generateSpec(context.Background(), requests, tt.apiType, 0.5, tt.probe, tt.deduplicate, tt.verbose)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("generateSpec() expected error containing %q, got nil", tt.wantErrStr)
@@ -532,9 +543,10 @@ func TestGenerateCmdRun_ValidCapture(t *testing.T) {
 	_ = f.Close()
 
 	cmd := &GenerateCmd{
-		APIType: "rest",
-		Capture: capturePath,
-		Probe:   false,
+		APIType:     "rest",
+		Capture:     capturePath,
+		Probe:       false,
+		Deduplicate: true,
 	}
 	err = cmd.Run()
 	if err != nil {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -472,7 +472,7 @@ func TestGenerateSpec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := generateSpec(context.Background(), requests, tt.apiType, 0.5, tt.probe, tt.verbose)
+			_, err := generateSpec(context.Background(), requests, tt.apiType, 0.5, tt.probe, true, tt.verbose)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("generateSpec() expected error containing %q, got nil", tt.wantErrStr)
@@ -493,7 +493,7 @@ func TestGenerateSpec(t *testing.T) {
 // With real implementations, empty requests produce no classified endpoints,
 // so the generator returns nil spec with no error.
 func TestGenerateSpec_EmptyRequests(t *testing.T) {
-	spec, err := generateSpec(context.Background(), []crawl.ObservedRequest{}, "rest", 0.5, false, false)
+	spec, err := generateSpec(context.Background(), []crawl.ObservedRequest{}, "rest", 0.5, false, true, false)
 	if err != nil {
 		t.Fatalf("generateSpec() unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Description

Allow disabling deduplication so all classified requests are preserved. This is needed for GraphQL where all requests share the same METHOD:path key, causing the deduplicator to collapse them into a single entry.

## Changes

- Added Deduplicate bool field to both GenerateCmd and ScanCmd structs, defaulting to true, with CLI help text
- Updated generateSpec function signature to accept a new deduplicate bool parameter
- Made deduplication conditional in generateSpec — classify.Deduplicate() is now only called when deduplicate is true, instead of always running
- Passed c.Deduplicate through from both GenerateCmd.Run() and ScanCmd.Run() to generateSpec()
- Updated test call sites in TestGenerateSpec and TestGenerateSpec_EmptyRequests to pass true for the new deduplicate parameter
- Re-aligned struct field tags in GenerateCmd and ScanCmd to accommodate the new longer field name

The motivation is to support GraphQL APIs where all requests share the same METHOD:path key, causing the deduplicator to incorrectly collapse distinct operations into a single entry.

## Testing

- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manual verification (describe below)

Deduplication works well for GraphQL SDL generation.

## Checklist

- [ ] Code follows project conventions
- [ ] Tests added/updated for new functionality
- [ ] Documentation updated (if applicable)
