### PR TITLE
feat: graphql support

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -761,7 +761,7 @@ func classifiersForType(apiType string) []classify.APIClassifier {
 		return []classify.APIClassifier{&classify.RESTClassifier{}}
 	case apiTypeWSDL:
 		return []classify.APIClassifier{&classify.WSDLClassifier{}}
-	case "graphql":
+	case apiTypeGraphQL:
 		return []classify.APIClassifier{&classify.GraphQLClassifier{}}
 	default:
 		return nil
@@ -779,12 +779,11 @@ func classifiersForType(apiType string) []classify.APIClassifier {
 // detectAPIType only needs to answer "which generator?", while generateSpec's
 // pass produces the full ClassifiedRequest slice needed for generation.
 func detectAPIType(requests []crawl.ObservedRequest, threshold float64) string {
-	// Currently checks WSDL vs REST. Add GraphQL check here when
-	// GraphQLClassifier is available.
 	wsdlClassifier := &classify.WSDLClassifier{}
 	restClassifier := &classify.RESTClassifier{}
+	graphqlClassifier := &classify.GraphQLClassifier{}
 
-	var wsdlCount, restCount int
+	var wsdlCount, restCount, graphqlCount int
 	for _, req := range requests {
 		if isAPI, confidence := wsdlClassifier.Classify(req); isAPI && confidence >= threshold {
 			wsdlCount++
@@ -792,8 +791,15 @@ func detectAPIType(requests []crawl.ObservedRequest, threshold float64) string {
 		if isAPI, confidence := restClassifier.Classify(req); isAPI && confidence >= threshold {
 			restCount++
 		}
+		if isAPI, confidence := graphqlClassifier.Classify(req); isAPI && confidence >= threshold {
+			graphqlCount++
+		}
 	}
 
+	// GraphQL wins when it has matches and at least as many as both others.
+	if graphqlCount > 0 && graphqlCount >= wsdlCount && graphqlCount >= restCount {
+		return apiTypeGraphQL
+	}
 	// WSDL wins only when it has matches and they represent the majority
 	// of classified traffic (or there are no REST matches at all).
 	if wsdlCount > 0 && wsdlCount >= restCount {

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -724,6 +724,8 @@ func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, opts ge
 		switch opts.APIType {
 		case apiTypeWSDL:
 			strategies = []probe.ProbeStrategy{probe.NewWSDLProbe(cfg)}
+		case apiTypeGraphQL:
+			strategies = []probe.ProbeStrategy{probe.NewGraphQLProbe(cfg)}
 		default:
 			strategies = []probe.ProbeStrategy{
 				probe.NewOptionsProbe(cfg),

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -759,6 +759,8 @@ func classifiersForType(apiType string) []classify.APIClassifier {
 		return []classify.APIClassifier{&classify.RESTClassifier{}}
 	case apiTypeWSDL:
 		return []classify.APIClassifier{&classify.WSDLClassifier{}}
+	case "graphql":
+		return []classify.APIClassifier{&classify.GraphQLClassifier{}}
 	default:
 		return nil
 	}

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -1425,6 +1425,114 @@ func TestDetectAPIType(t *testing.T) {
 			threshold: 0.90,
 			want:      apiTypeREST,
 		},
+		{
+			name: "GraphQL POST to /graphql returns graphql",
+			requests: []crawl.ObservedRequest{
+				{
+					Method: "POST",
+					URL:    "https://example.com/graphql",
+					Headers: map[string]string{
+						"Content-Type": "application/json",
+					},
+					Body: []byte(`{"query":"{ users { id name } }"}`),
+					Response: crawl.ObservedResponse{
+						StatusCode:  200,
+						ContentType: "application/json",
+						Body:        []byte(`{"data":{"users":[{"id":"1","name":"Alice"}]}}`),
+					},
+				},
+			},
+			threshold: 0.5,
+			want:      apiTypeGraphQL,
+		},
+		{
+			name: "majority GraphQL traffic returns graphql",
+			requests: []crawl.ObservedRequest{
+				{
+					Method: "POST",
+					URL:    "https://example.com/graphql",
+					Headers: map[string]string{
+						"Content-Type": "application/json",
+					},
+					Body: []byte(`{"query":"{ users { id } }"}`),
+					Response: crawl.ObservedResponse{
+						StatusCode:  200,
+						ContentType: "application/json",
+						Body:        []byte(`{"data":{"users":[]}}`),
+					},
+				},
+				{
+					Method: "POST",
+					URL:    "https://example.com/graphql",
+					Headers: map[string]string{
+						"Content-Type": "application/json",
+					},
+					Body: []byte(`{"query":"mutation { createUser(name: \"Bob\") { id } }"}`),
+					Response: crawl.ObservedResponse{
+						StatusCode:  200,
+						ContentType: "application/json",
+						Body:        []byte(`{"data":{"createUser":{"id":"2"}}}`),
+					},
+				},
+				{
+					// Non-API request (HTML page) — REST classifier won't match this,
+					// so GraphQL count (2) ties REST count (2) and GraphQL wins via >=.
+					Method: "GET",
+					URL:    "https://example.com/",
+					Response: crawl.ObservedResponse{
+						StatusCode:  200,
+						ContentType: "text/html",
+						Body:        []byte(`<html><body>Welcome</body></html>`),
+					},
+				},
+			},
+			threshold: 0.5,
+			want:      apiTypeGraphQL,
+		},
+		{
+			name: "minority GraphQL in mostly REST traffic returns rest",
+			requests: []crawl.ObservedRequest{
+				{
+					Method: "GET",
+					URL:    "https://example.com/api/users",
+					Headers: map[string]string{
+						"Accept": "application/json",
+					},
+					Response: crawl.ObservedResponse{
+						StatusCode:  200,
+						ContentType: "application/json",
+						Body:        []byte(`[{"id":1}]`),
+					},
+				},
+				{
+					Method: "GET",
+					URL:    "https://example.com/api/posts",
+					Headers: map[string]string{
+						"Accept": "application/json",
+					},
+					Response: crawl.ObservedResponse{
+						StatusCode:  200,
+						ContentType: "application/json",
+						Body:        []byte(`[{"id":1}]`),
+					},
+				},
+				{
+					Method: "POST",
+					URL:    "https://example.com/graphql",
+					Headers: map[string]string{
+						"Content-Type": "application/json",
+					},
+					Body: []byte(`{"query":"{ users { id } }"}`),
+					Response: crawl.ObservedResponse{
+						StatusCode:  200,
+						ContentType: "application/json",
+						Body:        []byte(`{"data":{"users":[]}}`),
+					},
+				},
+			},
+			threshold: 0.5,
+			want:      apiTypeREST,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -347,7 +347,7 @@ func TestClassifiersForType(t *testing.T) {
 	}{
 		{"rest returns classifier", "rest", 1},
 		{"unknown returns nil", "unknown", 0},
-		{"graphql returns nil", "graphql", 0},
+		{"graphql returns classifier", "graphql", 1},
 	}
 
 	for _, tt := range tests {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -497,10 +497,8 @@ func TestGenerateSpec(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.wantErrStr) {
 					t.Errorf("generateSpec() error = %q, want error containing %q", err.Error(), tt.wantErrStr)
 				}
-			} else {
-				if err != nil {
-					t.Errorf("generateSpec() unexpected error: %v", err)
-				}
+			} else if err != nil {
+				t.Errorf("generateSpec() unexpected error: %v", err)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809 // indirect
 	github.com/PuerkitoBio/goquery v1.11.0 // indirect
 	github.com/STARRY-S/zip v0.2.3 // indirect
+	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/akrylysov/pogreb v0.10.1 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
@@ -110,6 +111,7 @@ require (
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
+	github.com/vektah/gqlparser/v2 v2.5.32 // indirect
 	github.com/vulncheck-oss/go-exploit v1.51.0 // indirect
 	github.com/weppos/publicsuffix-go v0.40.3-0.20250408071509-6074bbe7fd39 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHf
 github.com/RumbleDiscovery/rumble-tools v0.0.0-20201105153123-f2adbb3244d2/go.mod h1:jD2+mU+E2SZUuAOHZvZj4xP4frlOo+N/YrXDvASFhkE=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=
+github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
+github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/akrylysov/pogreb v0.10.1 h1:FqlR8VR7uCbJdfUob916tPM+idpKgeESDXOA1K0DK4w=
 github.com/akrylysov/pogreb v0.10.1/go.mod h1:pNs6QmpQ1UlTJKDezuRWmaqkgUE2TuU0YTWyqJZ7+lI=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
@@ -356,6 +358,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/vektah/gqlparser/v2 v2.5.32 h1:k9QPJd4sEDTL+qB4ncPLflqTJ3MmjB9SrVzJrawpFSc=
+github.com/vektah/gqlparser/v2 v2.5.32/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 github.com/vulncheck-oss/go-exploit v1.51.0 h1:HTmJ4Q94tbEDPb35mQZn6qMg4rT+Sw9n+L7g3Pjr+3o=
 github.com/vulncheck-oss/go-exploit v1.51.0/go.mod h1:J28w0dLnA6DnCrnBm9Sbt6smX8lvztnnN2wCXy7No6c=
 github.com/weppos/publicsuffix-go v0.13.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -17,9 +17,10 @@ package classify
 import (
 	"testing"
 
-	"github.com/praetorian-inc/vespasian/pkg/crawl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
 )
 
 // stubClassifier is a simple classifier for testing that returns fixed values.

--- a/pkg/classify/graphql.go
+++ b/pkg/classify/graphql.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package classify
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+// Confidence scores for GraphQL classification signals.
+const (
+	GraphQLPathConfidence      = 0.70 // Path contains /graphql
+	GraphQLBodyConfidence      = 0.85 // Request body has query/mutation field
+	GraphQLResponseConfidence  = 0.80 // Response has data/errors top-level keys
+	GraphQLFullMatchConfidence = 0.95 // Path + body signals combined
+)
+
+// graphqlResponseContentTypes lists content types that may carry GraphQL responses.
+var graphqlResponseContentTypes = []string{
+	"application/json",
+	"application/graphql+json",
+	"application/graphql-response+json",
+}
+
+// GraphQLClassifier classifies GraphQL API requests using ordered heuristic rules.
+type GraphQLClassifier struct{}
+
+// Name returns the classifier name.
+func (c *GraphQLClassifier) Name() string {
+	return "graphql"
+}
+
+// Classify determines if the request is a GraphQL API call.
+func (c *GraphQLClassifier) Classify(req crawl.ObservedRequest) (bool, float64) {
+	isAPI, confidence, _ := c.ClassifyDetail(req)
+	return isAPI, confidence
+}
+
+// ClassifyDetail returns classification result with a detailed reason string.
+//
+// Signals applied in order, taking max confidence (not additive):
+//  1. Static asset exclusion → (false, 0, "")
+//  2. Path contains /graphql → confidence 0.70
+//  3. Request body has GraphQL query structure (POST only) → confidence 0.85
+//     If path also matched → confidence 0.95
+//  4. Response has data/errors top-level keys → confidence max(current, 0.80)
+func (c *GraphQLClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, float64, string) {
+	parsedURL, err := url.Parse(req.URL)
+	if err != nil {
+		return false, 0, ""
+	}
+
+	lowerPath := strings.ToLower(parsedURL.Path)
+
+	// Rule 1: Static asset exclusion.
+	for _, ext := range staticExtensions {
+		if strings.HasSuffix(lowerPath, ext) {
+			return false, 0, ""
+		}
+	}
+
+	var confidence float64
+	var reason string
+	pathMatched := false
+
+	// Rule 2: Path heuristic.
+	if strings.Contains(lowerPath, "/graphql") {
+		confidence = GraphQLPathConfidence
+		reason = "graphql-path"
+		pathMatched = true
+	}
+
+	// Rule 3: Request body analysis (POST only).
+	if strings.EqualFold(req.Method, "POST") && len(req.Body) > 0 {
+		if b, ok := firstNonSpace(req.Body); ok && b == '{' {
+			if hasGraphQLBody(req.Body) {
+				if pathMatched {
+					confidence = GraphQLFullMatchConfidence
+					reason = "graphql-path+graphql-body"
+				} else {
+					if confidence < GraphQLBodyConfidence {
+						confidence = GraphQLBodyConfidence
+					}
+					if reason == "" {
+						reason = "graphql-body"
+					} else {
+						reason += "+graphql-body"
+					}
+				}
+			}
+		}
+	}
+
+	// Rule 4: Response structure — only boosts when another signal already matched.
+	if confidence > 0 && len(req.Response.Body) > 0 && hasGraphQLContentType(req.Response) {
+		if hasGraphQLResponseStructure(req.Response.Body) {
+			if confidence < GraphQLResponseConfidence {
+				confidence = GraphQLResponseConfidence
+			}
+			reason += "+graphql-response"
+		}
+	}
+
+	return confidence > 0, confidence, reason
+}
+
+// hasGraphQLBody checks if the request body contains a GraphQL query structure.
+// It looks for a "query" field whose value starts with GraphQL syntax.
+func hasGraphQLBody(body []byte) bool {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return false
+	}
+
+	queryVal, ok := obj["query"]
+	if !ok {
+		return false
+	}
+
+	queryStr, ok := queryVal.(string)
+	if !ok {
+		return false
+	}
+
+	return looksLikeGraphQL(queryStr)
+}
+
+// looksLikeGraphQL checks if a query string value contains GraphQL syntax
+// rather than a plain search string.
+func looksLikeGraphQL(s string) bool {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return false
+	}
+
+	// GraphQL queries typically start with these tokens or an opening brace.
+	prefixes := []string{"{", "query", "mutation", "subscription", "fragment"}
+	lower := strings.ToLower(trimmed)
+	for _, p := range prefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+
+	// Fallback: if the string contains a brace, it likely has GraphQL syntax.
+	return strings.ContainsRune(trimmed, '{')
+}
+
+// hasGraphQLContentType checks if the response has a JSON-compatible content type
+// that could carry a GraphQL response.
+func hasGraphQLContentType(resp crawl.ObservedResponse) bool {
+	ct := strings.ToLower(resp.ContentType)
+	if ct == "" {
+		for k, v := range resp.Headers {
+			if strings.EqualFold(k, "content-type") {
+				ct = strings.ToLower(v)
+				break
+			}
+		}
+	}
+	if idx := strings.Index(ct, ";"); idx != -1 {
+		ct = strings.TrimSpace(ct[:idx])
+	}
+
+	for _, allowed := range graphqlResponseContentTypes {
+		if ct == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// hasGraphQLResponseStructure checks if the response body is a JSON object
+// with "data" or "errors" as top-level keys (standard GraphQL response shape).
+func hasGraphQLResponseStructure(body []byte) bool {
+	b, ok := firstNonSpace(body)
+	if !ok || b != '{' {
+		return false
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return false
+	}
+
+	_, hasData := obj["data"]
+	_, hasErrors := obj["errors"]
+	return hasData || hasErrors
+}

--- a/pkg/classify/graphql.go
+++ b/pkg/classify/graphql.go
@@ -162,8 +162,7 @@ func looksLikeGraphQL(s string) bool {
 		}
 	}
 
-	// Fallback: if the string contains a brace, it likely has GraphQL syntax.
-	return strings.ContainsRune(trimmed, '{')
+	return false
 }
 
 // hasGraphQLContentType checks if the response has a JSON-compatible content type

--- a/pkg/classify/graphql.go
+++ b/pkg/classify/graphql.go
@@ -86,25 +86,7 @@ func (c *GraphQLClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, flo
 	}
 
 	// Rule 3: Request body analysis (POST only).
-	if strings.EqualFold(req.Method, "POST") && len(req.Body) > 0 {
-		if b, ok := firstNonSpace(req.Body); ok && b == '{' {
-			if hasGraphQLBody(req.Body) {
-				if pathMatched {
-					confidence = GraphQLFullMatchConfidence
-					reason = "graphql-path+graphql-body"
-				} else {
-					if confidence < GraphQLBodyConfidence {
-						confidence = GraphQLBodyConfidence
-					}
-					if reason == "" {
-						reason = "graphql-body"
-					} else {
-						reason += "+graphql-body"
-					}
-				}
-			}
-		}
-	}
+	confidence, reason = classifyGraphQLBody(req, pathMatched, confidence, reason)
 
 	// Rule 4: Response structure — only boosts when another signal already matched.
 	if confidence > 0 && len(req.Response.Body) > 0 && hasGraphQLContentType(req.Response) {
@@ -117,6 +99,29 @@ func (c *GraphQLClassifier) ClassifyDetail(req crawl.ObservedRequest) (bool, flo
 	}
 
 	return confidence > 0, confidence, reason
+}
+
+// classifyGraphQLBody applies Rule 3: request body analysis for POST requests.
+func classifyGraphQLBody(req crawl.ObservedRequest, pathMatched bool, confidence float64, reason string) (float64, string) {
+	if !strings.EqualFold(req.Method, "POST") || len(req.Body) == 0 {
+		return confidence, reason
+	}
+	b, ok := firstNonSpace(req.Body)
+	if !ok || b != '{' || !hasGraphQLBody(req.Body) {
+		return confidence, reason
+	}
+	if pathMatched {
+		return GraphQLFullMatchConfidence, "graphql-path+graphql-body"
+	}
+	if confidence < GraphQLBodyConfidence {
+		confidence = GraphQLBodyConfidence
+	}
+	if reason == "" {
+		reason = "graphql-body"
+	} else {
+		reason += "+graphql-body"
+	}
+	return confidence, reason
 }
 
 // hasGraphQLBody checks if the request body contains a GraphQL query structure.

--- a/pkg/classify/graphql_test.go
+++ b/pkg/classify/graphql_test.go
@@ -17,8 +17,9 @@ package classify
 import (
 	"testing"
 
-	"github.com/praetorian-inc/vespasian/pkg/crawl"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
 )
 
 func TestGraphQLClassifier_Classify(t *testing.T) {

--- a/pkg/classify/graphql_test.go
+++ b/pkg/classify/graphql_test.go
@@ -1,0 +1,347 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package classify
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGraphQLClassifier_Classify(t *testing.T) {
+	c := &GraphQLClassifier{}
+
+	tests := []struct {
+		name          string
+		req           crawl.ObservedRequest
+		wantIsAPI     bool
+		wantMinConf   float64
+		wantMaxConf   float64
+		wantReasonSub string
+	}{
+		// Positive cases
+		{
+			name: "POST /graphql with GraphQL body",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/graphql",
+				Body:   []byte(`{"query":"{ users { id name } }"}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"data":{"users":[]}}`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "graphql-path+graphql-body",
+		},
+		{
+			name: "POST /graphql without body (path only)",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/graphql",
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.70,
+			wantMaxConf:   0.70,
+			wantReasonSub: "graphql-path",
+		},
+		{
+			name: "GET /graphql (no body)",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/graphql",
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.70,
+			wantMaxConf:   0.70,
+			wantReasonSub: "graphql-path",
+		},
+		{
+			name: "POST to non-graphql path with GraphQL body",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/api/data",
+				Body:   []byte(`{"query":"query GetUsers { users { id } }","operationName":"GetUsers"}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.85,
+			wantMaxConf:   0.85,
+			wantReasonSub: "graphql-body",
+		},
+		{
+			name: "POST /graphql with mutation body",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/graphql",
+				Body:   []byte(`{"query":"mutation { createUser(name: \"test\") { id } }"}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "graphql-path+graphql-body",
+		},
+		{
+			name: "Path variation /v1/graphql",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/v1/graphql",
+				Body:   []byte(`{"query":"{ hello }"}`),
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "graphql-path+graphql-body",
+		},
+		{
+			name: "Path variation /api/graphql",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/api/graphql",
+				Body:   []byte(`{"query":"{ hello }"}`),
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "graphql-path+graphql-body",
+		},
+		{
+			name: "Path variation /graphql/ (trailing slash)",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/graphql/",
+				Body:   []byte(`{"query":"{ hello }"}`),
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "graphql-path+graphql-body",
+		},
+		{
+			name: "GraphQL response structure boosts confidence",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/api/data",
+				Body:   []byte(`{"query":"subscription { messages { text } }"}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"data":{"messages":[{"text":"hi"}]}}`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.85,
+			wantMaxConf:   1.0,
+			wantReasonSub: "graphql-body",
+		},
+		{
+			name: "GraphQL response with errors key",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/graphql",
+				Body:   []byte(`{"query":"{ bad }"}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"errors":[{"message":"Cannot query field bad"}]}`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.95,
+			wantMaxConf:   1.0,
+			wantReasonSub: "graphql-path+graphql-body",
+		},
+		{
+			name: "application/graphql+json content type",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/api/endpoint",
+				Body:   []byte(`{"query":"{ users { id } }"}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/graphql+json",
+					Body:        []byte(`{"data":{"users":[]}}`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.85,
+			wantMaxConf:   1.0,
+			wantReasonSub: "graphql-body",
+		},
+		{
+			name: "Response-only signal (no body match, path match + response)",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/graphql",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"data":{"__schema":{"types":[]}}}`),
+				},
+			},
+			wantIsAPI:     true,
+			wantMinConf:   0.80,
+			wantMaxConf:   1.0,
+			wantReasonSub: "graphql-path",
+		},
+
+		// False positive exclusions
+		{
+			name: "Search API with plain query string",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/api/search",
+				Body:   []byte(`{"query":"shoes"}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"results":[{"name":"shoes"}]}`),
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "Search API with numeric query",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/api/search",
+				Body:   []byte(`{"query":12345}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "JSON POST with data in response but no GraphQL signals",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/api/items",
+				Body:   []byte(`{"name":"test"}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"data":[1,2,3]}`),
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+
+		// Negative cases
+		{
+			name: "Static asset .js",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/graphql.js",
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "Static asset .css",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/app.css",
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "HTML response",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/page",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "text/html",
+					Body:        []byte(`<html><body>Hello</body></html>`),
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "REST JSON API",
+			req: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://example.com/api/users",
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"users":[{"id":1}]}`),
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+		{
+			name: "SOAP request",
+			req: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/service",
+				Headers: map[string]string{
+					"SOAPAction": `"urn:GetUser"`,
+				},
+				Body: []byte(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetUser/></soap:Body></soap:Envelope>`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/soap+xml",
+				},
+			},
+			wantIsAPI:   false,
+			wantMinConf: 0,
+			wantMaxConf: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isAPI, confidence, reason := c.ClassifyDetail(tt.req)
+			assert.Equal(t, tt.wantIsAPI, isAPI, "isAPI")
+			assert.GreaterOrEqual(t, confidence, tt.wantMinConf, "confidence lower bound")
+			assert.LessOrEqual(t, confidence, tt.wantMaxConf, "confidence upper bound")
+			if tt.wantReasonSub != "" {
+				assert.Contains(t, reason, tt.wantReasonSub, "reason")
+			}
+		})
+	}
+}
+
+func TestGraphQLClassifier_ImplementsDetailedClassifier(t *testing.T) {
+	var c APIClassifier = &GraphQLClassifier{}
+	assert.Implements(t, (*DetailedClassifier)(nil), c)
+}

--- a/pkg/classify/types.go
+++ b/pkg/classify/types.go
@@ -33,4 +33,38 @@ type ClassifiedRequest struct {
 
 	// WSDLDocument holds a probed WSDL document for SOAP endpoints.
 	WSDLDocument []byte `json:"wsdl_document,omitempty"`
+
+	// GraphQLSchema holds the parsed introspection result for GraphQL endpoints.
+	// Nil means introspection was not attempted or failed.
+	GraphQLSchema *GraphQLIntrospection `json:"graphql_schema,omitempty"`
+}
+
+// GraphQLIntrospection holds parsed GraphQL introspection results.
+type GraphQLIntrospection struct {
+	// IntrospectionEnabled indicates whether the endpoint responded to introspection.
+	IntrospectionEnabled bool `json:"introspection_enabled"`
+	// Types is the parsed list of types from __schema.types.
+	Types []GraphQLType `json:"types,omitempty"`
+	// RawResponse stores the raw introspection JSON for downstream generators.
+	RawResponse []byte `json:"raw_response,omitempty"`
+}
+
+// GraphQLType represents a single type from a GraphQL introspection response.
+type GraphQLType struct {
+	Name   string         `json:"name"`
+	Kind   string         `json:"kind"`
+	Fields []GraphQLField `json:"fields,omitempty"`
+}
+
+// GraphQLField represents a field on a GraphQL type.
+type GraphQLField struct {
+	Name string         `json:"name"`
+	Type GraphQLTypeRef `json:"type"`
+}
+
+// GraphQLTypeRef represents a type reference (name + kind + ofType for wrapping types).
+type GraphQLTypeRef struct {
+	Name   *string        `json:"name"`
+	Kind   string         `json:"kind"`
+	OfType *GraphQLTypeRef `json:"ofType,omitempty"`
 }

--- a/pkg/classify/types.go
+++ b/pkg/classify/types.go
@@ -47,19 +47,48 @@ type GraphQLIntrospection struct {
 	Types []GraphQLType `json:"types,omitempty"`
 	// RawResponse stores the raw introspection JSON for downstream generators.
 	RawResponse []byte `json:"raw_response,omitempty"`
+	// Root type names from __schema.queryType/mutationType/subscriptionType.
+	QueryTypeName        string `json:"query_type_name,omitempty"`
+	MutationTypeName     string `json:"mutation_type_name,omitempty"`
+	SubscriptionTypeName string `json:"subscription_type_name,omitempty"`
 }
 
 // GraphQLType represents a single type from a GraphQL introspection response.
 type GraphQLType struct {
-	Name   string         `json:"name"`
-	Kind   string         `json:"kind"`
-	Fields []GraphQLField `json:"fields,omitempty"`
+	Name          string              `json:"name"`
+	Kind          string              `json:"kind"`
+	Description   string              `json:"description,omitempty"`
+	Fields        []GraphQLField      `json:"fields,omitempty"`
+	InputFields   []GraphQLInputValue `json:"inputFields,omitempty"`
+	EnumValues    []GraphQLEnumValue  `json:"enumValues,omitempty"`
+	Interfaces    []GraphQLTypeRef    `json:"interfaces,omitempty"`
+	PossibleTypes []GraphQLTypeRef    `json:"possibleTypes,omitempty"`
 }
 
 // GraphQLField represents a field on a GraphQL type.
 type GraphQLField struct {
-	Name string         `json:"name"`
-	Type GraphQLTypeRef `json:"type"`
+	Name              string              `json:"name"`
+	Description       string              `json:"description,omitempty"`
+	Type              GraphQLTypeRef      `json:"type"`
+	Args              []GraphQLInputValue `json:"args,omitempty"`
+	IsDeprecated      bool                `json:"isDeprecated,omitempty"`
+	DeprecationReason string              `json:"deprecationReason,omitempty"`
+}
+
+// GraphQLInputValue represents an argument or input field.
+type GraphQLInputValue struct {
+	Name         string         `json:"name"`
+	Description  string         `json:"description,omitempty"`
+	Type         GraphQLTypeRef `json:"type"`
+	DefaultValue *string        `json:"defaultValue,omitempty"`
+}
+
+// GraphQLEnumValue represents a single value of an enum type.
+type GraphQLEnumValue struct {
+	Name              string `json:"name"`
+	Description       string `json:"description,omitempty"`
+	IsDeprecated      bool   `json:"isDeprecated,omitempty"`
+	DeprecationReason string `json:"deprecationReason,omitempty"`
 }
 
 // GraphQLTypeRef represents a type reference (name + kind + ofType for wrapping types).

--- a/pkg/classify/types.go
+++ b/pkg/classify/types.go
@@ -64,7 +64,7 @@ type GraphQLField struct {
 
 // GraphQLTypeRef represents a type reference (name + kind + ofType for wrapping types).
 type GraphQLTypeRef struct {
-	Name   *string        `json:"name"`
-	Kind   string         `json:"kind"`
+	Name   *string         `json:"name"`
+	Kind   string          `json:"kind"`
 	OfType *GraphQLTypeRef `json:"ofType,omitempty"`
 }

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -60,11 +60,12 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	var ops []inferredOperation
 	syntheticTypes := make(map[string]*inferredType)
 	syntheticInputTypes := make(map[string]*inferredType)
+	syntheticUnions := make(map[string][]string) // union name -> member type names
 	anonCounter := 0
 	seen := make(map[string]bool) // deduplicate by composite key (opType:fieldName:opName)
 
 	for _, ep := range endpoints {
-		if op, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes, syntheticInputTypes); ok {
+		if op, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes, syntheticInputTypes, syntheticUnions); ok {
 			ops = append(ops, op)
 		}
 	}
@@ -95,15 +96,19 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		for i := range groupOps {
 			op := &groupOps[i]
 			if existing, ok := merged[op.FieldName]; ok {
-				// Merge args (add new args, keep existing)
+				// Merge args: prefer more specific types over String
 				for k, v := range op.Args {
-					if _, exists := existing.Args[k]; !exists {
+					if existingType, exists := existing.Args[k]; !exists {
+						existing.Args[k] = v
+					} else if isMoreSpecificType(v, existingType) {
 						existing.Args[k] = v
 					}
 				}
-				// Merge response fields
+				// Merge response fields: prefer more specific types
 				for k, v := range op.ResponseFields {
-					if _, exists := existing.ResponseFields[k]; !exists {
+					if existingType, exists := existing.ResponseFields[k]; !exists {
+						existing.ResponseFields[k] = v
+					} else if isMoreSpecificType(v, existingType) {
 						existing.ResponseFields[k] = v
 					}
 				}
@@ -130,9 +135,11 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		for _, op := range groupOps {
 			if len(op.ResponseFields) > 0 {
 				if existing, ok := syntheticTypes[op.ReturnType]; ok {
-					// Merge fields into existing type
+					// Merge fields into existing type: prefer more specific types
 					for k, v := range op.ResponseFields {
-						if _, exists := existing.Fields[k]; !exists {
+						if existingType, exists := existing.Fields[k]; !exists {
+							existing.Fields[k] = v
+						} else if isMoreSpecificType(v, existingType) {
 							existing.Fields[k] = v
 						}
 					}
@@ -218,11 +225,23 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		sb.WriteString("}\n")
 	}
 
+	// Emit synthetic union types sorted by name
+	var unionNames []string
+	for name := range syntheticUnions {
+		unionNames = append(unionNames, name)
+	}
+	sort.Strings(unionNames)
+
+	for _, name := range unionNames {
+		members := syntheticUnions[name]
+		fmt.Fprintf(&sb, "\nunion %s = %s\n", name, strings.Join(members, " | "))
+	}
+
 	return []byte(sb.String()), nil
 }
 
 // processEndpoint processes a single classified endpoint and returns an inferred operation.
-func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType) (inferredOperation, bool) {
+func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType, syntheticUnions map[string][]string) (inferredOperation, bool) {
 	if ep.APIType != "graphql" {
 		return inferredOperation{}, false
 	}
@@ -262,7 +281,7 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 	}
 	seen[dedupKey] = true
 
-	args := buildArgTypes(parsed, body.Variables)
+	args := buildArgTypes(parsed, body.Variables, syntheticInputTypes)
 	inferInputTypes(parsed, body.Variables, syntheticInputTypes)
 
 	returnTypeName := upperFirst(fieldName) + "Response"
@@ -270,8 +289,47 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 
 	responseObj, isList, responseOK := unwrapResponseValue(ep.Response.Body, fieldName)
 	var responseFields map[string]string
-	if responseOK && responseObj != nil && len(parsed.selectionTree) > 0 {
+
+	if len(parsed.inlineFragments) >= 2 && !parsed.hasNonFragmentFields {
+		// Fix 5: Union type inference from inline fragments
+		unionName := typePrefix + "Result"
+		var memberNames []string
+
+		// Merge all array elements for type inference
+		mergedObj := mergeArrayElements(ep.Response.Body, fieldName)
+		if mergedObj == nil {
+			mergedObj = responseObj
+		}
+
+		for _, frag := range parsed.inlineFragments {
+			memberNames = append(memberNames, frag.TypeName)
+			fragFields := inferFieldsRecursive(mergedObj, frag.SelectionTree, frag.TypeName, syntheticTypes)
+			if len(fragFields) > 0 {
+				if existing, ok := syntheticTypes[frag.TypeName]; ok {
+					for k, v := range fragFields {
+						if _, exists := existing.Fields[k]; !exists {
+							existing.Fields[k] = v
+						}
+					}
+				} else {
+					syntheticTypes[frag.TypeName] = &inferredType{
+						Name:   frag.TypeName,
+						Fields: fragFields,
+					}
+				}
+			}
+		}
+
+		syntheticUnions[unionName] = memberNames
+		returnTypeName = unionName
+	} else if responseOK && responseObj != nil && len(parsed.selectionTree) > 0 {
 		responseFields = inferFieldsRecursive(responseObj, parsed.selectionTree, typePrefix, syntheticTypes)
+	} else if scalarType, ok := detectScalarReturnType(ep.Response.Body, fieldName); ok {
+		// Fix 1: Scalar root field return
+		returnTypeName = scalarType
+	} else if len(parsed.selectionTree) > 0 {
+		// Fix 4: Response was null/error but we have selection tree — generate type from selection fields
+		responseFields = inferFieldsRecursive(nil, parsed.selectionTree, typePrefix, syntheticTypes)
 	} else {
 		// Fallback: existing flat inference
 		responseFields, isList = inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
@@ -293,15 +351,23 @@ type selectionNode struct {
 	Children []*selectionNode // nil = leaf (scalar), non-nil = object with sub-fields
 }
 
+// inlineFragmentInfo holds type condition and selection tree from an inline fragment.
+type inlineFragmentInfo struct {
+	TypeName      string           // the type condition, e.g., "PasteObject"
+	SelectionTree []*selectionNode // nested selection tree for this fragment
+}
+
 // parsedQuery holds the results of parsing a GraphQL query string with gqlparser.
 type parsedQuery struct {
-	opType          ast.Operation
-	opName          string
-	rootFieldName   string
-	rootFieldArgs   []*ast.Argument // arguments on the root field
-	varDefs         ast.VariableDefinitionList
-	selectionFields []string           // field names from the root field's selection set (flat)
-	selectionTree   []*selectionNode   // nested selection tree for recursive type inference
+	opType               ast.Operation
+	opName               string
+	rootFieldName        string
+	rootFieldArgs        []*ast.Argument // arguments on the root field
+	varDefs              ast.VariableDefinitionList
+	selectionFields      []string              // field names from the root field's selection set (flat)
+	selectionTree        []*selectionNode      // nested selection tree for recursive type inference
+	inlineFragments      []inlineFragmentInfo  // inline fragments with type conditions on root field
+	hasNonFragmentFields bool                  // true if root field has direct field selections alongside inline fragments
 }
 
 // parseQueryAST parses a GraphQL query string and extracts operation info.
@@ -325,6 +391,8 @@ func parseQueryAST(query string) *parsedQuery {
 			result.rootFieldArgs = field.Arguments
 			result.selectionFields = collectSelectionFields(field.SelectionSet, doc.Fragments)
 			result.selectionTree = collectSelectionTree(field.SelectionSet, doc.Fragments)
+			result.inlineFragments = collectInlineFragments(field.SelectionSet, doc.Fragments)
+			result.hasNonFragmentFields = hasTopLevelFields(field.SelectionSet)
 		}
 	}
 
@@ -416,6 +484,49 @@ func collectSelectionTree(selections ast.SelectionSet, fragments ast.FragmentDef
 	}
 
 	return nodes
+}
+
+// collectInlineFragments extracts inline fragments with type conditions from a selection set.
+func collectInlineFragments(selections ast.SelectionSet, fragments ast.FragmentDefinitionList) []inlineFragmentInfo {
+	var frags []inlineFragmentInfo
+	seen := make(map[string]bool)
+
+	for _, sel := range selections {
+		switch s := sel.(type) {
+		case *ast.InlineFragment:
+			if s.TypeCondition != "" && !seen[s.TypeCondition] {
+				seen[s.TypeCondition] = true
+				tree := collectSelectionTree(s.SelectionSet, fragments)
+				frags = append(frags, inlineFragmentInfo{
+					TypeName:      s.TypeCondition,
+					SelectionTree: tree,
+				})
+			}
+		case *ast.FragmentSpread:
+			if frag := fragments.ForName(s.Name); frag != nil {
+				nested := collectInlineFragments(frag.SelectionSet, fragments)
+				for _, n := range nested {
+					if !seen[n.TypeName] {
+						seen[n.TypeName] = true
+						frags = append(frags, n)
+					}
+				}
+			}
+		}
+	}
+
+	return frags
+}
+
+// hasTopLevelFields returns true if a selection set contains direct field selections
+// (not inside inline fragments). Used to distinguish union patterns from interface patterns.
+func hasTopLevelFields(selections ast.SelectionSet) bool {
+	for _, sel := range selections {
+		if f, ok := sel.(*ast.Field); ok && !isMetaField(f.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 // mergeIntoNodeList merges source nodes into an existing ordered node list with deduplication.
@@ -672,9 +783,65 @@ func astTypeToSDL(t *ast.Type) string {
 	return base
 }
 
+// inferTypeFromASTValue infers a GraphQL type from an AST value kind.
+func inferTypeFromASTValue(v *ast.Value) string {
+	if v == nil {
+		return "String"
+	}
+	switch v.Kind {
+	case ast.IntValue:
+		return "Int"
+	case ast.FloatValue:
+		return "Float"
+	case ast.BooleanValue:
+		return "Boolean"
+	case ast.StringValue, ast.BlockValue:
+		return "String"
+	case ast.ListValue:
+		if len(v.Children) > 0 {
+			elemType := inferTypeFromASTValue(v.Children[0].Value)
+			return "[" + elemType + "]"
+		}
+		return "[String]"
+	default:
+		return "String"
+	}
+}
+
+// inferInputTypeFromASTObject creates an input type definition from an AST object value.
+func inferInputTypeFromASTObject(value *ast.Value, typeName string, inputTypes map[string]*inferredType) {
+	if value == nil || value.Kind != ast.ObjectValue {
+		return
+	}
+
+	fields := make(map[string]string)
+	for _, child := range value.Children {
+		if child.Value != nil && child.Value.Kind == ast.ObjectValue {
+			nestedTypeName := typeName + "_" + upperFirst(child.Name)
+			inferInputTypeFromASTObject(child.Value, nestedTypeName, inputTypes)
+			fields[child.Name] = nestedTypeName
+		} else {
+			fields[child.Name] = inferTypeFromASTValue(child.Value)
+		}
+	}
+
+	if existing, ok := inputTypes[typeName]; ok {
+		for k, v := range fields {
+			if _, exists := existing.Fields[k]; !exists {
+				existing.Fields[k] = v
+			}
+		}
+	} else {
+		inputTypes[typeName] = &inferredType{
+			Name:   typeName,
+			Fields: fields,
+		}
+	}
+}
+
 // buildArgTypes builds argument type mappings. It prefers declared variable types from the AST,
 // falling back to JSON value inference for variables not declared in the query.
-func buildArgTypes(parsed *parsedQuery, variables map[string]interface{}) map[string]string {
+func buildArgTypes(parsed *parsedQuery, variables map[string]interface{}, inputTypes map[string]*inferredType) map[string]string {
 	args := make(map[string]string)
 
 	// Build a map from variable name to its declared type
@@ -698,6 +865,18 @@ func buildArgTypes(parsed *parsedQuery, variables map[string]interface{}) map[st
 				args[argName] = inferTypeFromValue(val)
 				continue
 			}
+		}
+		// Fix 3: Inline object literal — create input type
+		if arg.Value != nil && arg.Value.Kind == ast.ObjectValue {
+			inputTypeName := upperFirst(argName) + "Input"
+			inferInputTypeFromASTObject(arg.Value, inputTypeName, inputTypes)
+			args[argName] = inputTypeName
+			continue
+		}
+		// Fix 2: Infer type from inline literal value
+		if arg.Value != nil {
+			args[argName] = inferTypeFromASTValue(arg.Value)
+			continue
 		}
 		// Default fallback
 		args[argName] = "String"
@@ -854,6 +1033,117 @@ func unwrapResponseValue(body []byte, rootFieldName string) (map[string]interfac
 	default:
 		return nil, false, false
 	}
+}
+
+// detectScalarReturnType checks if a GraphQL response field is a scalar value
+// and returns the corresponding SDL type name.
+func detectScalarReturnType(body []byte, rootFieldName string) (string, bool) {
+	if len(body) == 0 {
+		return "", false
+	}
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "", false
+	}
+
+	data, ok := envelope["data"]
+	if !ok {
+		return "", false
+	}
+
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+
+	responseVal, ok := dataMap[rootFieldName]
+	if !ok {
+		keys := make([]string, 0, len(dataMap))
+		for k := range dataMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		if len(keys) > 0 {
+			responseVal = dataMap[keys[0]]
+		} else {
+			return "", false
+		}
+	}
+
+	switch v := responseVal.(type) {
+	case string:
+		return "String", true
+	case bool:
+		return "Boolean", true
+	case float64:
+		if v == math.Trunc(v) {
+			return "Int", true
+		}
+		return "Float", true
+	default:
+		return "", false
+	}
+}
+
+// mergeArrayElements parses a GraphQL response and merges all array elements
+// for the given root field into a single map for comprehensive type inference.
+func mergeArrayElements(body []byte, rootFieldName string) map[string]interface{} {
+	if len(body) == 0 {
+		return nil
+	}
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil
+	}
+
+	data, ok := envelope["data"]
+	if !ok {
+		return nil
+	}
+
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	responseVal, ok := dataMap[rootFieldName]
+	if !ok {
+		return nil
+	}
+
+	arr, ok := responseVal.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	merged := make(map[string]interface{})
+	for _, elem := range arr {
+		if obj, ok := elem.(map[string]interface{}); ok {
+			for k, v := range obj {
+				if _, exists := merged[k]; !exists {
+					merged[k] = v
+				}
+			}
+		}
+	}
+
+	return merged
+}
+
+// isMoreSpecificType returns true if newType is more specific than existingType.
+// Used during merge to prefer typed args over String defaults.
+func isMoreSpecificType(newType, existingType string) bool {
+	if existingType == "String" && newType != "String" && newType != "" {
+		return true
+	}
+	// Prefer non-null over nullable of the same base type
+	if strings.HasSuffix(newType, "!") && !strings.HasSuffix(existingType, "!") &&
+		strings.TrimSuffix(newType, "!") == existingType {
+		return true
+	}
+	return false
 }
 
 // upperFirst returns the string with its first character uppercased.

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -60,11 +60,12 @@ type inferredType struct {
 func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	var ops []inferredOperation
 	syntheticTypes := make(map[string]*inferredType)
+	syntheticInputTypes := make(map[string]*inferredType)
 	anonCounter := 0
 	seen := make(map[string]bool) // deduplicate by composite key (opType:fieldName:opName)
 
 	for _, ep := range endpoints {
-		if op, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes); ok {
+		if op, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes, syntheticInputTypes); ok {
 			ops = append(ops, op)
 		}
 	}
@@ -184,11 +185,34 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		sb.WriteString("}\n")
 	}
 
+	// Emit synthetic input types sorted by name
+	var inputTypeNames []string
+	for name := range syntheticInputTypes {
+		inputTypeNames = append(inputTypeNames, name)
+	}
+	sort.Strings(inputTypeNames)
+
+	for _, name := range inputTypeNames {
+		it := syntheticInputTypes[name]
+		fmt.Fprintf(&sb, "\ninput %s {\n", it.Name)
+
+		var fieldNames []string
+		for fn := range it.Fields {
+			fieldNames = append(fieldNames, fn)
+		}
+		sort.Strings(fieldNames)
+
+		for _, fn := range fieldNames {
+			fmt.Fprintf(&sb, "  %s: %s\n", fn, it.Fields[fn])
+		}
+		sb.WriteString("}\n")
+	}
+
 	return []byte(sb.String()), nil
 }
 
 // processEndpoint processes a single classified endpoint and returns an inferred operation.
-func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType) (inferredOperation, bool) {
+func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType) (inferredOperation, bool) {
 	if ep.APIType != "graphql" {
 		return inferredOperation{}, false
 	}
@@ -229,6 +253,7 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 	seen[dedupKey] = true
 
 	args := buildArgTypes(parsed, body.Variables)
+	inferInputTypes(parsed, body.Variables, syntheticInputTypes)
 
 	returnTypeName := upperFirst(fieldName) + "Response"
 	typePrefix := upperFirst(fieldName)
@@ -484,6 +509,118 @@ func inferFieldsRecursive(
 	}
 
 	return fields
+}
+
+// extractNamedType unwraps list/non-null wrappers from an AST type to get the base named type.
+// E.g., [Foo!]! -> "Foo".
+func extractNamedType(t *ast.Type) string {
+	if t == nil {
+		return ""
+	}
+	if t.Elem != nil {
+		return extractNamedType(t.Elem)
+	}
+	return t.NamedType
+}
+
+// inferInputFieldsRecursive walks a JSON object and builds input type field definitions,
+// creating nested input types for nested objects.
+func inferInputFieldsRecursive(
+	obj map[string]interface{},
+	parentTypeName string,
+	inputTypes map[string]*inferredType,
+) map[string]string {
+	fields := make(map[string]string)
+
+	for key, val := range obj {
+		switch v := val.(type) {
+		case map[string]interface{}:
+			nestedTypeName := parentTypeName + "_" + upperFirst(key)
+			nestedFields := inferInputFieldsRecursive(v, nestedTypeName, inputTypes)
+			inputTypes[nestedTypeName] = &inferredType{
+				Name:   nestedTypeName,
+				Fields: nestedFields,
+			}
+			fields[key] = nestedTypeName
+		case []interface{}:
+			if len(v) > 0 {
+				if obj, ok := v[0].(map[string]interface{}); ok {
+					elemTypeName := parentTypeName + "_" + upperFirst(key)
+					elemFields := inferInputFieldsRecursive(obj, elemTypeName, inputTypes)
+					inputTypes[elemTypeName] = &inferredType{
+						Name:   elemTypeName,
+						Fields: elemFields,
+					}
+					fields[key] = "[" + elemTypeName + "]"
+				} else {
+					fields[key] = "[" + inferTypeFromValue(v[0]) + "]"
+				}
+			} else {
+				fields[key] = "[String]"
+			}
+		default:
+			fields[key] = inferTypeFromValue(val)
+		}
+	}
+
+	return fields
+}
+
+// inferInputTypes examines variable definitions and their runtime values to build
+// input type definitions for non-scalar variable types.
+func inferInputTypes(
+	parsed *parsedQuery,
+	variables map[string]interface{},
+	inputTypes map[string]*inferredType,
+) {
+	for _, vd := range parsed.varDefs {
+		baseType := extractNamedType(vd.Type)
+		if baseType == "" || builtinScalars[baseType] {
+			continue
+		}
+
+		val, ok := variables[vd.Variable]
+		if !ok || val == nil {
+			continue
+		}
+
+		switch v := val.(type) {
+		case map[string]interface{}:
+			fields := inferInputFieldsRecursive(v, baseType, inputTypes)
+			if existing, ok := inputTypes[baseType]; ok {
+				// Merge fields: first-wins per field
+				for k, ft := range fields {
+					if _, exists := existing.Fields[k]; !exists {
+						existing.Fields[k] = ft
+					}
+				}
+			} else {
+				inputTypes[baseType] = &inferredType{
+					Name:   baseType,
+					Fields: fields,
+				}
+			}
+		case []interface{}:
+			if len(v) > 0 {
+				if obj, ok := v[0].(map[string]interface{}); ok {
+					// The base type is the element type name
+					fields := inferInputFieldsRecursive(obj, baseType, inputTypes)
+					if existing, ok := inputTypes[baseType]; ok {
+						for k, ft := range fields {
+							if _, exists := existing.Fields[k]; !exists {
+								existing.Fields[k] = ft
+							}
+						}
+					} else {
+						inputTypes[baseType] = &inferredType{
+							Name:   baseType,
+							Fields: fields,
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 // astOpTypeToString converts an ast.Operation to a string.

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -383,7 +383,7 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 	responseObj, isList, responseOK := unwrapResponseValue(ep.Response.Body, fieldName)
 	var responseFields map[string]string
 
-	if len(parsed.inlineFragments) >= 2 && !parsed.hasNonFragmentFields {
+	if len(parsed.inlineFragments) >= 1 && !parsed.hasNonFragmentFields {
 		// Union type inference from inline fragments
 		unionName := typePrefix + "Result"
 		var memberNames []string
@@ -644,11 +644,34 @@ func collectInlineFragments(selections ast.SelectionSet, fragments ast.FragmentD
 			}
 		case *ast.FragmentSpread:
 			if frag := fragments.ForName(s.Name); frag != nil {
+				// Check for nested inline fragments within the named fragment
 				nested := collectInlineFragments(frag.SelectionSet, fragments)
-				for _, n := range nested {
-					if !seen[n.TypeName] {
-						seen[n.TypeName] = true
-						frags = append(frags, n)
+				if len(nested) > 0 {
+					// Fragment contains type-narrowing inline fragments (e.g., fragment X on Viewer { ... on User { ... } })
+					// Only extract the nested fragments — the outer fragment is on the parent type, not a union member
+					for _, n := range nested {
+						if !seen[n.TypeName] {
+							seen[n.TypeName] = true
+							frags = append(frags, n)
+						}
+					}
+				} else if frag.TypeCondition != "" && !seen[frag.TypeCondition] {
+					// Fragment has no nested inline fragments and has substantive fields —
+					// treat it as a typed fragment (e.g., fragment UserFields on User { id profile { bio } }).
+					tree := collectSelectionTree(frag.SelectionSet, fragments)
+					hasSubstantiveFields := false
+					for _, node := range tree {
+						if !isMetaField(node.Name) {
+							hasSubstantiveFields = true
+							break
+						}
+					}
+					if hasSubstantiveFields {
+						seen[frag.TypeCondition] = true
+						frags = append(frags, inlineFragmentInfo{
+							TypeName:      frag.TypeCondition,
+							SelectionTree: tree,
+						})
 					}
 				}
 			}

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -61,12 +61,13 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	var ops []inferredOperation
 	syntheticTypes := make(map[string]*inferredType)
 	syntheticInputTypes := make(map[string]*inferredType)
-	syntheticUnions := make(map[string][]string) // union name -> member type names
+	syntheticUnions := make(map[string][]string)          // union name -> member type names
+	observedEnumValues := make(map[string]map[string]bool) // type name -> set of observed string values
 	anonCounter := 0
 	seen := make(map[string]bool) // deduplicate by composite key (opType:fieldName:opName)
 
 	for _, ep := range endpoints {
-		if epOps, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes, syntheticInputTypes, syntheticUnions); ok {
+		if epOps, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes, syntheticInputTypes, syntheticUnions, observedEnumValues); ok {
 			ops = append(ops, epOps...)
 		}
 	}
@@ -319,12 +320,26 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		fmt.Fprintf(&sb, "\nunion %s = %s\n", name, strings.Join(members, " | "))
 	}
 
-	// Emit custom scalar declarations for referenced but undeclared types (e.g., Upload)
+	// Emit custom scalar/enum declarations for referenced but undeclared types
 	referencedScalars := collectCustomScalars(grouped, syntheticTypes, syntheticInputTypes, syntheticUnions)
 	if len(referencedScalars) > 0 {
 		sort.Strings(referencedScalars)
 		for _, s := range referencedScalars {
-			fmt.Fprintf(&sb, "\nscalar %s\n", s)
+			if values, ok := observedEnumValues[s]; ok && len(values) > 0 {
+				// Emit as enum with observed values
+				var sortedVals []string
+				for v := range values {
+					sortedVals = append(sortedVals, v)
+				}
+				sort.Strings(sortedVals)
+				fmt.Fprintf(&sb, "\nenum %s {\n", s)
+				for _, v := range sortedVals {
+					fmt.Fprintf(&sb, "  %s\n", v)
+				}
+				sb.WriteString("}\n")
+			} else {
+				fmt.Fprintf(&sb, "\nscalar %s\n", s)
+			}
 		}
 	}
 
@@ -333,7 +348,7 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 
 // processEndpoint processes a single classified endpoint and returns inferred operations
 // (one per root field in multi-root queries).
-func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType, syntheticUnions map[string][]string) ([]inferredOperation, bool) {
+func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType, syntheticUnions map[string][]string, observedEnumValues map[string]map[string]bool) ([]inferredOperation, bool) {
 	if ep.APIType != "graphql" {
 		return nil, false
 	}
@@ -358,7 +373,7 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 
 	var ops []inferredOperation
 	for _, parsed := range parsedQueries {
-		op, ok := processParsedQuery(parsed, ep, body, seen, anonCounter, syntheticTypes, syntheticInputTypes, syntheticUnions)
+		op, ok := processParsedQuery(parsed, ep, body, seen, anonCounter, syntheticTypes, syntheticInputTypes, syntheticUnions, observedEnumValues)
 		if ok {
 			ops = append(ops, op)
 		}
@@ -371,7 +386,7 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 }
 
 // processParsedQuery processes a single parsed query (one root field) from an endpoint.
-func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body *graphqlBody, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType, syntheticUnions map[string][]string) (inferredOperation, bool) {
+func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body *graphqlBody, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType, syntheticUnions map[string][]string, observedEnumValues map[string]map[string]bool) (inferredOperation, bool) {
 	opType := astOpTypeToString(parsed.opType)
 	fieldName := parsed.rootFieldName
 	if fieldName == "" {
@@ -399,6 +414,10 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 	for _, vd := range parsed.varDefs {
 		varTypes[vd.Variable] = astTypeToSDL(vd.Type)
 	}
+
+	// Collect observed enum values: when a non-builtin, non-input variable has a string value,
+	// record it as a potential enum value for that type.
+	collectEnumValues(parsed, body.Variables, syntheticInputTypes, observedEnumValues)
 
 	returnTypeName := upperFirst(fieldName) + "Response"
 	typePrefix := upperFirst(fieldName)
@@ -1211,7 +1230,7 @@ func inferFieldArgTypes(args []*ast.Argument, varTypes map[string]string, inputT
 		}
 		if arg.Value != nil && arg.Value.Kind == ast.ObjectValue {
 			inputTypeName := fieldPrefix + "_" + upperFirst(arg.Name) + "Input"
-			inferInputTypeFromASTObject(arg.Value, inputTypeName, inputTypes)
+			inferInputTypeFromASTObject(arg.Value, inputTypeName, inputTypes, varTypes)
 			result[arg.Name] = inputTypeName
 			continue
 		}
@@ -1364,6 +1383,50 @@ func inferInputTypes(
 	}
 }
 
+// collectEnumValues records observed string values for non-builtin, non-input variable types.
+// When a variable is declared as a custom type (e.g., $status: InterviewInvitationStatus) and
+// its runtime value is a string, we record that string as a potential enum value.
+func collectEnumValues(
+	parsed *parsedQuery,
+	variables map[string]interface{},
+	inputTypes map[string]*inferredType,
+	observedEnumValues map[string]map[string]bool,
+) {
+	for _, vd := range parsed.varDefs {
+		baseType := extractNamedType(vd.Type)
+		if baseType == "" || builtinScalars[baseType] {
+			continue
+		}
+		// Skip types that are already known input types
+		if _, isInput := inputTypes[baseType]; isInput {
+			continue
+		}
+
+		val, ok := variables[vd.Variable]
+		if !ok || val == nil {
+			continue
+		}
+
+		switch v := val.(type) {
+		case string:
+			if observedEnumValues[baseType] == nil {
+				observedEnumValues[baseType] = make(map[string]bool)
+			}
+			observedEnumValues[baseType][v] = true
+		case []interface{}:
+			// Array of enum values (e.g., $intents: [UserVerificationIntent!]!)
+			for _, elem := range v {
+				if s, ok := elem.(string); ok {
+					if observedEnumValues[baseType] == nil {
+						observedEnumValues[baseType] = make(map[string]bool)
+					}
+					observedEnumValues[baseType][s] = true
+				}
+			}
+		}
+	}
+}
+
 // astOpTypeToString converts an ast.Operation to a string.
 func astOpTypeToString(op ast.Operation) string {
 	switch op {
@@ -1423,17 +1486,30 @@ func inferTypeFromASTValue(v *ast.Value) string {
 }
 
 // inferInputTypeFromASTObject creates an input type definition from an AST object value.
-func inferInputTypeFromASTObject(value *ast.Value, typeName string, inputTypes map[string]*inferredType) {
+func inferInputTypeFromASTObject(value *ast.Value, typeName string, inputTypes map[string]*inferredType, varTypes ...map[string]string) {
 	if value == nil || value.Kind != ast.ObjectValue {
 		return
+	}
+
+	// Merge varTypes if provided
+	var vt map[string]string
+	if len(varTypes) > 0 {
+		vt = varTypes[0]
 	}
 
 	fields := make(map[string]string)
 	for _, child := range value.Children {
 		if child.Value != nil && child.Value.Kind == ast.ObjectValue {
 			nestedTypeName := typeName + "_" + upperFirst(child.Name)
-			inferInputTypeFromASTObject(child.Value, nestedTypeName, inputTypes)
+			inferInputTypeFromASTObject(child.Value, nestedTypeName, inputTypes, varTypes...)
 			fields[child.Name] = nestedTypeName
+		} else if child.Value != nil && child.Value.Kind == ast.Variable && vt != nil {
+			// Resolve variable reference to its declared type
+			if t, ok := vt[child.Value.Raw]; ok {
+				fields[child.Name] = t
+			} else {
+				fields[child.Name] = inferTypeFromASTValue(child.Value)
+			}
 		} else {
 			fields[child.Name] = inferTypeFromASTValue(child.Value)
 		}
@@ -1484,7 +1560,7 @@ func buildArgTypes(parsed *parsedQuery, variables map[string]interface{}, inputT
 		// Use rootFieldName + argName to disambiguate (e.g., ValidateEmail_InputInput vs SetCurrentUserFlowState_InputInput)
 		if arg.Value != nil && arg.Value.Kind == ast.ObjectValue {
 			inputTypeName := upperFirst(parsed.rootFieldName) + "_" + upperFirst(argName) + "Input"
-			inferInputTypeFromASTObject(arg.Value, inputTypeName, inputTypes)
+			inferInputTypeFromASTObject(arg.Value, inputTypeName, inputTypes, varTypes)
 			args[argName] = inputTypeName
 			continue
 		}
@@ -1770,12 +1846,28 @@ func isMoreSpecificType(newType, existingType string) bool {
 	if existingType == "String" && newType != "String" && newType != "" {
 		return true
 	}
+	// Unwrap list/non-null wrappers and compare base types
+	existingBase := unwrapBaseType(existingType)
+	newBase := unwrapBaseType(newType)
+	if existingBase == "String" && newBase != "String" && newBase != "" {
+		return true
+	}
 	// Prefer non-null over nullable of the same base type
 	if strings.HasSuffix(newType, "!") && !strings.HasSuffix(existingType, "!") &&
 		strings.TrimSuffix(newType, "!") == existingType {
 		return true
 	}
 	return false
+}
+
+// unwrapBaseType strips list brackets and non-null markers to get the base named type.
+func unwrapBaseType(t string) string {
+	base := t
+	base = strings.TrimSuffix(base, "!")
+	base = strings.TrimPrefix(base, "[")
+	base = strings.TrimSuffix(base, "]")
+	base = strings.TrimSuffix(base, "!")
+	return base
 }
 
 // isScalarType returns true if the type string represents a built-in GraphQL scalar.
@@ -1956,6 +2048,12 @@ func collectCustomScalars(
 			for _, argType := range args {
 				checkCustomScalar(argType, known, candidates)
 			}
+		}
+	}
+	// Check input type fields for custom scalar references
+	for _, it := range syntheticInputTypes {
+		for _, fieldType := range it.Fields {
+			checkCustomScalar(fieldType, known, candidates)
 		}
 	}
 

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -145,6 +145,10 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 			if _, isUnion := syntheticUnions[op.ReturnType]; isUnion {
 				continue
 			}
+			// Skip builtin scalar return types — they must not be redefined as object types
+			if builtinScalars[op.ReturnType] {
+				continue
+			}
 			fields := op.ResponseFields
 			if fields == nil {
 				fields = make(map[string]string)

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -395,7 +395,7 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 	responseObj, isList, responseOK := unwrapResponseValue(ep.Response.Body, fieldName)
 	var responseFields map[string]string
 
-	if len(parsed.inlineFragments) >= 1 && !parsed.hasNonFragmentFields {
+	if len(parsed.inlineFragments) >= 1 {
 		// Union type inference from inline fragments
 		unionName := typePrefix + "Result"
 		var memberNames []string
@@ -404,6 +404,15 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 		mergedObj := mergeArrayElements(ep.Response.Body, fieldName)
 		if mergedObj == nil {
 			mergedObj = responseObj
+		}
+
+		// Mixed case: merge common (direct) fields into each fragment's selection tree
+		if parsed.hasNonFragmentFields && len(parsed.selectionTree) > 0 {
+			for i := range parsed.inlineFragments {
+				parsed.inlineFragments[i].SelectionTree = mergeSelectionNodes(
+					parsed.inlineFragments[i].SelectionTree, parsed.selectionTree,
+				)
+			}
 		}
 
 		for _, frag := range parsed.inlineFragments {
@@ -518,6 +527,16 @@ func parseQueryAST(query string) []*parsedQuery {
 
 	var results []*parsedQuery
 	for _, field := range rootFields {
+		frags := collectInlineFragments(field.SelectionSet, doc.Fragments)
+		hasDirect := hasTopLevelFields(field.SelectionSet)
+		var tree []*selectionNode
+		if len(frags) > 0 && hasDirect {
+			// Mixed case: only collect direct fields for selectionTree;
+			// type-conditioned content stays in inlineFragments only.
+			tree = collectDirectFieldNodes(field.SelectionSet, doc.Fragments)
+		} else {
+			tree = collectSelectionTree(field.SelectionSet, doc.Fragments)
+		}
 		result := &parsedQuery{
 			opType:               op.Operation,
 			opName:               op.Name,
@@ -525,9 +544,9 @@ func parseQueryAST(query string) []*parsedQuery {
 			rootFieldName:        field.Name,
 			rootFieldArgs:        field.Arguments,
 			selectionFields:      collectSelectionFields(field.SelectionSet, doc.Fragments),
-			selectionTree:        collectSelectionTree(field.SelectionSet, doc.Fragments),
-			inlineFragments:      collectInlineFragments(field.SelectionSet, doc.Fragments),
-			hasNonFragmentFields: hasTopLevelFields(field.SelectionSet),
+			selectionTree:        tree,
+			inlineFragments:      frags,
+			hasNonFragmentFields: hasDirect,
 		}
 		results = append(results, result)
 	}
@@ -663,6 +682,10 @@ func collectSelectionTree(selections ast.SelectionSet, fragments ast.FragmentDef
 				if len(subFrags) > 0 && !hasDirectFields {
 					// Pure union/interface pattern: don't flatten into children
 					children = nil
+				} else if len(subFrags) > 0 {
+					// Mixed case: only collect direct (non-typed) fields as children.
+					// Type-conditioned content stays in InlineFragments only.
+					children = collectDirectFieldNodes(s.SelectionSet, fragments)
 				} else {
 					children = collectSelectionTree(s.SelectionSet, fragments)
 				}
@@ -1019,8 +1042,8 @@ func inferFieldsRecursive(
 			}
 		}
 
-		// Sub-field union/interface pattern: inline fragments without direct fields
-		if len(node.InlineFragments) > 0 && !node.HasDirectFields {
+		// Sub-field union/interface pattern: inline fragments (with or without direct fields)
+		if len(node.InlineFragments) > 0 {
 			unionName := typePrefix + "_" + upperFirst(node.Name) + "Result"
 			var memberNames []string
 
@@ -1037,6 +1060,16 @@ func inferFieldsRecursive(
 						// Merge all array elements for richer type inference
 						nestedObj = mergeArrayElementsRaw(rv)
 					}
+				}
+			}
+
+			// Mixed case: merge common (direct) fields into each fragment's selection tree
+			// so union member types include the shared fields alongside their type-specific fields
+			if node.HasDirectFields && node.Children != nil {
+				for i := range node.InlineFragments {
+					node.InlineFragments[i].SelectionTree = mergeSelectionNodes(
+						node.InlineFragments[i].SelectionTree, node.Children,
+					)
 				}
 			}
 

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -22,9 +22,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/praetorian-inc/vespasian/pkg/classify"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/parser"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
 )
 
 // graphqlBody represents a parsed GraphQL request body.
@@ -56,52 +57,9 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	seen := make(map[string]bool) // deduplicate by root field name
 
 	for _, ep := range endpoints {
-		if ep.APIType != "graphql" {
-			continue
+		if op, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes); ok {
+			ops = append(ops, op)
 		}
-
-		body := parseGraphQLBody(ep.Body)
-		if body == nil {
-			continue
-		}
-
-		parsed := parseQueryAST(body.Query)
-		if parsed == nil {
-			continue
-		}
-
-		opType := astOpTypeToString(parsed.opType)
-		fieldName := parsed.rootFieldName
-		if fieldName == "" {
-			anonCounter++
-			fieldName = fmt.Sprintf("anonymous%d", anonCounter)
-		}
-
-		if seen[fieldName] {
-			continue
-		}
-		seen[fieldName] = true
-
-		// Build argument types: prefer AST variable definitions mapped through arguments
-		args := buildArgTypes(parsed, body.Variables)
-
-		// Infer return type from response, using root field name to locate data
-		returnTypeName := upperFirst(fieldName) + "Response"
-		responseFields, isList := inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
-		if len(responseFields) > 0 {
-			syntheticTypes[returnTypeName] = &inferredType{
-				Name:   returnTypeName,
-				Fields: responseFields,
-			}
-		}
-
-		ops = append(ops, inferredOperation{
-			OpType:     opType,
-			FieldName:  fieldName,
-			Args:       args,
-			ReturnType: returnTypeName,
-			IsList:     isList,
-		})
 	}
 
 	if len(ops) == 0 {
@@ -172,6 +130,54 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	}
 
 	return []byte(sb.String()), nil
+}
+
+// processEndpoint processes a single classified endpoint and returns an inferred operation.
+func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType) (inferredOperation, bool) {
+	if ep.APIType != "graphql" {
+		return inferredOperation{}, false
+	}
+
+	body := parseGraphQLBody(ep.Body)
+	if body == nil {
+		return inferredOperation{}, false
+	}
+
+	parsed := parseQueryAST(body.Query)
+	if parsed == nil {
+		return inferredOperation{}, false
+	}
+
+	opType := astOpTypeToString(parsed.opType)
+	fieldName := parsed.rootFieldName
+	if fieldName == "" {
+		*anonCounter++
+		fieldName = fmt.Sprintf("anonymous%d", *anonCounter)
+	}
+
+	if seen[fieldName] {
+		return inferredOperation{}, false
+	}
+	seen[fieldName] = true
+
+	args := buildArgTypes(parsed, body.Variables)
+
+	returnTypeName := upperFirst(fieldName) + "Response"
+	responseFields, isList := inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
+	if len(responseFields) > 0 {
+		syntheticTypes[returnTypeName] = &inferredType{
+			Name:   returnTypeName,
+			Fields: responseFields,
+		}
+	}
+
+	return inferredOperation{
+		OpType:     opType,
+		FieldName:  fieldName,
+		Args:       args,
+		ReturnType: returnTypeName,
+		IsList:     isList,
+	}, true
 }
 
 // parsedQuery holds the results of parsing a GraphQL query string with gqlparser.
@@ -349,52 +355,8 @@ func inferTypeFromValue(v interface{}) string {
 // and uses selectionFields to guide which fields to include.
 // Returns the fields map and whether the response value was an array.
 func inferFieldsFromResponse(body []byte, rootFieldName string, selectionFields []string) (map[string]string, bool) {
-	if len(body) == 0 {
-		return nil, false
-	}
-
-	var envelope map[string]interface{}
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		return nil, false
-	}
-
-	data, ok := envelope["data"]
+	responseObj, isList, ok := unwrapResponseValue(body, rootFieldName)
 	if !ok {
-		return nil, false
-	}
-
-	dataMap, ok := data.(map[string]interface{})
-	if !ok {
-		return nil, false
-	}
-
-	// Look up the root field by name, then fall back to first key
-	responseVal, ok := dataMap[rootFieldName]
-	if !ok {
-		for _, v := range dataMap {
-			responseVal = v
-			break
-		}
-	}
-
-	if responseVal == nil {
-		return nil, false
-	}
-
-	// Handle array responses: inspect the first element
-	isList := false
-	var responseObj map[string]interface{}
-	switch rv := responseVal.(type) {
-	case []interface{}:
-		isList = true
-		if len(rv) > 0 {
-			responseObj, _ = rv[0].(map[string]interface{})
-		}
-	case map[string]interface{}:
-		responseObj = rv
-	}
-
-	if responseObj == nil {
 		return nil, isList
 	}
 
@@ -417,6 +379,56 @@ func inferFieldsFromResponse(body []byte, rootFieldName string, selectionFields 
 	}
 
 	return fields, isList
+}
+
+// unwrapResponseValue parses a GraphQL JSON response envelope, locates the response
+// value for the given root field, and unwraps arrays. Returns the response object,
+// whether it was a list, and whether a valid object was found.
+func unwrapResponseValue(body []byte, rootFieldName string) (map[string]interface{}, bool, bool) {
+	if len(body) == 0 {
+		return nil, false, false
+	}
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, false, false
+	}
+
+	data, ok := envelope["data"]
+	if !ok {
+		return nil, false, false
+	}
+
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return nil, false, false
+	}
+
+	responseVal, ok := dataMap[rootFieldName]
+	if !ok {
+		for _, v := range dataMap {
+			responseVal = v
+			break
+		}
+	}
+
+	if responseVal == nil {
+		return nil, false, false
+	}
+
+	switch rv := responseVal.(type) {
+	case []interface{}:
+		if len(rv) > 0 {
+			if obj, ok := rv[0].(map[string]interface{}); ok {
+				return obj, true, true
+			}
+		}
+		return nil, true, false
+	case map[string]interface{}:
+		return rv, false, true
+	default:
+		return nil, false, false
+	}
 }
 
 // upperFirst returns the string with its first character uppercased.

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -1054,7 +1054,7 @@ func inferFieldsRecursive(
 	for _, node := range tree {
 		// Infer field arguments if present
 		if len(node.Arguments) > 0 {
-			args := inferFieldArgTypes(node.Arguments, varTypes, inputTypes)
+			args := inferFieldArgTypes(node.Arguments, varTypes, inputTypes, typePrefix+"_"+upperFirst(node.Name))
 			if len(args) > 0 {
 				storeFieldArgs(syntheticTypes, parentTypeName, node.Name, args)
 			}
@@ -1199,7 +1199,8 @@ func inferFieldsRecursive(
 }
 
 // inferFieldArgTypes infers argument types for a field's arguments.
-func inferFieldArgTypes(args []*ast.Argument, varTypes map[string]string, inputTypes map[string]*inferredType) map[string]string {
+// fieldPrefix is used to disambiguate inline object type names (e.g., "AiInterviewer_BulkConfigs").
+func inferFieldArgTypes(args []*ast.Argument, varTypes map[string]string, inputTypes map[string]*inferredType, fieldPrefix string) map[string]string {
 	result := make(map[string]string)
 	for _, arg := range args {
 		if arg.Value != nil && arg.Value.Kind == ast.Variable {
@@ -1209,7 +1210,7 @@ func inferFieldArgTypes(args []*ast.Argument, varTypes map[string]string, inputT
 			}
 		}
 		if arg.Value != nil && arg.Value.Kind == ast.ObjectValue {
-			inputTypeName := upperFirst(arg.Name) + "Input"
+			inputTypeName := fieldPrefix + "_" + upperFirst(arg.Name) + "Input"
 			inferInputTypeFromASTObject(arg.Value, inputTypeName, inputTypes)
 			result[arg.Name] = inputTypeName
 			continue
@@ -1480,8 +1481,9 @@ func buildArgTypes(parsed *parsedQuery, variables map[string]interface{}, inputT
 			}
 		}
 		// Fix 3: Inline object literal — create input type
+		// Use rootFieldName + argName to disambiguate (e.g., ValidateEmail_InputInput vs SetCurrentUserFlowState_InputInput)
 		if arg.Value != nil && arg.Value.Kind == ast.ObjectValue {
-			inputTypeName := upperFirst(argName) + "Input"
+			inputTypeName := upperFirst(parsed.rootFieldName) + "_" + upperFirst(argName) + "Input"
 			inferInputTypeFromASTObject(arg.Value, inputTypeName, inputTypes)
 			args[argName] = inputTypeName
 			continue

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -19,15 +19,13 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/praetorian-inc/vespasian/pkg/classify"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
 )
-
-// operationRe matches GraphQL operation declarations (query/mutation/subscription OperationName).
-var operationRe = regexp.MustCompile(`^\s*(query|mutation|subscription)\s+(\w+)`)
 
 // graphqlBody represents a parsed GraphQL request body.
 type graphqlBody struct {
@@ -38,9 +36,10 @@ type graphqlBody struct {
 // inferredOperation holds an inferred GraphQL operation.
 type inferredOperation struct {
 	OpType     string            // "query", "mutation", or "subscription"
-	Name       string            // operation name
-	Args       map[string]string // variable name -> inferred type
+	FieldName  string            // root field name from the selection set
+	Args       map[string]string // argument name -> type
 	ReturnType string            // inferred return type name
+	IsList     bool              // whether the return type is a list
 }
 
 // inferredType holds a synthetic type inferred from response data.
@@ -54,7 +53,7 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	var ops []inferredOperation
 	syntheticTypes := make(map[string]*inferredType)
 	anonCounter := 0
-	seen := make(map[string]bool) // deduplicate by operation name
+	seen := make(map[string]bool) // deduplicate by root field name
 
 	for _, ep := range endpoints {
 		if ep.APIType != "graphql" {
@@ -66,29 +65,29 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 			continue
 		}
 
-		opType, opName := extractOperationInfo(body.Query)
-		if opName == "" {
-			anonCounter++
-			opName = fmt.Sprintf("Anonymous%d", anonCounter)
-		}
-		if opType == "" {
-			opType = "query"
-		}
-
-		if seen[opName] {
+		parsed := parseQueryAST(body.Query)
+		if parsed == nil {
 			continue
 		}
-		seen[opName] = true
 
-		// Infer argument types from variables
-		args := make(map[string]string)
-		for k, v := range body.Variables {
-			args[k] = inferTypeFromValue(v)
+		opType := astOpTypeToString(parsed.opType)
+		fieldName := parsed.rootFieldName
+		if fieldName == "" {
+			anonCounter++
+			fieldName = fmt.Sprintf("anonymous%d", anonCounter)
 		}
 
-		// Infer return type from response
-		returnTypeName := opName + "Response"
-		responseFields := inferFieldsFromResponse(ep.Response.Body, opName)
+		if seen[fieldName] {
+			continue
+		}
+		seen[fieldName] = true
+
+		// Build argument types: prefer AST variable definitions mapped through arguments
+		args := buildArgTypes(parsed, body.Variables)
+
+		// Infer return type from response, using root field name to locate data
+		returnTypeName := upperFirst(fieldName) + "Response"
+		responseFields, isList := inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
 		if len(responseFields) > 0 {
 			syntheticTypes[returnTypeName] = &inferredType{
 				Name:   returnTypeName,
@@ -98,9 +97,10 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 
 		ops = append(ops, inferredOperation{
 			OpType:     opType,
-			Name:       opName,
+			FieldName:  fieldName,
 			Args:       args,
 			ReturnType: returnTypeName,
+			IsList:     isList,
 		})
 	}
 
@@ -108,9 +108,9 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		return nil, errors.New("no GraphQL operations found in traffic")
 	}
 
-	// Sort operations by name for deterministic output
+	// Sort operations by field name for deterministic output
 	sort.Slice(ops, func(i, j int) bool {
-		return ops[i].Name < ops[j].Name
+		return ops[i].FieldName < ops[j].FieldName
 	})
 
 	var sb strings.Builder
@@ -133,13 +133,17 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		fmt.Fprintf(&sb, "\ntype %s {\n", typeName)
 		for _, op := range groupOps {
 			sb.WriteString("  ")
-			sb.WriteString(op.Name)
+			sb.WriteString(op.FieldName)
 			if len(op.Args) > 0 {
 				sb.WriteString("(")
 				writeArgs(&sb, op.Args)
 				sb.WriteString(")")
 			}
-			fmt.Fprintf(&sb, ": %s\n", op.ReturnType)
+			returnType := op.ReturnType
+			if op.IsList {
+				returnType = "[" + returnType + "]"
+			}
+			fmt.Fprintf(&sb, ": %s\n", returnType)
 		}
 		sb.WriteString("}\n")
 	}
@@ -155,7 +159,6 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		st := syntheticTypes[name]
 		fmt.Fprintf(&sb, "\ntype %s {\n", st.Name)
 
-		// Sort fields for determinism
 		var fieldNames []string
 		for fn := range st.Fields {
 			fieldNames = append(fieldNames, fn)
@@ -169,6 +172,126 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	}
 
 	return []byte(sb.String()), nil
+}
+
+// parsedQuery holds the results of parsing a GraphQL query string with gqlparser.
+type parsedQuery struct {
+	opType         ast.Operation
+	opName         string
+	rootFieldName  string
+	rootFieldArgs  []*ast.Argument      // arguments on the root field
+	varDefs        ast.VariableDefinitionList
+	selectionFields []string            // field names from the root field's selection set
+}
+
+// parseQueryAST parses a GraphQL query string and extracts operation info.
+func parseQueryAST(query string) *parsedQuery {
+	doc, parseErr := parser.ParseQuery(&ast.Source{Input: query})
+	if parseErr != nil || len(doc.Operations) == 0 {
+		return nil
+	}
+
+	op := doc.Operations[0]
+	result := &parsedQuery{
+		opType:  op.Operation,
+		opName:  op.Name,
+		varDefs: op.VariableDefinitions,
+	}
+
+	// Extract root field name and its selection set from the first field in the operation
+	if len(op.SelectionSet) > 0 {
+		if field, ok := op.SelectionSet[0].(*ast.Field); ok {
+			result.rootFieldName = field.Name
+			result.rootFieldArgs = field.Arguments
+			for _, sel := range field.SelectionSet {
+				if subField, ok := sel.(*ast.Field); ok {
+					result.selectionFields = append(result.selectionFields, subField.Name)
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// astOpTypeToString converts an ast.Operation to a string.
+func astOpTypeToString(op ast.Operation) string {
+	switch op {
+	case ast.Mutation:
+		return "mutation"
+	case ast.Subscription:
+		return "subscription"
+	default:
+		return "query"
+	}
+}
+
+// astTypeToSDL converts a gqlparser AST type to its SDL string representation.
+func astTypeToSDL(t *ast.Type) string {
+	if t == nil {
+		return "String"
+	}
+	var base string
+	if t.Elem != nil {
+		// List type
+		base = "[" + astTypeToSDL(t.Elem) + "]"
+	} else {
+		base = t.NamedType
+		if base == "" {
+			base = "String"
+		}
+	}
+	if t.NonNull {
+		base += "!"
+	}
+	return base
+}
+
+// buildArgTypes builds argument type mappings. It prefers declared variable types from the AST,
+// falling back to JSON value inference for variables not declared in the query.
+func buildArgTypes(parsed *parsedQuery, variables map[string]interface{}) map[string]string {
+	args := make(map[string]string)
+
+	// Build a map from variable name to its declared type
+	varTypes := make(map[string]string)
+	for _, vd := range parsed.varDefs {
+		varTypes[vd.Variable] = astTypeToSDL(vd.Type)
+	}
+
+	// Map root field arguments: arg name -> type from the variable it references
+	for _, arg := range parsed.rootFieldArgs {
+		argName := arg.Name
+		// If the argument value is a variable reference, use the variable's declared type
+		if arg.Value != nil && arg.Value.Kind == ast.Variable {
+			varName := arg.Value.Raw
+			if declaredType, ok := varTypes[varName]; ok {
+				args[argName] = declaredType
+				continue
+			}
+			// Fall back to JSON inference for this variable
+			if val, ok := variables[varName]; ok {
+				args[argName] = inferTypeFromValue(val)
+				continue
+			}
+		}
+		// Default fallback
+		args[argName] = "String"
+	}
+
+	// If no root field arguments were extracted but we have variables, use them directly
+	if len(args) == 0 {
+		for varName, varType := range varTypes {
+			args[varName] = varType
+		}
+		// For variables not declared in the query, infer from JSON values
+		for k, v := range variables {
+			if _, exists := args[k]; !exists {
+				args[k] = inferTypeFromValue(v)
+			}
+		}
+	}
+
+	return args
 }
 
 // writeArgs writes sorted argument definitions.
@@ -202,15 +325,6 @@ func parseGraphQLBody(body []byte) *graphqlBody {
 	return &gb
 }
 
-// extractOperationInfo extracts the operation type and name from a GraphQL query string.
-func extractOperationInfo(query string) (opType, opName string) {
-	matches := operationRe.FindStringSubmatch(query)
-	if len(matches) >= 3 {
-		return matches[1], matches[2]
-	}
-	return "", ""
-}
-
 // inferTypeFromValue infers a GraphQL type from a JSON value.
 func inferTypeFromValue(v interface{}) string {
 	switch val := v.(type) {
@@ -230,48 +344,85 @@ func inferTypeFromValue(v interface{}) string {
 	}
 }
 
-// inferFieldsFromResponse parses a GraphQL JSON response and extracts field types
-// from data.<operationName> or data.<firstKey>.
-func inferFieldsFromResponse(body []byte, opName string) map[string]string {
+// inferFieldsFromResponse parses a GraphQL JSON response and extracts field types.
+// It uses the root field name to locate the data, handles array responses,
+// and uses selectionFields to guide which fields to include.
+// Returns the fields map and whether the response value was an array.
+func inferFieldsFromResponse(body []byte, rootFieldName string, selectionFields []string) (map[string]string, bool) {
 	if len(body) == 0 {
-		return nil
+		return nil, false
 	}
 
 	var envelope map[string]interface{}
 	if err := json.Unmarshal(body, &envelope); err != nil {
-		return nil
+		return nil, false
 	}
 
 	data, ok := envelope["data"]
 	if !ok {
-		return nil
+		return nil, false
 	}
 
 	dataMap, ok := data.(map[string]interface{})
 	if !ok {
-		return nil
+		return nil, false
 	}
 
-	// Try operation name first, then first key
-	var responseObj map[string]interface{}
-	if obj, ok := dataMap[opName]; ok {
-		responseObj, _ = obj.(map[string]interface{})
-	}
-	if responseObj == nil {
-		// Use first key
+	// Look up the root field by name, then fall back to first key
+	responseVal, ok := dataMap[rootFieldName]
+	if !ok {
 		for _, v := range dataMap {
-			responseObj, _ = v.(map[string]interface{})
+			responseVal = v
 			break
 		}
 	}
 
+	if responseVal == nil {
+		return nil, false
+	}
+
+	// Handle array responses: inspect the first element
+	isList := false
+	var responseObj map[string]interface{}
+	switch rv := responseVal.(type) {
+	case []interface{}:
+		isList = true
+		if len(rv) > 0 {
+			responseObj, _ = rv[0].(map[string]interface{})
+		}
+	case map[string]interface{}:
+		responseObj = rv
+	}
+
 	if responseObj == nil {
-		return nil
+		return nil, isList
 	}
 
 	fields := make(map[string]string)
-	for k, v := range responseObj {
-		fields[k] = inferTypeFromValue(v)
+
+	// If we have selection fields from the query AST, use them as the authoritative field list
+	if len(selectionFields) > 0 {
+		for _, fieldName := range selectionFields {
+			if v, ok := responseObj[fieldName]; ok {
+				fields[fieldName] = inferTypeFromValue(v)
+			} else {
+				fields[fieldName] = "String"
+			}
+		}
+	} else {
+		// Fall back to all fields from the response object
+		for k, v := range responseObj {
+			fields[k] = inferTypeFromValue(v)
+		}
 	}
-	return fields
+
+	return fields, isList
+}
+
+// upperFirst returns the string with its first character uppercased.
+func upperFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -40,12 +40,14 @@ type graphqlBody struct {
 
 // inferredOperation holds an inferred GraphQL operation.
 type inferredOperation struct {
-	OpType     string            // "query", "mutation", or "subscription"
-	FieldName  string            // root field name from the selection set
-	OpName     string            // original operation name from the query
-	Args       map[string]string // argument name -> type
-	ReturnType string            // inferred return type name
-	IsList     bool              // whether the return type is a list
+	OpType         string            // "query", "mutation", or "subscription"
+	FieldName      string            // root field name from the selection set
+	OpName         string            // original operation name from the query
+	Args           map[string]string // argument name -> type
+	ReturnType     string            // inferred return type name
+	IsList         bool              // whether the return type is a list
+	TypePrefix     string            // prefix used for nested type names (op name when available)
+	ResponseFields map[string]string // fields for the root synthetic type (created after disambiguation)
 }
 
 // inferredType holds a synthetic type inferred from response data.
@@ -106,16 +108,31 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 					}
 					newFieldName := op.FieldName + "_" + suffix
 					newReturnType := upperFirst(newFieldName) + "Response"
-					// Update synthetic types: rename root and any nested types with the old prefix
-					oldPrefix := upperFirst(op.FieldName) + "_"
-					newPrefix := upperFirst(newFieldName) + "_"
-					renameSyntheticTypes(syntheticTypes, op.ReturnType, newReturnType, oldPrefix, newPrefix)
+					// Only rename the root type — nested types use op-name prefix
+					// and don't collide across operations
+					if st, ok := syntheticTypes[op.ReturnType]; ok {
+						delete(syntheticTypes, op.ReturnType)
+						st.Name = newReturnType
+						syntheticTypes[newReturnType] = st
+					}
 					groupOps[i].FieldName = newFieldName
 					groupOps[i].ReturnType = newReturnType
 				}
 			}
 		}
 		grouped[opType] = groupOps
+	}
+
+	// Create root synthetic types after disambiguation to avoid map collisions
+	for _, groupOps := range grouped {
+		for _, op := range groupOps {
+			if len(op.ResponseFields) > 0 {
+				syntheticTypes[op.ReturnType] = &inferredType{
+					Name:   op.ReturnType,
+					Fields: op.ResponseFields,
+				}
+			}
+		}
 	}
 
 	// Emit operation types in canonical order
@@ -215,6 +232,9 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 
 	returnTypeName := upperFirst(fieldName) + "Response"
 	typePrefix := upperFirst(fieldName)
+	if parsed.opName != "" {
+		typePrefix = parsed.opName
+	}
 
 	responseObj, isList, responseOK := unwrapResponseValue(ep.Response.Body, fieldName)
 	var responseFields map[string]string
@@ -224,20 +244,15 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 		// Fallback: existing flat inference
 		responseFields, isList = inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
 	}
-	if len(responseFields) > 0 {
-		syntheticTypes[returnTypeName] = &inferredType{
-			Name:   returnTypeName,
-			Fields: responseFields,
-		}
-	}
-
 	return inferredOperation{
-		OpType:     opType,
-		FieldName:  fieldName,
-		OpName:     parsed.opName,
-		Args:       args,
-		ReturnType: returnTypeName,
-		IsList:     isList,
+		OpType:         opType,
+		FieldName:      fieldName,
+		OpName:         parsed.opName,
+		Args:           args,
+		ReturnType:     returnTypeName,
+		IsList:         isList,
+		TypePrefix:     typePrefix,
+		ResponseFields: responseFields,
 	}, true
 }
 
@@ -683,37 +698,6 @@ func unwrapResponseValue(body []byte, rootFieldName string) (map[string]interfac
 		return rv, false, true
 	default:
 		return nil, false, false
-	}
-}
-
-// renameSyntheticTypes renames the root type and any nested types that share the old prefix.
-// It also updates field type references within renamed types.
-func renameSyntheticTypes(syntheticTypes map[string]*inferredType, oldRoot, newRoot, oldPrefix, newPrefix string) {
-	// Collect all types that need renaming
-	renames := make(map[string]string) // old name -> new name
-	if _, ok := syntheticTypes[oldRoot]; ok {
-		renames[oldRoot] = newRoot
-	}
-	for name := range syntheticTypes {
-		if strings.HasPrefix(name, oldPrefix) {
-			newName := newPrefix + name[len(oldPrefix):]
-			renames[name] = newName
-		}
-	}
-
-	// Apply renames
-	for oldName, newName := range renames {
-		st := syntheticTypes[oldName]
-		delete(syntheticTypes, oldName)
-		st.Name = newName
-		// Update field type references within this type
-		for fn, ft := range st.Fields {
-			for oldRef, newRef := range renames {
-				ft = strings.ReplaceAll(ft, oldRef, newRef)
-			}
-			st.Fields[fn] = ft
-		}
-		syntheticTypes[newName] = st
 	}
 }
 

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -106,12 +106,10 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 					}
 					newFieldName := op.FieldName + "_" + suffix
 					newReturnType := upperFirst(newFieldName) + "Response"
-					// Update the synthetic type name if it exists
-					if st, ok := syntheticTypes[op.ReturnType]; ok {
-						delete(syntheticTypes, op.ReturnType)
-						st.Name = newReturnType
-						syntheticTypes[newReturnType] = st
-					}
+					// Update synthetic types: rename root and any nested types with the old prefix
+					oldPrefix := upperFirst(op.FieldName) + "_"
+					newPrefix := upperFirst(newFieldName) + "_"
+					renameSyntheticTypes(syntheticTypes, op.ReturnType, newReturnType, oldPrefix, newPrefix)
 					groupOps[i].FieldName = newFieldName
 					groupOps[i].ReturnType = newReturnType
 				}
@@ -216,7 +214,16 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 	args := buildArgTypes(parsed, body.Variables)
 
 	returnTypeName := upperFirst(fieldName) + "Response"
-	responseFields, isList := inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
+	typePrefix := upperFirst(fieldName)
+
+	responseObj, isList, responseOK := unwrapResponseValue(ep.Response.Body, fieldName)
+	var responseFields map[string]string
+	if responseOK && responseObj != nil && len(parsed.selectionTree) > 0 {
+		responseFields = inferFieldsRecursive(responseObj, parsed.selectionTree, typePrefix, syntheticTypes)
+	} else {
+		// Fallback: existing flat inference
+		responseFields, isList = inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
+	}
 	if len(responseFields) > 0 {
 		syntheticTypes[returnTypeName] = &inferredType{
 			Name:   returnTypeName,
@@ -234,6 +241,12 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 	}, true
 }
 
+// selectionNode represents a field in a nested selection tree.
+type selectionNode struct {
+	Name     string
+	Children []*selectionNode // nil = leaf (scalar), non-nil = object with sub-fields
+}
+
 // parsedQuery holds the results of parsing a GraphQL query string with gqlparser.
 type parsedQuery struct {
 	opType          ast.Operation
@@ -241,7 +254,8 @@ type parsedQuery struct {
 	rootFieldName   string
 	rootFieldArgs   []*ast.Argument // arguments on the root field
 	varDefs         ast.VariableDefinitionList
-	selectionFields []string // field names from the root field's selection set
+	selectionFields []string           // field names from the root field's selection set (flat)
+	selectionTree   []*selectionNode   // nested selection tree for recursive type inference
 }
 
 // parseQueryAST parses a GraphQL query string and extracts operation info.
@@ -264,6 +278,7 @@ func parseQueryAST(query string) *parsedQuery {
 			result.rootFieldName = field.Name
 			result.rootFieldArgs = field.Arguments
 			result.selectionFields = collectSelectionFields(field.SelectionSet, doc.Fragments)
+			result.selectionTree = collectSelectionTree(field.SelectionSet, doc.Fragments)
 		}
 	}
 
@@ -308,6 +323,151 @@ func collectSelectionFields(selections ast.SelectionSet, fragments ast.FragmentD
 			fields = append(fields, collectSelectionFields(s.SelectionSet, fragments)...)
 		}
 	}
+	return fields
+}
+
+// isMetaField returns true for GraphQL introspection meta-fields like __typename.
+func isMetaField(name string) bool {
+	return strings.HasPrefix(name, "__")
+}
+
+// collectSelectionTree builds a recursive selection tree from an AST selection set.
+func collectSelectionTree(selections ast.SelectionSet, fragments ast.FragmentDefinitionList) []*selectionNode {
+	// Use ordered dedup: track seen names and their indices
+	seen := make(map[string]int)
+	var nodes []*selectionNode
+
+	for _, sel := range selections {
+		switch s := sel.(type) {
+		case *ast.Field:
+			if isMetaField(s.Name) {
+				continue
+			}
+			var children []*selectionNode
+			if len(s.SelectionSet) > 0 {
+				children = collectSelectionTree(s.SelectionSet, fragments)
+			}
+			if idx, ok := seen[s.Name]; ok {
+				// Merge children into existing node
+				if children != nil {
+					nodes[idx].Children = mergeSelectionNodes(nodes[idx].Children, children)
+				}
+			} else {
+				seen[s.Name] = len(nodes)
+				nodes = append(nodes, &selectionNode{Name: s.Name, Children: children})
+			}
+		case *ast.FragmentSpread:
+			if frag := fragments.ForName(s.Name); frag != nil {
+				fragNodes := collectSelectionTree(frag.SelectionSet, fragments)
+				nodes, seen = mergeIntoNodeList(nodes, seen, fragNodes)
+			}
+		case *ast.InlineFragment:
+			inlineNodes := collectSelectionTree(s.SelectionSet, fragments)
+			nodes, seen = mergeIntoNodeList(nodes, seen, inlineNodes)
+		}
+	}
+
+	return nodes
+}
+
+// mergeIntoNodeList merges source nodes into an existing ordered node list with deduplication.
+func mergeIntoNodeList(nodes []*selectionNode, seen map[string]int, source []*selectionNode) ([]*selectionNode, map[string]int) {
+	for _, sn := range source {
+		if idx, ok := seen[sn.Name]; ok {
+			if sn.Children != nil {
+				nodes[idx].Children = mergeSelectionNodes(nodes[idx].Children, sn.Children)
+			}
+		} else {
+			seen[sn.Name] = len(nodes)
+			nodes = append(nodes, sn)
+		}
+	}
+	return nodes, seen
+}
+
+// mergeSelectionNodes merges two child node slices, deduplicating by name.
+func mergeSelectionNodes(a, b []*selectionNode) []*selectionNode {
+	seen := make(map[string]int)
+	var merged []*selectionNode
+	for _, n := range a {
+		seen[n.Name] = len(merged)
+		merged = append(merged, n)
+	}
+	for _, n := range b {
+		if idx, ok := seen[n.Name]; ok {
+			if n.Children != nil {
+				merged[idx].Children = mergeSelectionNodes(merged[idx].Children, n.Children)
+			}
+		} else {
+			seen[n.Name] = len(merged)
+			merged = append(merged, n)
+		}
+	}
+	return merged
+}
+
+// inferFieldsRecursive walks the selection tree and response JSON together to build
+// nested synthetic types. It returns the fields map for the current level.
+func inferFieldsRecursive(
+	responseObj map[string]interface{},
+	tree []*selectionNode,
+	typePrefix string,
+	syntheticTypes map[string]*inferredType,
+) map[string]string {
+	fields := make(map[string]string)
+
+	for _, node := range tree {
+		if node.Children == nil {
+			// Leaf node: infer scalar type from response
+			if responseObj != nil {
+				if v, ok := responseObj[node.Name]; ok {
+					fields[node.Name] = inferTypeFromValue(v)
+					continue
+				}
+			}
+			fields[node.Name] = "String"
+			continue
+		}
+
+		// Object node: generate nested type
+		nestedTypeName := typePrefix + "_" + upperFirst(node.Name) + "Response"
+
+		// Extract nested response value
+		var nestedObj map[string]interface{}
+		isList := false
+		if responseObj != nil {
+			if v, ok := responseObj[node.Name]; ok {
+				switch rv := v.(type) {
+				case map[string]interface{}:
+					nestedObj = rv
+				case []interface{}:
+					isList = true
+					if len(rv) > 0 {
+						if obj, ok := rv[0].(map[string]interface{}); ok {
+							nestedObj = obj
+						}
+					}
+				}
+			}
+		}
+
+		// Recurse to build nested type fields
+		nestedFields := inferFieldsRecursive(nestedObj, node.Children, typePrefix+"_"+upperFirst(node.Name), syntheticTypes)
+
+		if len(nestedFields) > 0 {
+			syntheticTypes[nestedTypeName] = &inferredType{
+				Name:   nestedTypeName,
+				Fields: nestedFields,
+			}
+		}
+
+		if isList {
+			fields[node.Name] = "[" + nestedTypeName + "]"
+		} else {
+			fields[node.Name] = nestedTypeName
+		}
+	}
+
 	return fields
 }
 
@@ -523,6 +683,37 @@ func unwrapResponseValue(body []byte, rootFieldName string) (map[string]interfac
 		return rv, false, true
 	default:
 		return nil, false, false
+	}
+}
+
+// renameSyntheticTypes renames the root type and any nested types that share the old prefix.
+// It also updates field type references within renamed types.
+func renameSyntheticTypes(syntheticTypes map[string]*inferredType, oldRoot, newRoot, oldPrefix, newPrefix string) {
+	// Collect all types that need renaming
+	renames := make(map[string]string) // old name -> new name
+	if _, ok := syntheticTypes[oldRoot]; ok {
+		renames[oldRoot] = newRoot
+	}
+	for name := range syntheticTypes {
+		if strings.HasPrefix(name, oldPrefix) {
+			newName := newPrefix + name[len(oldPrefix):]
+			renames[name] = newName
+		}
+	}
+
+	// Apply renames
+	for oldName, newName := range renames {
+		st := syntheticTypes[oldName]
+		delete(syntheticTypes, oldName)
+		st.Name = newName
+		// Update field type references within this type
+		for fn, ft := range st.Fields {
+			for oldRef, newRef := range renames {
+				ft = strings.ReplaceAll(ft, oldRef, newRef)
+			}
+			st.Fields[fn] = ft
+		}
+		syntheticTypes[newName] = st
 	}
 }
 

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -155,6 +155,9 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		}
 	}
 
+	// Cross-type field type propagation: unify structurally similar types
+	unifyStructuralFieldTypes(syntheticTypes)
+
 	// Emit operation types in canonical order
 	for _, opType := range []string{"query", "mutation", "subscription"} {
 		groupOps, ok := grouped[opType]
@@ -1239,6 +1242,145 @@ func isMoreSpecificType(newType, existingType string) bool {
 		return true
 	}
 	return false
+}
+
+// isScalarType returns true if the type string represents a built-in GraphQL scalar.
+func isScalarType(t string) bool {
+	base := strings.TrimSuffix(t, "!")
+	return builtinScalars[base]
+}
+
+// scalarFieldNames returns the set of field names whose types are scalars.
+func scalarFieldNames(st *inferredType) map[string]bool {
+	names := make(map[string]bool)
+	for fieldName, fieldType := range st.Fields {
+		if isScalarType(fieldType) {
+			names[fieldName] = true
+		}
+	}
+	return names
+}
+
+// jaccardSimilarity computes |A∩B| / |A∪B| for two string sets.
+func jaccardSimilarity(a, b map[string]bool) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	intersection := 0
+	for k := range a {
+		if b[k] {
+			intersection++
+		}
+	}
+	union := len(a) + len(b) - intersection
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}
+
+// unifyStructuralFieldTypes detects structurally similar synthetic types and
+// propagates more-specific scalar field types across them. This fixes the case
+// where null responses cause all fields to default to String, even when other
+// operations returning the same structure have real data with correct types.
+func unifyStructuralFieldTypes(syntheticTypes map[string]*inferredType) {
+	// Step 1: Collect scalar field name sets for each type (skip types with < 3 scalar fields)
+	type typeInfo struct {
+		name        string
+		scalarNames map[string]bool
+	}
+	var candidates []typeInfo
+	for name, st := range syntheticTypes {
+		sn := scalarFieldNames(st)
+		if len(sn) >= 3 {
+			candidates = append(candidates, typeInfo{name: name, scalarNames: sn})
+		}
+	}
+
+	if len(candidates) < 2 {
+		return
+	}
+
+	// Sort for deterministic grouping
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].name < candidates[j].name
+	})
+
+	// Step 2: Union-find to group structurally similar types
+	parent := make([]int, len(candidates))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(x, y int) {
+		px, py := find(x), find(y)
+		if px != py {
+			parent[px] = py
+		}
+	}
+
+	for i := 0; i < len(candidates); i++ {
+		for j := i + 1; j < len(candidates); j++ {
+			// Count shared scalar fields
+			shared := 0
+			for k := range candidates[i].scalarNames {
+				if candidates[j].scalarNames[k] {
+					shared++
+				}
+			}
+			if shared >= 3 && jaccardSimilarity(candidates[i].scalarNames, candidates[j].scalarNames) >= 0.5 {
+				union(i, j)
+			}
+		}
+	}
+
+	// Step 3: Collect groups
+	groups := make(map[int][]int)
+	for i := range candidates {
+		root := find(i)
+		groups[root] = append(groups[root], i)
+	}
+
+	// Step 4: Within each group, propagate the most specific type for each scalar field
+	for _, members := range groups {
+		if len(members) < 2 {
+			continue
+		}
+
+		// Find the best type for each field across all group members
+		bestType := make(map[string]string)
+		for _, idx := range members {
+			st := syntheticTypes[candidates[idx].name]
+			for fieldName, fieldType := range st.Fields {
+				if !isScalarType(fieldType) {
+					continue
+				}
+				if existing, ok := bestType[fieldName]; !ok {
+					bestType[fieldName] = fieldType
+				} else if isMoreSpecificType(fieldType, existing) {
+					bestType[fieldName] = fieldType
+				}
+			}
+		}
+
+		// Apply best types back to all group members (only upgrade, never downgrade)
+		for _, idx := range members {
+			st := syntheticTypes[candidates[idx].name]
+			for fieldName, best := range bestType {
+				if current, ok := st.Fields[fieldName]; ok && isScalarType(current) {
+					if isMoreSpecificType(best, current) {
+						st.Fields[fieldName] = best
+					}
+				}
+			}
+		}
+	}
 }
 
 // upperFirst returns the string with its first character uppercased.

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -51,8 +51,9 @@ type inferredOperation struct {
 
 // inferredType holds a synthetic type inferred from response data.
 type inferredType struct {
-	Name   string
-	Fields map[string]string // field name -> type string
+	Name      string
+	Fields    map[string]string            // field name -> type string
+	FieldArgs map[string]map[string]string // field name -> (arg name -> arg type)
 }
 
 // inferSDL produces a partial SDL from observed GraphQL traffic.
@@ -145,8 +146,9 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 					}
 				} else {
 					syntheticTypes[op.ReturnType] = &inferredType{
-						Name:   op.ReturnType,
-						Fields: op.ResponseFields,
+						Name:      op.ReturnType,
+						Fields:    op.ResponseFields,
+						FieldArgs: make(map[string]map[string]string),
 					}
 				}
 			}
@@ -197,6 +199,14 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		sort.Strings(fieldNames)
 
 		for _, fn := range fieldNames {
+			if st.FieldArgs != nil {
+				if args, ok := st.FieldArgs[fn]; ok && len(args) > 0 {
+					fmt.Fprintf(&sb, "  %s(", fn)
+					writeArgs(&sb, args)
+					fmt.Fprintf(&sb, "): %s\n", st.Fields[fn])
+					continue
+				}
+			}
 			fmt.Fprintf(&sb, "  %s: %s\n", fn, st.Fields[fn])
 		}
 		sb.WriteString("}\n")
@@ -284,6 +294,12 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 	args := buildArgTypes(parsed, body.Variables, syntheticInputTypes)
 	inferInputTypes(parsed, body.Variables, syntheticInputTypes)
 
+	// Build variable type map for resolving field argument types
+	varTypes := make(map[string]string)
+	for _, vd := range parsed.varDefs {
+		varTypes[vd.Variable] = astTypeToSDL(vd.Type)
+	}
+
 	returnTypeName := upperFirst(fieldName) + "Response"
 	typePrefix := upperFirst(fieldName)
 
@@ -303,7 +319,7 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 
 		for _, frag := range parsed.inlineFragments {
 			memberNames = append(memberNames, frag.TypeName)
-			fragFields := inferFieldsRecursive(mergedObj, frag.SelectionTree, frag.TypeName, syntheticTypes)
+			fragFields := inferFieldsRecursive(mergedObj, frag.SelectionTree, frag.TypeName, syntheticTypes, varTypes, syntheticInputTypes, frag.TypeName)
 			if len(fragFields) > 0 {
 				if existing, ok := syntheticTypes[frag.TypeName]; ok {
 					for k, v := range fragFields {
@@ -313,8 +329,9 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 					}
 				} else {
 					syntheticTypes[frag.TypeName] = &inferredType{
-						Name:   frag.TypeName,
-						Fields: fragFields,
+						Name:      frag.TypeName,
+						Fields:    fragFields,
+						FieldArgs: make(map[string]map[string]string),
 					}
 				}
 			}
@@ -323,13 +340,13 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 		syntheticUnions[unionName] = memberNames
 		returnTypeName = unionName
 	} else if responseOK && responseObj != nil && len(parsed.selectionTree) > 0 {
-		responseFields = inferFieldsRecursive(responseObj, parsed.selectionTree, typePrefix, syntheticTypes)
+		responseFields = inferFieldsRecursive(responseObj, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName)
 	} else if scalarType, ok := detectScalarReturnType(ep.Response.Body, fieldName); ok {
 		// Fix 1: Scalar root field return
 		returnTypeName = scalarType
 	} else if len(parsed.selectionTree) > 0 {
 		// Fix 4: Response was null/error but we have selection tree — generate type from selection fields
-		responseFields = inferFieldsRecursive(nil, parsed.selectionTree, typePrefix, syntheticTypes)
+		responseFields = inferFieldsRecursive(nil, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName)
 	} else {
 		// Fallback: existing flat inference
 		responseFields, isList = inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
@@ -347,8 +364,9 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 
 // selectionNode represents a field in a nested selection tree.
 type selectionNode struct {
-	Name     string
-	Children []*selectionNode // nil = leaf (scalar), non-nil = object with sub-fields
+	Name      string
+	Children  []*selectionNode // nil = leaf (scalar), non-nil = object with sub-fields
+	Arguments []*ast.Argument  // field-level arguments from the query AST
 }
 
 // inlineFragmentInfo holds type condition and selection tree from an inline fragment.
@@ -468,9 +486,13 @@ func collectSelectionTree(selections ast.SelectionSet, fragments ast.FragmentDef
 				if children != nil {
 					nodes[idx].Children = mergeSelectionNodes(nodes[idx].Children, children)
 				}
+				// Merge arguments: keep first non-empty set
+				if len(nodes[idx].Arguments) == 0 && len(s.Arguments) > 0 {
+					nodes[idx].Arguments = s.Arguments
+				}
 			} else {
 				seen[s.Name] = len(nodes)
-				nodes = append(nodes, &selectionNode{Name: s.Name, Children: children})
+				nodes = append(nodes, &selectionNode{Name: s.Name, Children: children, Arguments: s.Arguments})
 			}
 		case *ast.FragmentSpread:
 			if frag := fragments.ForName(s.Name); frag != nil {
@@ -536,6 +558,9 @@ func mergeIntoNodeList(nodes []*selectionNode, seen map[string]int, source []*se
 			if sn.Children != nil {
 				nodes[idx].Children = mergeSelectionNodes(nodes[idx].Children, sn.Children)
 			}
+			if len(nodes[idx].Arguments) == 0 && len(sn.Arguments) > 0 {
+				nodes[idx].Arguments = sn.Arguments
+			}
 		} else {
 			seen[sn.Name] = len(nodes)
 			nodes = append(nodes, sn)
@@ -557,6 +582,9 @@ func mergeSelectionNodes(a, b []*selectionNode) []*selectionNode {
 			if n.Children != nil {
 				merged[idx].Children = mergeSelectionNodes(merged[idx].Children, n.Children)
 			}
+			if len(merged[idx].Arguments) == 0 && len(n.Arguments) > 0 {
+				merged[idx].Arguments = n.Arguments
+			}
 		} else {
 			seen[n.Name] = len(merged)
 			merged = append(merged, n)
@@ -567,15 +595,28 @@ func mergeSelectionNodes(a, b []*selectionNode) []*selectionNode {
 
 // inferFieldsRecursive walks the selection tree and response JSON together to build
 // nested synthetic types. It returns the fields map for the current level.
+// parentTypeName identifies the synthetic type being built at this level, so field
+// arguments can be stored in its FieldArgs.
 func inferFieldsRecursive(
 	responseObj map[string]interface{},
 	tree []*selectionNode,
 	typePrefix string,
 	syntheticTypes map[string]*inferredType,
+	varTypes map[string]string,
+	inputTypes map[string]*inferredType,
+	parentTypeName string,
 ) map[string]string {
 	fields := make(map[string]string)
 
 	for _, node := range tree {
+		// Infer field arguments if present
+		if len(node.Arguments) > 0 {
+			args := inferFieldArgTypes(node.Arguments, varTypes, inputTypes)
+			if len(args) > 0 {
+				storeFieldArgs(syntheticTypes, parentTypeName, node.Name, args)
+			}
+		}
+
 		if node.Children == nil {
 			// Leaf node: infer scalar type from response
 			if responseObj != nil {
@@ -611,7 +652,7 @@ func inferFieldsRecursive(
 		}
 
 		// Recurse to build nested type fields
-		nestedFields := inferFieldsRecursive(nestedObj, node.Children, typePrefix+"_"+upperFirst(node.Name), syntheticTypes)
+		nestedFields := inferFieldsRecursive(nestedObj, node.Children, typePrefix+"_"+upperFirst(node.Name), syntheticTypes, varTypes, inputTypes, nestedTypeName)
 
 		if len(nestedFields) > 0 {
 			if existing, ok := syntheticTypes[nestedTypeName]; ok {
@@ -622,8 +663,9 @@ func inferFieldsRecursive(
 				}
 			} else {
 				syntheticTypes[nestedTypeName] = &inferredType{
-					Name:   nestedTypeName,
-					Fields: nestedFields,
+					Name:      nestedTypeName,
+					Fields:    nestedFields,
+					FieldArgs: make(map[string]map[string]string),
 				}
 			}
 		}
@@ -636,6 +678,59 @@ func inferFieldsRecursive(
 	}
 
 	return fields
+}
+
+// inferFieldArgTypes infers argument types for a field's arguments.
+func inferFieldArgTypes(args []*ast.Argument, varTypes map[string]string, inputTypes map[string]*inferredType) map[string]string {
+	result := make(map[string]string)
+	for _, arg := range args {
+		if arg.Value != nil && arg.Value.Kind == ast.Variable {
+			if t, ok := varTypes[arg.Value.Raw]; ok {
+				result[arg.Name] = t
+				continue
+			}
+		}
+		if arg.Value != nil && arg.Value.Kind == ast.ObjectValue {
+			inputTypeName := upperFirst(arg.Name) + "Input"
+			inferInputTypeFromASTObject(arg.Value, inputTypeName, inputTypes)
+			result[arg.Name] = inputTypeName
+			continue
+		}
+		if arg.Value != nil {
+			result[arg.Name] = inferTypeFromASTValue(arg.Value)
+			continue
+		}
+		result[arg.Name] = "String"
+	}
+	return result
+}
+
+// storeFieldArgs stores field argument definitions on a synthetic type, creating the type if needed.
+func storeFieldArgs(syntheticTypes map[string]*inferredType, typeName string, fieldName string, args map[string]string) {
+	st, ok := syntheticTypes[typeName]
+	if !ok {
+		st = &inferredType{
+			Name:      typeName,
+			Fields:    make(map[string]string),
+			FieldArgs: make(map[string]map[string]string),
+		}
+		syntheticTypes[typeName] = st
+	}
+	if st.FieldArgs == nil {
+		st.FieldArgs = make(map[string]map[string]string)
+	}
+	if existing, ok := st.FieldArgs[fieldName]; ok {
+		// Merge: prefer more specific types
+		for k, v := range args {
+			if existingType, exists := existing[k]; !exists {
+				existing[k] = v
+			} else if isMoreSpecificType(v, existingType) {
+				existing[k] = v
+			}
+		}
+	} else {
+		st.FieldArgs[fieldName] = args
+	}
 }
 
 // extractNamedType unwraps list/non-null wrappers from an AST type to get the base named type.

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -18,7 +18,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
+	"mime"
+	"mime/multipart"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -38,6 +42,7 @@ type graphqlBody struct {
 type inferredOperation struct {
 	OpType     string            // "query", "mutation", or "subscription"
 	FieldName  string            // root field name from the selection set
+	OpName     string            // original operation name from the query
 	Args       map[string]string // argument name -> type
 	ReturnType string            // inferred return type name
 	IsList     bool              // whether the return type is a list
@@ -54,7 +59,7 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	var ops []inferredOperation
 	syntheticTypes := make(map[string]*inferredType)
 	anonCounter := 0
-	seen := make(map[string]bool) // deduplicate by root field name
+	seen := make(map[string]bool) // deduplicate by composite key (opType:fieldName:opName)
 
 	for _, ep := range endpoints {
 		if op, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes); ok {
@@ -78,6 +83,41 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	grouped := make(map[string][]inferredOperation)
 	for _, op := range ops {
 		grouped[op.OpType] = append(grouped[op.OpType], op)
+	}
+
+	// Disambiguate field name collisions within each operation type
+	for opType, groupOps := range grouped {
+		fieldCount := make(map[string]int)
+		for _, op := range groupOps {
+			fieldCount[op.FieldName]++
+		}
+
+		fieldSeen := make(map[string]bool)
+		for i, op := range groupOps {
+			if fieldCount[op.FieldName] > 1 {
+				if !fieldSeen[op.FieldName] {
+					// First occurrence keeps the bare name
+					fieldSeen[op.FieldName] = true
+				} else {
+					// Subsequent occurrences get a suffix from the operation name
+					suffix := op.OpName
+					if suffix == "" {
+						suffix = fmt.Sprintf("variant%d", i)
+					}
+					newFieldName := op.FieldName + "_" + suffix
+					newReturnType := upperFirst(newFieldName) + "Response"
+					// Update the synthetic type name if it exists
+					if st, ok := syntheticTypes[op.ReturnType]; ok {
+						delete(syntheticTypes, op.ReturnType)
+						st.Name = newReturnType
+						syntheticTypes[newReturnType] = st
+					}
+					groupOps[i].FieldName = newFieldName
+					groupOps[i].ReturnType = newReturnType
+				}
+			}
+		}
+		grouped[opType] = groupOps
 	}
 
 	// Emit operation types in canonical order
@@ -140,6 +180,14 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 
 	body := parseGraphQLBody(ep.Body)
 	if body == nil {
+		body = parseGraphQLURL(ep.URL)
+	}
+	if body == nil {
+		if ct := getContentType(ep.Headers); strings.Contains(ct, "multipart") {
+			body = parseGraphQLMultipart(ep.Body, ct)
+		}
+	}
+	if body == nil {
 		return inferredOperation{}, false
 	}
 
@@ -151,14 +199,19 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 	opType := astOpTypeToString(parsed.opType)
 	fieldName := parsed.rootFieldName
 	if fieldName == "" {
+		fieldName = lowerFirst(parsed.opName)
+	}
+	if fieldName == "" {
 		*anonCounter++
 		fieldName = fmt.Sprintf("anonymous%d", *anonCounter)
 	}
 
-	if seen[fieldName] {
+	// Deduplicate by composite key incorporating operation name
+	dedupKey := opType + ":" + fieldName + ":" + parsed.opName
+	if seen[dedupKey] {
 		return inferredOperation{}, false
 	}
-	seen[fieldName] = true
+	seen[dedupKey] = true
 
 	args := buildArgTypes(parsed, body.Variables)
 
@@ -174,6 +227,7 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 	return inferredOperation{
 		OpType:     opType,
 		FieldName:  fieldName,
+		OpName:     parsed.opName,
 		Args:       args,
 		ReturnType: returnTypeName,
 		IsList:     isList,
@@ -204,20 +258,57 @@ func parseQueryAST(query string) *parsedQuery {
 		varDefs: op.VariableDefinitions,
 	}
 
-	// Extract root field name and its selection set from the first field in the operation
+	// Extract root field name and its selection set, resolving fragment spreads
 	if len(op.SelectionSet) > 0 {
-		if field, ok := op.SelectionSet[0].(*ast.Field); ok {
+		if field := resolveFirstField(op.SelectionSet, doc.Fragments); field != nil {
 			result.rootFieldName = field.Name
 			result.rootFieldArgs = field.Arguments
-			for _, sel := range field.SelectionSet {
-				if subField, ok := sel.(*ast.Field); ok {
-					result.selectionFields = append(result.selectionFields, subField.Name)
-				}
-			}
+			result.selectionFields = collectSelectionFields(field.SelectionSet, doc.Fragments)
 		}
 	}
 
 	return result
+}
+
+// resolveFirstField walks a selection set to find the first concrete *ast.Field,
+// resolving fragment spreads and inline fragments as needed.
+func resolveFirstField(selections ast.SelectionSet, fragments ast.FragmentDefinitionList) *ast.Field {
+	for _, sel := range selections {
+		switch s := sel.(type) {
+		case *ast.Field:
+			return s
+		case *ast.FragmentSpread:
+			if frag := fragments.ForName(s.Name); frag != nil {
+				if field := resolveFirstField(frag.SelectionSet, fragments); field != nil {
+					return field
+				}
+			}
+		case *ast.InlineFragment:
+			if field := resolveFirstField(s.SelectionSet, fragments); field != nil {
+				return field
+			}
+		}
+	}
+	return nil
+}
+
+// collectSelectionFields recursively collects field names from a selection set,
+// resolving fragment spreads and inline fragments.
+func collectSelectionFields(selections ast.SelectionSet, fragments ast.FragmentDefinitionList) []string {
+	var fields []string
+	for _, sel := range selections {
+		switch s := sel.(type) {
+		case *ast.Field:
+			fields = append(fields, s.Name)
+		case *ast.FragmentSpread:
+			if frag := fragments.ForName(s.Name); frag != nil {
+				fields = append(fields, collectSelectionFields(frag.SelectionSet, fragments)...)
+			}
+		case *ast.InlineFragment:
+			fields = append(fields, collectSelectionFields(s.SelectionSet, fragments)...)
+		}
+	}
+	return fields
 }
 
 // astOpTypeToString converts an ast.Operation to a string.
@@ -441,4 +532,72 @@ func upperFirst(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// lowerFirst returns the string with its first character lowercased.
+func lowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToLower(s[:1]) + s[1:]
+}
+
+// parseGraphQLURL extracts a GraphQL operation from URL query parameters (GET requests).
+func parseGraphQLURL(rawURL string) *graphqlBody {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil
+	}
+	query := u.Query().Get("query")
+	if query == "" {
+		return nil
+	}
+	gb := &graphqlBody{Query: query}
+	if vars := u.Query().Get("variables"); vars != "" {
+		_ = json.Unmarshal([]byte(vars), &gb.Variables)
+	}
+	return gb
+}
+
+// parseGraphQLMultipart extracts a GraphQL operation from a multipart form data body.
+func parseGraphQLMultipart(body []byte, contentType string) *graphqlBody {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		return nil
+	}
+	reader := multipart.NewReader(strings.NewReader(string(body)), boundary)
+	for {
+		part, err := reader.NextPart()
+		if err != nil {
+			return nil
+		}
+		if part.FormName() == "operations" {
+			data, err := io.ReadAll(part)
+			if err != nil {
+				return nil
+			}
+			var gb graphqlBody
+			if err := json.Unmarshal(data, &gb); err != nil {
+				return nil
+			}
+			if gb.Query == "" {
+				return nil
+			}
+			return &gb
+		}
+	}
+}
+
+// getContentType returns the Content-Type header value, case-insensitively.
+func getContentType(headers map[string]string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, "content-type") {
+			return v
+		}
+	}
+	return ""
 }

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -46,8 +46,7 @@ type inferredOperation struct {
 	Args           map[string]string // argument name -> type
 	ReturnType     string            // inferred return type name
 	IsList         bool              // whether the return type is a list
-	TypePrefix     string            // prefix used for nested type names (op name when available)
-	ResponseFields map[string]string // fields for the root synthetic type (created after disambiguation)
+	ResponseFields map[string]string // fields for the root synthetic type
 }
 
 // inferredType holds a synthetic type inferred from response data.
@@ -88,49 +87,60 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		grouped[op.OpType] = append(grouped[op.OpType], op)
 	}
 
-	// Disambiguate field name collisions within each operation type
+	// Merge operations with the same root field name within each operation type
 	for opType, groupOps := range grouped {
-		fieldCount := make(map[string]int)
-		for _, op := range groupOps {
-			fieldCount[op.FieldName]++
-		}
+		merged := make(map[string]*inferredOperation) // fieldName -> merged op
+		var order []string                             // preserve first-seen order
 
-		fieldSeen := make(map[string]bool)
-		for i, op := range groupOps {
-			if fieldCount[op.FieldName] > 1 {
-				if !fieldSeen[op.FieldName] {
-					// First occurrence keeps the bare name
-					fieldSeen[op.FieldName] = true
-				} else {
-					// Subsequent occurrences get a suffix from the operation name
-					suffix := op.OpName
-					if suffix == "" {
-						suffix = fmt.Sprintf("variant%d", i)
+		for i := range groupOps {
+			op := &groupOps[i]
+			if existing, ok := merged[op.FieldName]; ok {
+				// Merge args (add new args, keep existing)
+				for k, v := range op.Args {
+					if _, exists := existing.Args[k]; !exists {
+						existing.Args[k] = v
 					}
-					newFieldName := op.FieldName + "_" + suffix
-					newReturnType := upperFirst(newFieldName) + "Response"
-					// Only rename the root type — nested types use op-name prefix
-					// and don't collide across operations
-					if st, ok := syntheticTypes[op.ReturnType]; ok {
-						delete(syntheticTypes, op.ReturnType)
-						st.Name = newReturnType
-						syntheticTypes[newReturnType] = st
-					}
-					groupOps[i].FieldName = newFieldName
-					groupOps[i].ReturnType = newReturnType
 				}
+				// Merge response fields
+				for k, v := range op.ResponseFields {
+					if _, exists := existing.ResponseFields[k]; !exists {
+						existing.ResponseFields[k] = v
+					}
+				}
+				// Upgrade to list if any operation shows it as a list
+				if op.IsList {
+					existing.IsList = true
+				}
+			} else {
+				merged[op.FieldName] = op
+				order = append(order, op.FieldName)
 			}
 		}
-		grouped[opType] = groupOps
+
+		// Rebuild groupOps from merged map in original order
+		var mergedOps []inferredOperation
+		for _, name := range order {
+			mergedOps = append(mergedOps, *merged[name])
+		}
+		grouped[opType] = mergedOps
 	}
 
-	// Create root synthetic types after disambiguation to avoid map collisions
+	// Create root synthetic types from merged operations
 	for _, groupOps := range grouped {
 		for _, op := range groupOps {
 			if len(op.ResponseFields) > 0 {
-				syntheticTypes[op.ReturnType] = &inferredType{
-					Name:   op.ReturnType,
-					Fields: op.ResponseFields,
+				if existing, ok := syntheticTypes[op.ReturnType]; ok {
+					// Merge fields into existing type
+					for k, v := range op.ResponseFields {
+						if _, exists := existing.Fields[k]; !exists {
+							existing.Fields[k] = v
+						}
+					}
+				} else {
+					syntheticTypes[op.ReturnType] = &inferredType{
+						Name:   op.ReturnType,
+						Fields: op.ResponseFields,
+					}
 				}
 			}
 		}
@@ -257,9 +267,6 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 
 	returnTypeName := upperFirst(fieldName) + "Response"
 	typePrefix := upperFirst(fieldName)
-	if parsed.opName != "" {
-		typePrefix = parsed.opName
-	}
 
 	responseObj, isList, responseOK := unwrapResponseValue(ep.Response.Body, fieldName)
 	var responseFields map[string]string
@@ -276,7 +283,6 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 		Args:           args,
 		ReturnType:     returnTypeName,
 		IsList:         isList,
-		TypePrefix:     typePrefix,
 		ResponseFields: responseFields,
 	}, true
 }
@@ -497,9 +503,17 @@ func inferFieldsRecursive(
 		nestedFields := inferFieldsRecursive(nestedObj, node.Children, typePrefix+"_"+upperFirst(node.Name), syntheticTypes)
 
 		if len(nestedFields) > 0 {
-			syntheticTypes[nestedTypeName] = &inferredType{
-				Name:   nestedTypeName,
-				Fields: nestedFields,
+			if existing, ok := syntheticTypes[nestedTypeName]; ok {
+				for k, v := range nestedFields {
+					if _, exists := existing.Fields[k]; !exists {
+						existing.Fields[k] = v
+					}
+				}
+			} else {
+				syntheticTypes[nestedTypeName] = &inferredType{
+					Name:   nestedTypeName,
+					Fields: nestedFields,
+				}
 			}
 		}
 

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -371,8 +371,10 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 		fieldName = fmt.Sprintf("anonymous%d", *anonCounter)
 	}
 
-	// Deduplicate by composite key incorporating operation name
-	dedupKey := opType + ":" + fieldName + ":" + parsed.opName
+	// Deduplicate by composite key incorporating operation name and selection fingerprint.
+	// The fingerprint ensures different queries with the same opName are not collapsed.
+	selFP := selectionFingerprint(parsed.selectionFields)
+	dedupKey := opType + ":" + fieldName + ":" + parsed.opName + ":" + selFP
 	if seen[dedupKey] {
 		return inferredOperation{}, false
 	}
@@ -465,8 +467,9 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 // selectionNode represents a field in a nested selection tree.
 type selectionNode struct {
 	Name            string
-	Children        []*selectionNode   // nil = leaf (scalar), non-nil = object with sub-fields
-	Arguments       []*ast.Argument    // field-level arguments from the query AST
+	Aliases         []string             // aliases used for this field in queries (for response data lookup)
+	Children        []*selectionNode     // nil = leaf (scalar), non-nil = object with sub-fields
+	Arguments       []*ast.Argument      // field-level arguments from the query AST
 	InlineFragments []inlineFragmentInfo // inline fragments with type conditions on this sub-field
 	HasDirectFields bool                 // true if this field has direct field selections alongside inline fragments
 }
@@ -509,6 +512,10 @@ func parseQueryAST(query string) []*parsedQuery {
 		return nil
 	}
 
+	// Merge duplicate root fields (e.g., multiple fragment spreads contributing the same
+	// field name like "viewer") so all selection sets and arguments are combined.
+	rootFields = mergeRootFieldsByName(rootFields)
+
 	var results []*parsedQuery
 	for _, field := range rootFields {
 		result := &parsedQuery{
@@ -545,6 +552,36 @@ func resolveAllFields(selections ast.SelectionSet, fragments ast.FragmentDefinit
 		}
 	}
 	return fields
+}
+
+// mergeRootFieldsByName groups root fields by name and merges their SelectionSets
+// and Arguments. This handles queries where multiple fragment spreads contribute
+// different selection sets for the same root field (e.g., "viewer").
+func mergeRootFieldsByName(fields []*ast.Field) []*ast.Field {
+	seen := make(map[string]int)
+	var result []*ast.Field
+	for _, f := range fields {
+		if idx, ok := seen[f.Name]; ok {
+			result[idx].SelectionSet = append(result[idx].SelectionSet, f.SelectionSet...)
+			// Union-merge arguments by name
+			for _, newArg := range f.Arguments {
+				found := false
+				for _, ea := range result[idx].Arguments {
+					if ea.Name == newArg.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					result[idx].Arguments = append(result[idx].Arguments, newArg)
+				}
+			}
+		} else {
+			seen[f.Name] = len(result)
+			result = append(result, f)
+		}
+	}
+	return result
 }
 
 // resolveFirstField walks a selection set to find the first concrete *ast.Field,
@@ -588,6 +625,15 @@ func collectSelectionFields(selections ast.SelectionSet, fragments ast.FragmentD
 		}
 	}
 	return fields
+}
+
+// selectionFingerprint returns a deterministic string fingerprint for a set of field names.
+// Used to distinguish queries with different selection sets but the same operation name.
+func selectionFingerprint(fields []string) string {
+	sorted := make([]string, len(fields))
+	copy(sorted, fields)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
 }
 
 // isMetaField returns true for GraphQL introspection meta-fields like __typename.
@@ -644,10 +690,19 @@ func collectSelectionTree(selections ast.SelectionSet, fragments ast.FragmentDef
 						nodes[idx].Arguments = append(nodes[idx].Arguments, newArg)
 					}
 				}
+				// Track alias for response data lookup
+				if s.Alias != "" && s.Alias != s.Name {
+					nodes[idx].Aliases = appendUnique(nodes[idx].Aliases, s.Alias)
+				}
 			} else {
+				var aliases []string
+				if s.Alias != "" && s.Alias != s.Name {
+					aliases = []string{s.Alias}
+				}
 				seen[s.Name] = len(nodes)
 				nodes = append(nodes, &selectionNode{
 					Name:            s.Name,
+					Aliases:         aliases,
 					Children:        children,
 					Arguments:       s.Arguments,
 					InlineFragments: subFrags,
@@ -694,13 +749,31 @@ func collectInlineFragments(selections ast.SelectionSet, fragments ast.FragmentD
 				nested := collectInlineFragments(frag.SelectionSet, fragments)
 				if len(nested) > 0 {
 					// Fragment contains type-narrowing inline fragments (e.g., fragment X on Viewer { ... on User { ... } })
-					// Only extract the nested fragments — the outer fragment is on the parent type, not a union member
+					// Extract the nested fragments — the outer fragment is on the parent type, not a union member
 					for _, n := range nested {
 						if idx, ok := seen[n.TypeName]; ok {
 							frags[idx].SelectionTree = mergeSelectionNodes(frags[idx].SelectionTree, n.SelectionTree)
 						} else {
 							seen[n.TypeName] = len(frags)
 							frags = append(frags, n)
+						}
+					}
+					// Also collect direct *ast.Field entries from the fragment body
+					// and merge them into the fragment's type condition. This handles
+					// fragments that have both nested inline fragments AND direct fields
+					// (e.g., fragment Wallet_user on User { ...WalletDashboard_user referFriend { ... } })
+					if frag.TypeCondition != "" {
+						directTree := collectDirectFieldNodes(frag.SelectionSet, fragments)
+						if len(directTree) > 0 {
+							if idx, ok := seen[frag.TypeCondition]; ok {
+								frags[idx].SelectionTree = mergeSelectionNodes(frags[idx].SelectionTree, directTree)
+							} else {
+								seen[frag.TypeCondition] = len(frags)
+								frags = append(frags, inlineFragmentInfo{
+									TypeName:      frag.TypeCondition,
+									SelectionTree: directTree,
+								})
+							}
 						}
 					}
 				} else if frag.TypeCondition != "" {
@@ -731,6 +804,22 @@ func collectInlineFragments(selections ast.SelectionSet, fragments ast.FragmentD
 	}
 
 	return frags
+}
+
+// collectDirectFieldNodes extracts only direct *ast.Field entries from a selection set
+// (ignoring inline fragments and fragment spreads) and builds them into selection nodes.
+// Used to capture sibling fields that appear alongside nested inline fragments.
+func collectDirectFieldNodes(selections ast.SelectionSet, fragments ast.FragmentDefinitionList) []*selectionNode {
+	var fieldOnly ast.SelectionSet
+	for _, sel := range selections {
+		if _, ok := sel.(*ast.Field); ok {
+			fieldOnly = append(fieldOnly, sel)
+		}
+	}
+	if len(fieldOnly) == 0 {
+		return nil
+	}
+	return collectSelectionTree(fieldOnly, fragments)
 }
 
 // hasTopLevelFields returns true if a selection set contains direct field selections
@@ -768,6 +857,10 @@ func mergeIntoNodeList(nodes []*selectionNode, seen map[string]int, source []*se
 				if !found {
 					nodes[idx].Arguments = append(nodes[idx].Arguments, newArg)
 				}
+			}
+			// Merge aliases
+			for _, alias := range sn.Aliases {
+				nodes[idx].Aliases = appendUnique(nodes[idx].Aliases, alias)
 			}
 		} else {
 			seen[sn.Name] = len(nodes)
@@ -808,6 +901,10 @@ func mergeSelectionNodes(a, b []*selectionNode) []*selectionNode {
 					merged[idx].Arguments = append(merged[idx].Arguments, newArg)
 				}
 			}
+			// Merge aliases
+			for _, alias := range n.Aliases {
+				merged[idx].Aliases = appendUnique(merged[idx].Aliases, alias)
+			}
 		} else {
 			seen[n.Name] = len(merged)
 			merged = append(merged, n)
@@ -834,6 +931,67 @@ func mergeInlineFragments(a, b []inlineFragmentInfo) []inlineFragmentInfo {
 		}
 	}
 	return merged
+}
+
+// lookupResponseValue looks up a response value by the node's name and any known aliases.
+// When multiple keys match (e.g., aliased and non-aliased versions of the same field),
+// it prefers the richest value — a non-nil map or non-empty slice over nil/empty ones.
+// This ensures aliased fields like `validFareLocks: fareLocks(first:3)` contribute
+// their response data for type inference even when a non-aliased empty variant exists.
+func lookupResponseValue(responseObj map[string]interface{}, node *selectionNode) (interface{}, bool) {
+	var bestVal interface{}
+	found := false
+
+	// Check canonical name
+	if v, ok := responseObj[node.Name]; ok {
+		bestVal = v
+		found = true
+	}
+
+	// Check aliases, preferring richer values
+	for _, alias := range node.Aliases {
+		if alias != node.Name {
+			if v, ok := responseObj[alias]; ok {
+				if !found || isRicherValue(v, bestVal) {
+					bestVal = v
+					found = true
+				}
+			}
+		}
+	}
+
+	return bestVal, found
+}
+
+// isRicherValue returns true if candidate provides more type information than current.
+// A non-nil map or non-empty slice is richer than nil, a scalar, or an empty collection.
+func isRicherValue(candidate, current interface{}) bool {
+	if current == nil {
+		return candidate != nil
+	}
+	switch cv := candidate.(type) {
+	case map[string]interface{}:
+		if cm, ok := current.(map[string]interface{}); ok {
+			return len(cv) > len(cm)
+		}
+		return true // map is richer than scalar/nil
+	case []interface{}:
+		if ca, ok := current.([]interface{}); ok {
+			return len(cv) > len(ca)
+		}
+		return true // non-empty list is richer than scalar/nil
+	}
+	return false
+}
+
+// appendUnique appends a string to a slice only if it is not already present.
+func appendUnique(slice []string, val string) []string {
+	for _, s := range slice {
+		if s == val {
+			return slice
+		}
+	}
+	return append(slice, val)
 }
 
 // inferFieldsRecursive walks the selection tree and response JSON together to build
@@ -870,7 +1028,7 @@ func inferFieldsRecursive(
 			var nestedObj map[string]interface{}
 			isList := false
 			if responseObj != nil {
-				if v, ok := responseObj[node.Name]; ok {
+				if v, ok := lookupResponseValue(responseObj, node); ok {
 					switch rv := v.(type) {
 					case map[string]interface{}:
 						nestedObj = rv
@@ -929,7 +1087,7 @@ func inferFieldsRecursive(
 		if node.Children == nil {
 			// Leaf node: infer scalar type from response
 			if responseObj != nil {
-				if v, ok := responseObj[node.Name]; ok {
+				if v, ok := lookupResponseValue(responseObj, node); ok {
 					fields[node.Name] = inferTypeFromValue(v)
 					continue
 				}
@@ -945,7 +1103,7 @@ func inferFieldsRecursive(
 		var nestedObj map[string]interface{}
 		isList := false
 		if responseObj != nil {
-			if v, ok := responseObj[node.Name]; ok {
+			if v, ok := lookupResponseValue(responseObj, node); ok {
 				switch rv := v.(type) {
 				case map[string]interface{}:
 					nestedObj = rv

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -403,7 +403,7 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 	returnTypeName := upperFirst(fieldName) + "Response"
 	typePrefix := upperFirst(fieldName)
 
-	responseObj, isList, responseOK := unwrapResponseValue(ep.Response.Body, fieldName)
+	responseObj, isList, responseOK := unwrapResponseValue(ep.Response.Body, fieldName, parsed.rootFieldAliases...)
 	var responseFields map[string]string
 
 	if len(parsed.inlineFragments) >= 1 {
@@ -412,7 +412,7 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 		var memberNames []string
 
 		// Merge all array elements for type inference
-		mergedObj := mergeArrayElements(ep.Response.Body, fieldName)
+		mergedObj := mergeArrayElements(ep.Response.Body, fieldName, parsed.rootFieldAliases...)
 		if mergedObj == nil {
 			mergedObj = responseObj
 		}
@@ -464,14 +464,14 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 		returnTypeName = unionName
 	} else if responseOK && responseObj != nil && len(parsed.selectionTree) > 0 {
 		responseFields = inferFieldsRecursive(responseObj, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName, syntheticUnions)
-	} else if scalarType, ok := detectScalarReturnType(ep.Response.Body, fieldName); ok {
+	} else if scalarType, ok := detectScalarReturnType(ep.Response.Body, fieldName, parsed.rootFieldAliases...); ok {
 		returnTypeName = scalarType
 	} else if len(parsed.selectionTree) > 0 {
 		// Response was null/error but we have selection tree — generate type from selection fields
 		responseFields = inferFieldsRecursive(nil, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName, syntheticUnions)
 	} else {
 		// Fallback: existing flat inference
-		responseFields, isList = inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
+		responseFields, isList = inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields, parsed.rootFieldAliases...)
 	}
 	return inferredOperation{
 		OpType:         opType,
@@ -505,7 +505,8 @@ type parsedQuery struct {
 	opType               ast.Operation
 	opName               string
 	rootFieldName        string
-	rootFieldArgs        []*ast.Argument // arguments on the root field
+	rootFieldAliases     []string              // aliases used for this root field in queries (for response data lookup)
+	rootFieldArgs        []*ast.Argument       // arguments on the root field
 	varDefs              ast.VariableDefinitionList
 	selectionFields      []string              // field names from the root field's selection set (flat)
 	selectionTree        []*selectionNode      // nested selection tree for recursive type inference
@@ -548,11 +549,17 @@ func parseQueryAST(query string) []*parsedQuery {
 		} else {
 			tree = collectSelectionTree(field.SelectionSet, doc.Fragments)
 		}
+		// Capture root field alias if it differs from the field name
+		var aliases []string
+		if field.Alias != "" && field.Alias != field.Name {
+			aliases = []string{field.Alias}
+		}
 		result := &parsedQuery{
 			opType:               op.Operation,
 			opName:               op.Name,
 			varDefs:              op.VariableDefinitions,
 			rootFieldName:        field.Name,
+			rootFieldAliases:     aliases,
 			rootFieldArgs:        field.Arguments,
 			selectionFields:      collectSelectionFields(field.SelectionSet, doc.Fragments),
 			selectionTree:        tree,
@@ -1545,8 +1552,8 @@ func inferTypeFromValue(v interface{}) string {
 // It uses the root field name to locate the data, handles array responses,
 // and uses selectionFields to guide which fields to include.
 // Returns the fields map and whether the response value was an array.
-func inferFieldsFromResponse(body []byte, rootFieldName string, selectionFields []string) (map[string]string, bool) {
-	responseObj, isList, ok := unwrapResponseValue(body, rootFieldName)
+func inferFieldsFromResponse(body []byte, rootFieldName string, selectionFields []string, aliases ...string) (map[string]string, bool) {
+	responseObj, isList, ok := unwrapResponseValue(body, rootFieldName, aliases...)
 	if !ok {
 		return nil, isList
 	}
@@ -1577,7 +1584,7 @@ func inferFieldsFromResponse(body []byte, rootFieldName string, selectionFields 
 // unwrapResponseValue parses a GraphQL JSON response envelope, locates the response
 // value for the given root field, and unwraps arrays. Returns the response object,
 // whether it was a list, and whether a valid object was found.
-func unwrapResponseValue(body []byte, rootFieldName string) (map[string]interface{}, bool, bool) {
+func unwrapResponseValue(body []byte, rootFieldName string, aliases ...string) (map[string]interface{}, bool, bool) {
 	if len(body) == 0 {
 		return nil, false, false
 	}
@@ -1599,17 +1606,17 @@ func unwrapResponseValue(body []byte, rootFieldName string) (map[string]interfac
 
 	responseVal, ok := dataMap[rootFieldName]
 	if !ok {
-		keys := make([]string, 0, len(dataMap))
-		for k := range dataMap {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		if len(keys) > 0 {
-			responseVal = dataMap[keys[0]]
+		// Try aliases before giving up
+		for _, alias := range aliases {
+			if v, exists := dataMap[alias]; exists {
+				responseVal = v
+				ok = true
+				break
+			}
 		}
 	}
 
-	if responseVal == nil {
+	if !ok || responseVal == nil {
 		return nil, false, false
 	}
 
@@ -1630,7 +1637,7 @@ func unwrapResponseValue(body []byte, rootFieldName string) (map[string]interfac
 
 // detectScalarReturnType checks if a GraphQL response field is a scalar value
 // and returns the corresponding SDL type name.
-func detectScalarReturnType(body []byte, rootFieldName string) (string, bool) {
+func detectScalarReturnType(body []byte, rootFieldName string, aliases ...string) (string, bool) {
 	if len(body) == 0 {
 		return "", false
 	}
@@ -1652,14 +1659,15 @@ func detectScalarReturnType(body []byte, rootFieldName string) (string, bool) {
 
 	responseVal, ok := dataMap[rootFieldName]
 	if !ok {
-		keys := make([]string, 0, len(dataMap))
-		for k := range dataMap {
-			keys = append(keys, k)
+		// Try aliases before giving up
+		for _, alias := range aliases {
+			if v, exists := dataMap[alias]; exists {
+				responseVal = v
+				ok = true
+				break
+			}
 		}
-		sort.Strings(keys)
-		if len(keys) > 0 {
-			responseVal = dataMap[keys[0]]
-		} else {
+		if !ok {
 			return "", false
 		}
 	}
@@ -1681,7 +1689,7 @@ func detectScalarReturnType(body []byte, rootFieldName string) (string, bool) {
 
 // mergeArrayElements parses a GraphQL response and merges all array elements
 // for the given root field into a single map for comprehensive type inference.
-func mergeArrayElements(body []byte, rootFieldName string) map[string]interface{} {
+func mergeArrayElements(body []byte, rootFieldName string, aliases ...string) map[string]interface{} {
 	if len(body) == 0 {
 		return nil
 	}
@@ -1703,7 +1711,17 @@ func mergeArrayElements(body []byte, rootFieldName string) map[string]interface{
 
 	responseVal, ok := dataMap[rootFieldName]
 	if !ok {
-		return nil
+		// Try aliases before giving up
+		for _, alias := range aliases {
+			if v, exists := dataMap[alias]; exists {
+				responseVal = v
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return nil
+		}
 	}
 
 	arr, ok := responseVal.([]interface{})

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -208,6 +208,17 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 				}
 				grouped[opType] = groupOps
 			}
+			// Update field references in synthetic types that still point to the deleted Response type
+			for _, st := range syntheticTypes {
+				for fieldName, fieldType := range st.Fields {
+					if fieldType == responseName {
+						st.Fields[fieldName] = unionName
+					}
+					if fieldType == "["+responseName+"]" {
+						st.Fields[fieldName] = "[" + unionName + "]"
+					}
+				}
+			}
 		}
 		// Also remove any type with the same name as the union itself
 		delete(syntheticTypes, unionName)

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -406,9 +406,13 @@ func unwrapResponseValue(body []byte, rootFieldName string) (map[string]interfac
 
 	responseVal, ok := dataMap[rootFieldName]
 	if !ok {
-		for _, v := range dataMap {
-			responseVal = v
-			break
+		keys := make([]string, 0, len(dataMap))
+		for k := range dataMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		if len(keys) > 0 {
+			responseVal = dataMap[keys[0]]
 		}
 	}
 

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -354,7 +354,9 @@ func collectSelectionFields(selections ast.SelectionSet, fragments ast.FragmentD
 	for _, sel := range selections {
 		switch s := sel.(type) {
 		case *ast.Field:
-			fields = append(fields, s.Name)
+			if !isMetaField(s.Name) {
+				fields = append(fields, s.Name)
+			}
 		case *ast.FragmentSpread:
 			if frag := fragments.ForName(s.Name); frag != nil {
 				fields = append(fields, collectSelectionFields(frag.SelectionSet, fragments)...)
@@ -777,7 +779,9 @@ func inferFieldsFromResponse(body []byte, rootFieldName string, selectionFields 
 	} else {
 		// Fall back to all fields from the response object
 		for k, v := range responseObj {
-			fields[k] = inferTypeFromValue(v)
+			if !isMetaField(k) {
+				fields[k] = inferTypeFromValue(v)
+			}
 		}
 	}
 

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -175,7 +175,17 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		// Convention: union is FooResult, response type is FooResponse
 		baseName := strings.TrimSuffix(unionName, "Result")
 		responseName := baseName + "Response"
-		if responseType, ok := syntheticTypes[responseName]; ok {
+
+		// Check if the Response type name is a union member — if so, keep it
+		isUnionMember := false
+		for _, m := range members {
+			if m == responseName {
+				isUnionMember = true
+				break
+			}
+		}
+
+		if responseType, ok := syntheticTypes[responseName]; ok && !isUnionMember {
 			// Merge response fields into the first union member type
 			if len(members) > 0 && len(responseType.Fields) > 0 {
 				firstMember := members[0]
@@ -396,7 +406,7 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 
 		for _, frag := range parsed.inlineFragments {
 			memberNames = append(memberNames, frag.TypeName)
-			fragFields := inferFieldsRecursive(mergedObj, frag.SelectionTree, frag.TypeName, syntheticTypes, varTypes, syntheticInputTypes, frag.TypeName)
+			fragFields := inferFieldsRecursive(mergedObj, frag.SelectionTree, frag.TypeName, syntheticTypes, varTypes, syntheticInputTypes, frag.TypeName, syntheticUnions)
 			if len(fragFields) > 0 {
 				if existing, ok := syntheticTypes[frag.TypeName]; ok {
 					for k, v := range fragFields {
@@ -431,12 +441,12 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 		}
 		returnTypeName = unionName
 	} else if responseOK && responseObj != nil && len(parsed.selectionTree) > 0 {
-		responseFields = inferFieldsRecursive(responseObj, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName)
+		responseFields = inferFieldsRecursive(responseObj, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName, syntheticUnions)
 	} else if scalarType, ok := detectScalarReturnType(ep.Response.Body, fieldName); ok {
 		returnTypeName = scalarType
 	} else if len(parsed.selectionTree) > 0 {
 		// Response was null/error but we have selection tree — generate type from selection fields
-		responseFields = inferFieldsRecursive(nil, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName)
+		responseFields = inferFieldsRecursive(nil, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName, syntheticUnions)
 	} else {
 		// Fallback: existing flat inference
 		responseFields, isList = inferFieldsFromResponse(ep.Response.Body, fieldName, parsed.selectionFields)
@@ -454,9 +464,11 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 
 // selectionNode represents a field in a nested selection tree.
 type selectionNode struct {
-	Name      string
-	Children  []*selectionNode // nil = leaf (scalar), non-nil = object with sub-fields
-	Arguments []*ast.Argument  // field-level arguments from the query AST
+	Name            string
+	Children        []*selectionNode   // nil = leaf (scalar), non-nil = object with sub-fields
+	Arguments       []*ast.Argument    // field-level arguments from the query AST
+	InlineFragments []inlineFragmentInfo // inline fragments with type conditions on this sub-field
+	HasDirectFields bool                 // true if this field has direct field selections alongside inline fragments
 }
 
 // inlineFragmentInfo holds type condition and selection tree from an inline fragment.
@@ -596,21 +608,51 @@ func collectSelectionTree(selections ast.SelectionSet, fragments ast.FragmentDef
 				continue
 			}
 			var children []*selectionNode
+			var subFrags []inlineFragmentInfo
+			hasDirectFields := false
 			if len(s.SelectionSet) > 0 {
-				children = collectSelectionTree(s.SelectionSet, fragments)
+				// Check if this sub-field has inline fragments (union/interface pattern)
+				subFrags = collectInlineFragments(s.SelectionSet, fragments)
+				hasDirectFields = hasTopLevelFields(s.SelectionSet)
+				if len(subFrags) > 0 && !hasDirectFields {
+					// Pure union/interface pattern: don't flatten into children
+					children = nil
+				} else {
+					children = collectSelectionTree(s.SelectionSet, fragments)
+				}
 			}
 			if idx, ok := seen[s.Name]; ok {
 				// Merge children into existing node
 				if children != nil {
 					nodes[idx].Children = mergeSelectionNodes(nodes[idx].Children, children)
 				}
-				// Merge arguments: keep first non-empty set
-				if len(nodes[idx].Arguments) == 0 && len(s.Arguments) > 0 {
-					nodes[idx].Arguments = s.Arguments
+				// Merge inline fragments from sub-field
+				if len(subFrags) > 0 {
+					nodes[idx].InlineFragments = mergeInlineFragments(nodes[idx].InlineFragments, subFrags)
+					nodes[idx].HasDirectFields = nodes[idx].HasDirectFields || hasDirectFields
+				}
+				// Merge arguments: union by argument name
+				for _, newArg := range s.Arguments {
+					found := false
+					for _, existingArg := range nodes[idx].Arguments {
+						if existingArg.Name == newArg.Name {
+							found = true
+							break
+						}
+					}
+					if !found {
+						nodes[idx].Arguments = append(nodes[idx].Arguments, newArg)
+					}
 				}
 			} else {
 				seen[s.Name] = len(nodes)
-				nodes = append(nodes, &selectionNode{Name: s.Name, Children: children, Arguments: s.Arguments})
+				nodes = append(nodes, &selectionNode{
+					Name:            s.Name,
+					Children:        children,
+					Arguments:       s.Arguments,
+					InlineFragments: subFrags,
+					HasDirectFields: hasDirectFields,
+				})
 			}
 		case *ast.FragmentSpread:
 			if frag := fragments.ForName(s.Name); frag != nil {
@@ -629,18 +671,22 @@ func collectSelectionTree(selections ast.SelectionSet, fragments ast.FragmentDef
 // collectInlineFragments extracts inline fragments with type conditions from a selection set.
 func collectInlineFragments(selections ast.SelectionSet, fragments ast.FragmentDefinitionList) []inlineFragmentInfo {
 	var frags []inlineFragmentInfo
-	seen := make(map[string]bool)
+	seen := make(map[string]int) // type name -> index in frags (merge duplicate type conditions)
 
 	for _, sel := range selections {
 		switch s := sel.(type) {
 		case *ast.InlineFragment:
-			if s.TypeCondition != "" && !seen[s.TypeCondition] {
-				seen[s.TypeCondition] = true
+			if s.TypeCondition != "" {
 				tree := collectSelectionTree(s.SelectionSet, fragments)
-				frags = append(frags, inlineFragmentInfo{
-					TypeName:      s.TypeCondition,
-					SelectionTree: tree,
-				})
+				if idx, ok := seen[s.TypeCondition]; ok {
+					frags[idx].SelectionTree = mergeSelectionNodes(frags[idx].SelectionTree, tree)
+				} else {
+					seen[s.TypeCondition] = len(frags)
+					frags = append(frags, inlineFragmentInfo{
+						TypeName:      s.TypeCondition,
+						SelectionTree: tree,
+					})
+				}
 			}
 		case *ast.FragmentSpread:
 			if frag := fragments.ForName(s.Name); frag != nil {
@@ -650,12 +696,14 @@ func collectInlineFragments(selections ast.SelectionSet, fragments ast.FragmentD
 					// Fragment contains type-narrowing inline fragments (e.g., fragment X on Viewer { ... on User { ... } })
 					// Only extract the nested fragments — the outer fragment is on the parent type, not a union member
 					for _, n := range nested {
-						if !seen[n.TypeName] {
-							seen[n.TypeName] = true
+						if idx, ok := seen[n.TypeName]; ok {
+							frags[idx].SelectionTree = mergeSelectionNodes(frags[idx].SelectionTree, n.SelectionTree)
+						} else {
+							seen[n.TypeName] = len(frags)
 							frags = append(frags, n)
 						}
 					}
-				} else if frag.TypeCondition != "" && !seen[frag.TypeCondition] {
+				} else if frag.TypeCondition != "" {
 					// Fragment has no nested inline fragments and has substantive fields —
 					// treat it as a typed fragment (e.g., fragment UserFields on User { id profile { bio } }).
 					tree := collectSelectionTree(frag.SelectionSet, fragments)
@@ -667,11 +715,15 @@ func collectInlineFragments(selections ast.SelectionSet, fragments ast.FragmentD
 						}
 					}
 					if hasSubstantiveFields {
-						seen[frag.TypeCondition] = true
-						frags = append(frags, inlineFragmentInfo{
-							TypeName:      frag.TypeCondition,
-							SelectionTree: tree,
-						})
+						if idx, ok := seen[frag.TypeCondition]; ok {
+							frags[idx].SelectionTree = mergeSelectionNodes(frags[idx].SelectionTree, tree)
+						} else {
+							seen[frag.TypeCondition] = len(frags)
+							frags = append(frags, inlineFragmentInfo{
+								TypeName:      frag.TypeCondition,
+								SelectionTree: tree,
+							})
+						}
 					}
 				}
 			}
@@ -699,8 +751,23 @@ func mergeIntoNodeList(nodes []*selectionNode, seen map[string]int, source []*se
 			if sn.Children != nil {
 				nodes[idx].Children = mergeSelectionNodes(nodes[idx].Children, sn.Children)
 			}
-			if len(nodes[idx].Arguments) == 0 && len(sn.Arguments) > 0 {
-				nodes[idx].Arguments = sn.Arguments
+			// Merge inline fragments from sub-field
+			if len(sn.InlineFragments) > 0 {
+				nodes[idx].InlineFragments = mergeInlineFragments(nodes[idx].InlineFragments, sn.InlineFragments)
+				nodes[idx].HasDirectFields = nodes[idx].HasDirectFields || sn.HasDirectFields
+			}
+			// Merge arguments: union by argument name
+			for _, newArg := range sn.Arguments {
+				found := false
+				for _, existingArg := range nodes[idx].Arguments {
+					if existingArg.Name == newArg.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					nodes[idx].Arguments = append(nodes[idx].Arguments, newArg)
+				}
 			}
 		} else {
 			seen[sn.Name] = len(nodes)
@@ -723,12 +790,47 @@ func mergeSelectionNodes(a, b []*selectionNode) []*selectionNode {
 			if n.Children != nil {
 				merged[idx].Children = mergeSelectionNodes(merged[idx].Children, n.Children)
 			}
-			if len(merged[idx].Arguments) == 0 && len(n.Arguments) > 0 {
-				merged[idx].Arguments = n.Arguments
+			// Merge inline fragments from sub-field
+			if len(n.InlineFragments) > 0 {
+				merged[idx].InlineFragments = mergeInlineFragments(merged[idx].InlineFragments, n.InlineFragments)
+				merged[idx].HasDirectFields = merged[idx].HasDirectFields || n.HasDirectFields
+			}
+			// Merge arguments: union by argument name
+			for _, newArg := range n.Arguments {
+				found := false
+				for _, existingArg := range merged[idx].Arguments {
+					if existingArg.Name == newArg.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					merged[idx].Arguments = append(merged[idx].Arguments, newArg)
+				}
 			}
 		} else {
 			seen[n.Name] = len(merged)
 			merged = append(merged, n)
+		}
+	}
+	return merged
+}
+
+// mergeInlineFragments merges two inline fragment lists, deduplicating by type name
+// and merging selection trees for duplicate type conditions.
+func mergeInlineFragments(a, b []inlineFragmentInfo) []inlineFragmentInfo {
+	seen := make(map[string]int)
+	var merged []inlineFragmentInfo
+	for i, f := range a {
+		seen[f.TypeName] = i
+		merged = append(merged, f)
+	}
+	for _, f := range b {
+		if idx, ok := seen[f.TypeName]; ok {
+			merged[idx].SelectionTree = mergeSelectionNodes(merged[idx].SelectionTree, f.SelectionTree)
+		} else {
+			seen[f.TypeName] = len(merged)
+			merged = append(merged, f)
 		}
 	}
 	return merged
@@ -746,6 +848,7 @@ func inferFieldsRecursive(
 	varTypes map[string]string,
 	inputTypes map[string]*inferredType,
 	parentTypeName string,
+	syntheticUnions map[string][]string,
 ) map[string]string {
 	fields := make(map[string]string)
 
@@ -756,6 +859,71 @@ func inferFieldsRecursive(
 			if len(args) > 0 {
 				storeFieldArgs(syntheticTypes, parentTypeName, node.Name, args)
 			}
+		}
+
+		// Sub-field union/interface pattern: inline fragments without direct fields
+		if len(node.InlineFragments) > 0 && !node.HasDirectFields {
+			unionName := typePrefix + "_" + upperFirst(node.Name) + "Result"
+			var memberNames []string
+
+			// Extract nested response value for type matching
+			var nestedObj map[string]interface{}
+			isList := false
+			if responseObj != nil {
+				if v, ok := responseObj[node.Name]; ok {
+					switch rv := v.(type) {
+					case map[string]interface{}:
+						nestedObj = rv
+					case []interface{}:
+						isList = true
+						// Merge all array elements for richer type inference
+						nestedObj = mergeArrayElementsRaw(rv)
+					}
+				}
+			}
+
+			for _, frag := range node.InlineFragments {
+				memberNames = append(memberNames, frag.TypeName)
+				fragFields := inferFieldsRecursive(nestedObj, frag.SelectionTree, frag.TypeName, syntheticTypes, varTypes, inputTypes, frag.TypeName, syntheticUnions)
+				if len(fragFields) > 0 {
+					if existing, ok := syntheticTypes[frag.TypeName]; ok {
+						for k, v := range fragFields {
+							if _, exists := existing.Fields[k]; !exists {
+								existing.Fields[k] = v
+							}
+						}
+					} else {
+						syntheticTypes[frag.TypeName] = &inferredType{
+							Name:      frag.TypeName,
+							Fields:    fragFields,
+							FieldArgs: make(map[string]map[string]string),
+						}
+					}
+				}
+			}
+
+			// Register union (merge with existing members)
+			if existingMembers, ok := syntheticUnions[unionName]; ok {
+				memberSet := make(map[string]bool)
+				for _, m := range existingMembers {
+					memberSet[m] = true
+				}
+				for _, m := range memberNames {
+					if !memberSet[m] {
+						existingMembers = append(existingMembers, m)
+					}
+				}
+				syntheticUnions[unionName] = existingMembers
+			} else {
+				syntheticUnions[unionName] = memberNames
+			}
+
+			if isList {
+				fields[node.Name] = "[" + unionName + "]"
+			} else {
+				fields[node.Name] = unionName
+			}
+			continue
 		}
 
 		if node.Children == nil {
@@ -793,7 +961,7 @@ func inferFieldsRecursive(
 		}
 
 		// Recurse to build nested type fields
-		nestedFields := inferFieldsRecursive(nestedObj, node.Children, typePrefix+"_"+upperFirst(node.Name), syntheticTypes, varTypes, inputTypes, nestedTypeName)
+		nestedFields := inferFieldsRecursive(nestedObj, node.Children, typePrefix+"_"+upperFirst(node.Name), syntheticTypes, varTypes, inputTypes, nestedTypeName, syntheticUnions)
 
 		if len(nestedFields) > 0 {
 			if existing, ok := syntheticTypes[nestedTypeName]; ok {
@@ -1352,6 +1520,25 @@ func mergeArrayElements(body []byte, rootFieldName string) map[string]interface{
 		}
 	}
 
+	return merged
+}
+
+// mergeArrayElementsRaw merges all object elements of a raw JSON array into a single
+// map, collecting the union of all fields. Used for sub-field array union inference.
+func mergeArrayElementsRaw(arr []interface{}) map[string]interface{} {
+	merged := make(map[string]interface{})
+	for _, elem := range arr {
+		if obj, ok := elem.(map[string]interface{}); ok {
+			for k, v := range obj {
+				if _, exists := merged[k]; !exists {
+					merged[k] = v
+				}
+			}
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
 	return merged
 }
 

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -451,7 +451,9 @@ func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body
 			if len(fragFields) > 0 {
 				if existing, ok := syntheticTypes[frag.TypeName]; ok {
 					for k, v := range fragFields {
-						if _, exists := existing.Fields[k]; !exists {
+						if existingType, exists := existing.Fields[k]; !exists {
+							existing.Fields[k] = v
+						} else if isMoreSpecificType(v, existingType) {
 							existing.Fields[k] = v
 						}
 					}
@@ -1116,7 +1118,9 @@ func inferFieldsRecursive(
 				if len(fragFields) > 0 {
 					if existing, ok := syntheticTypes[frag.TypeName]; ok {
 						for k, v := range fragFields {
-							if _, exists := existing.Fields[k]; !exists {
+							if existingType, exists := existing.Fields[k]; !exists {
+								existing.Fields[k] = v
+							} else if isMoreSpecificType(v, existingType) {
 								existing.Fields[k] = v
 							}
 						}
@@ -1179,11 +1183,8 @@ func inferFieldsRecursive(
 					nestedObj = rv
 				case []interface{}:
 					isList = true
-					if len(rv) > 0 {
-						if obj, ok := rv[0].(map[string]interface{}); ok {
-							nestedObj = obj
-						}
-					}
+					// Merge all array elements for richer type inference
+					nestedObj = mergeArrayElementsRaw(rv)
 				}
 			}
 		}
@@ -1194,7 +1195,9 @@ func inferFieldsRecursive(
 		if len(nestedFields) > 0 {
 			if existing, ok := syntheticTypes[nestedTypeName]; ok {
 				for k, v := range nestedFields {
-					if _, exists := existing.Fields[k]; !exists {
+					if existingType, exists := existing.Fields[k]; !exists {
+						existing.Fields[k] = v
+					} else if isMoreSpecificType(v, existingType) {
 						existing.Fields[k] = v
 					}
 				}

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -66,8 +66,8 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	seen := make(map[string]bool) // deduplicate by composite key (opType:fieldName:opName)
 
 	for _, ep := range endpoints {
-		if op, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes, syntheticInputTypes, syntheticUnions); ok {
-			ops = append(ops, op)
+		if epOps, ok := processEndpoint(ep, seen, &anonCounter, syntheticTypes, syntheticInputTypes, syntheticUnions); ok {
+			ops = append(ops, epOps...)
 		}
 	}
 
@@ -140,25 +140,67 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	// Create root synthetic types from merged operations
 	for _, groupOps := range grouped {
 		for _, op := range groupOps {
-			if len(op.ResponseFields) > 0 {
-				if existing, ok := syntheticTypes[op.ReturnType]; ok {
-					// Merge fields into existing type: prefer more specific types
-					for k, v := range op.ResponseFields {
-						if existingType, exists := existing.Fields[k]; !exists {
-							existing.Fields[k] = v
-						} else if isMoreSpecificType(v, existingType) {
-							existing.Fields[k] = v
-						}
+			// Skip union return types — they don't need a plain type definition
+			if _, isUnion := syntheticUnions[op.ReturnType]; isUnion {
+				continue
+			}
+			fields := op.ResponseFields
+			if fields == nil {
+				fields = make(map[string]string)
+			}
+			if existing, ok := syntheticTypes[op.ReturnType]; ok {
+				// Merge fields into existing type: prefer more specific types
+				for k, v := range fields {
+					if existingType, exists := existing.Fields[k]; !exists {
+						existing.Fields[k] = v
+					} else if isMoreSpecificType(v, existingType) {
+						existing.Fields[k] = v
 					}
-				} else {
-					syntheticTypes[op.ReturnType] = &inferredType{
-						Name:      op.ReturnType,
-						Fields:    op.ResponseFields,
-						FieldArgs: make(map[string]map[string]string),
-					}
+				}
+			} else {
+				syntheticTypes[op.ReturnType] = &inferredType{
+					Name:      op.ReturnType,
+					Fields:    fields,
+					FieldArgs: make(map[string]map[string]string),
 				}
 			}
 		}
+	}
+
+	// Reconcile type/union name collisions (D2, D6):
+	// If a union XResult exists and a type XResponse also exists, merge XResponse fields
+	// into the first union member type and remove the empty XResponse.
+	for unionName, members := range syntheticUnions {
+		// Find the corresponding Response type that may conflict
+		// Convention: union is FooResult, response type is FooResponse
+		baseName := strings.TrimSuffix(unionName, "Result")
+		responseName := baseName + "Response"
+		if responseType, ok := syntheticTypes[responseName]; ok {
+			// Merge response fields into the first union member type
+			if len(members) > 0 && len(responseType.Fields) > 0 {
+				firstMember := members[0]
+				if memberType, ok := syntheticTypes[firstMember]; ok {
+					for k, v := range responseType.Fields {
+						if _, exists := memberType.Fields[k]; !exists {
+							memberType.Fields[k] = v
+						}
+					}
+				}
+			}
+			// Remove the conflicting Response type
+			delete(syntheticTypes, responseName)
+			// Update any ops that reference the Response type to point to the union
+			for opType, groupOps := range grouped {
+				for i := range groupOps {
+					if groupOps[i].ReturnType == responseName {
+						groupOps[i].ReturnType = unionName
+					}
+				}
+				grouped[opType] = groupOps
+			}
+		}
+		// Also remove any type with the same name as the union itself
+		delete(syntheticTypes, unionName)
 	}
 
 	// Cross-type field type propagation: unify structurally similar types
@@ -256,13 +298,23 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 		fmt.Fprintf(&sb, "\nunion %s = %s\n", name, strings.Join(members, " | "))
 	}
 
+	// Emit custom scalar declarations for referenced but undeclared types (e.g., Upload)
+	referencedScalars := collectCustomScalars(grouped, syntheticTypes, syntheticInputTypes, syntheticUnions)
+	if len(referencedScalars) > 0 {
+		sort.Strings(referencedScalars)
+		for _, s := range referencedScalars {
+			fmt.Fprintf(&sb, "\nscalar %s\n", s)
+		}
+	}
+
 	return []byte(sb.String()), nil
 }
 
-// processEndpoint processes a single classified endpoint and returns an inferred operation.
-func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType, syntheticUnions map[string][]string) (inferredOperation, bool) {
+// processEndpoint processes a single classified endpoint and returns inferred operations
+// (one per root field in multi-root queries).
+func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType, syntheticUnions map[string][]string) ([]inferredOperation, bool) {
 	if ep.APIType != "graphql" {
-		return inferredOperation{}, false
+		return nil, false
 	}
 
 	body := parseGraphQLBody(ep.Body)
@@ -275,14 +327,30 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 		}
 	}
 	if body == nil {
-		return inferredOperation{}, false
+		return nil, false
 	}
 
-	parsed := parseQueryAST(body.Query)
-	if parsed == nil {
-		return inferredOperation{}, false
+	parsedQueries := parseQueryAST(body.Query)
+	if len(parsedQueries) == 0 {
+		return nil, false
 	}
 
+	var ops []inferredOperation
+	for _, parsed := range parsedQueries {
+		op, ok := processParsedQuery(parsed, ep, body, seen, anonCounter, syntheticTypes, syntheticInputTypes, syntheticUnions)
+		if ok {
+			ops = append(ops, op)
+		}
+	}
+
+	if len(ops) == 0 {
+		return nil, false
+	}
+	return ops, true
+}
+
+// processParsedQuery processes a single parsed query (one root field) from an endpoint.
+func processParsedQuery(parsed *parsedQuery, ep classify.ClassifiedRequest, body *graphqlBody, seen map[string]bool, anonCounter *int, syntheticTypes map[string]*inferredType, syntheticInputTypes map[string]*inferredType, syntheticUnions map[string][]string) (inferredOperation, bool) {
 	opType := astOpTypeToString(parsed.opType)
 	fieldName := parsed.rootFieldName
 	if fieldName == "" {
@@ -316,7 +384,7 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 	var responseFields map[string]string
 
 	if len(parsed.inlineFragments) >= 2 && !parsed.hasNonFragmentFields {
-		// Fix 5: Union type inference from inline fragments
+		// Union type inference from inline fragments
 		unionName := typePrefix + "Result"
 		var memberNames []string
 
@@ -346,15 +414,28 @@ func processEndpoint(ep classify.ClassifiedRequest, seen map[string]bool, anonCo
 			}
 		}
 
-		syntheticUnions[unionName] = memberNames
+		// Merge union members instead of overwriting
+		if existingMembers, ok := syntheticUnions[unionName]; ok {
+			memberSet := make(map[string]bool)
+			for _, m := range existingMembers {
+				memberSet[m] = true
+			}
+			for _, m := range memberNames {
+				if !memberSet[m] {
+					existingMembers = append(existingMembers, m)
+				}
+			}
+			syntheticUnions[unionName] = existingMembers
+		} else {
+			syntheticUnions[unionName] = memberNames
+		}
 		returnTypeName = unionName
 	} else if responseOK && responseObj != nil && len(parsed.selectionTree) > 0 {
 		responseFields = inferFieldsRecursive(responseObj, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName)
 	} else if scalarType, ok := detectScalarReturnType(ep.Response.Body, fieldName); ok {
-		// Fix 1: Scalar root field return
 		returnTypeName = scalarType
 	} else if len(parsed.selectionTree) > 0 {
-		// Fix 4: Response was null/error but we have selection tree — generate type from selection fields
+		// Response was null/error but we have selection tree — generate type from selection fields
 		responseFields = inferFieldsRecursive(nil, parsed.selectionTree, typePrefix, syntheticTypes, varTypes, syntheticInputTypes, returnTypeName)
 	} else {
 		// Fallback: existing flat inference
@@ -397,33 +478,61 @@ type parsedQuery struct {
 	hasNonFragmentFields bool                  // true if root field has direct field selections alongside inline fragments
 }
 
-// parseQueryAST parses a GraphQL query string and extracts operation info.
-func parseQueryAST(query string) *parsedQuery {
+// parseQueryAST parses a GraphQL query string and extracts operation info for all root fields.
+func parseQueryAST(query string) []*parsedQuery {
 	doc, parseErr := parser.ParseQuery(&ast.Source{Input: query})
 	if parseErr != nil || len(doc.Operations) == 0 {
 		return nil
 	}
 
 	op := doc.Operations[0]
-	result := &parsedQuery{
-		opType:  op.Operation,
-		opName:  op.Name,
-		varDefs: op.VariableDefinitions,
+
+	// Extract all root fields from the selection set
+	if len(op.SelectionSet) == 0 {
+		return nil
 	}
 
-	// Extract root field name and its selection set, resolving fragment spreads
-	if len(op.SelectionSet) > 0 {
-		if field := resolveFirstField(op.SelectionSet, doc.Fragments); field != nil {
-			result.rootFieldName = field.Name
-			result.rootFieldArgs = field.Arguments
-			result.selectionFields = collectSelectionFields(field.SelectionSet, doc.Fragments)
-			result.selectionTree = collectSelectionTree(field.SelectionSet, doc.Fragments)
-			result.inlineFragments = collectInlineFragments(field.SelectionSet, doc.Fragments)
-			result.hasNonFragmentFields = hasTopLevelFields(field.SelectionSet)
+	rootFields := resolveAllFields(op.SelectionSet, doc.Fragments)
+	if len(rootFields) == 0 {
+		return nil
+	}
+
+	var results []*parsedQuery
+	for _, field := range rootFields {
+		result := &parsedQuery{
+			opType:               op.Operation,
+			opName:               op.Name,
+			varDefs:              op.VariableDefinitions,
+			rootFieldName:        field.Name,
+			rootFieldArgs:        field.Arguments,
+			selectionFields:      collectSelectionFields(field.SelectionSet, doc.Fragments),
+			selectionTree:        collectSelectionTree(field.SelectionSet, doc.Fragments),
+			inlineFragments:      collectInlineFragments(field.SelectionSet, doc.Fragments),
+			hasNonFragmentFields: hasTopLevelFields(field.SelectionSet),
+		}
+		results = append(results, result)
+	}
+
+	return results
+}
+
+// resolveAllFields walks a selection set to collect all concrete *ast.Field entries,
+// resolving fragment spreads and inline fragments as needed.
+func resolveAllFields(selections ast.SelectionSet, fragments ast.FragmentDefinitionList) []*ast.Field {
+	var fields []*ast.Field
+	for _, sel := range selections {
+		switch s := sel.(type) {
+		case *ast.Field:
+			fields = append(fields, s)
+		case *ast.FragmentSpread:
+			if frag := fragments.ForName(s.Name); frag != nil {
+				fields = append(fields, resolveAllFields(frag.SelectionSet, fragments)...)
+			}
+		case *ast.InlineFragment:
+			fields = append(fields, resolveAllFields(s.SelectionSet, fragments)...)
 		}
 	}
-
-	return result
+	return fields
 }
 
 // resolveFirstField walks a selection set to find the first concrete *ast.Field,
@@ -986,19 +1095,6 @@ func buildArgTypes(parsed *parsedQuery, variables map[string]interface{}, inputT
 		args[argName] = "String"
 	}
 
-	// If no root field arguments were extracted but we have variables, use them directly
-	if len(args) == 0 {
-		for varName, varType := range varTypes {
-			args[varName] = varType
-		}
-		// For variables not declared in the query, infer from JSON values
-		for k, v := range variables {
-			if _, exists := args[k]; !exists {
-				args[k] = inferTypeFromValue(v)
-			}
-		}
-	}
-
 	return args
 }
 
@@ -1387,6 +1483,69 @@ func unifyStructuralFieldTypes(syntheticTypes map[string]*inferredType) {
 			}
 		}
 	}
+}
+
+// collectCustomScalars finds type names referenced in fields/args that are not builtins,
+// not synthetic types, not synthetic input types, and not unions. These are custom scalars
+// (e.g., Upload) that need explicit scalar declarations.
+func collectCustomScalars(
+	grouped map[string][]inferredOperation,
+	syntheticTypes map[string]*inferredType,
+	syntheticInputTypes map[string]*inferredType,
+	syntheticUnions map[string][]string,
+) []string {
+	known := make(map[string]bool)
+	for name := range syntheticTypes {
+		known[name] = true
+	}
+	for name := range syntheticInputTypes {
+		known[name] = true
+	}
+	for name := range syntheticUnions {
+		known[name] = true
+	}
+
+	candidates := make(map[string]bool)
+
+	// Check operation args
+	for _, groupOps := range grouped {
+		for _, op := range groupOps {
+			for _, argType := range op.Args {
+				checkCustomScalar(argType, known, candidates)
+			}
+		}
+	}
+	// Check synthetic type fields and field args
+	for _, st := range syntheticTypes {
+		for _, fieldType := range st.Fields {
+			checkCustomScalar(fieldType, known, candidates)
+		}
+		for _, args := range st.FieldArgs {
+			for _, argType := range args {
+				checkCustomScalar(argType, known, candidates)
+			}
+		}
+	}
+
+	var scalars []string
+	for s := range candidates {
+		scalars = append(scalars, s)
+	}
+	return scalars
+}
+
+// checkCustomScalar unwraps a type string and adds any non-builtin, non-known base type
+// to the candidates set.
+func checkCustomScalar(typeStr string, known map[string]bool, candidates map[string]bool) {
+	base := typeStr
+	base = strings.TrimSuffix(base, "!")
+	base = strings.TrimPrefix(base, "[")
+	base = strings.TrimSuffix(base, "]")
+	base = strings.TrimSuffix(base, "!")
+	if base == "" || builtinScalars[base] || known[base] {
+		return
+	}
+	candidates[base] = true
 }
 
 // upperFirst returns the string with its first character uppercased.

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -98,6 +98,9 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 			op := &groupOps[i]
 			if existing, ok := merged[op.FieldName]; ok {
 				// Merge args: prefer more specific types over String
+				if existing.Args == nil {
+					existing.Args = make(map[string]string)
+				}
 				for k, v := range op.Args {
 					if existingType, exists := existing.Args[k]; !exists {
 						existing.Args[k] = v
@@ -106,6 +109,9 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 					}
 				}
 				// Merge response fields: prefer more specific types
+				if existing.ResponseFields == nil {
+					existing.ResponseFields = make(map[string]string)
+				}
 				for k, v := range op.ResponseFields {
 					if existingType, exists := existing.ResponseFields[k]; !exists {
 						existing.ResponseFields[k] = v

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -114,7 +114,7 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 	})
 
 	var sb strings.Builder
-	sb.WriteString("# Inferred from observed traffic (introspection disabled)\n")
+	sb.WriteString("# Inferred from observed traffic\n")
 
 	// Group operations by type
 	grouped := make(map[string][]inferredOperation)
@@ -176,12 +176,12 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
 
 // parsedQuery holds the results of parsing a GraphQL query string with gqlparser.
 type parsedQuery struct {
-	opType         ast.Operation
-	opName         string
-	rootFieldName  string
-	rootFieldArgs  []*ast.Argument      // arguments on the root field
-	varDefs        ast.VariableDefinitionList
-	selectionFields []string            // field names from the root field's selection set
+	opType          ast.Operation
+	opName          string
+	rootFieldName   string
+	rootFieldArgs   []*ast.Argument // arguments on the root field
+	varDefs         ast.VariableDefinitionList
+	selectionFields []string // field names from the root field's selection set
 }
 
 // parseQueryAST parses a GraphQL query string and extracts operation info.

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graphql
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// operationRe matches GraphQL operation declarations (query/mutation/subscription OperationName).
+var operationRe = regexp.MustCompile(`^\s*(query|mutation|subscription)\s+(\w+)`)
+
+// graphqlBody represents a parsed GraphQL request body.
+type graphqlBody struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+// inferredOperation holds an inferred GraphQL operation.
+type inferredOperation struct {
+	OpType     string            // "query", "mutation", or "subscription"
+	Name       string            // operation name
+	Args       map[string]string // variable name -> inferred type
+	ReturnType string            // inferred return type name
+}
+
+// inferredType holds a synthetic type inferred from response data.
+type inferredType struct {
+	Name   string
+	Fields map[string]string // field name -> type string
+}
+
+// inferSDL produces a partial SDL from observed GraphQL traffic.
+func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) {
+	var ops []inferredOperation
+	syntheticTypes := make(map[string]*inferredType)
+	anonCounter := 0
+	seen := make(map[string]bool) // deduplicate by operation name
+
+	for _, ep := range endpoints {
+		if ep.APIType != "graphql" {
+			continue
+		}
+
+		body := parseGraphQLBody(ep.Body)
+		if body == nil {
+			continue
+		}
+
+		opType, opName := extractOperationInfo(body.Query)
+		if opName == "" {
+			anonCounter++
+			opName = fmt.Sprintf("Anonymous%d", anonCounter)
+		}
+		if opType == "" {
+			opType = "query"
+		}
+
+		if seen[opName] {
+			continue
+		}
+		seen[opName] = true
+
+		// Infer argument types from variables
+		args := make(map[string]string)
+		for k, v := range body.Variables {
+			args[k] = inferTypeFromValue(v)
+		}
+
+		// Infer return type from response
+		returnTypeName := opName + "Response"
+		responseFields := inferFieldsFromResponse(ep.Response.Body, opName)
+		if len(responseFields) > 0 {
+			syntheticTypes[returnTypeName] = &inferredType{
+				Name:   returnTypeName,
+				Fields: responseFields,
+			}
+		}
+
+		ops = append(ops, inferredOperation{
+			OpType:     opType,
+			Name:       opName,
+			Args:       args,
+			ReturnType: returnTypeName,
+		})
+	}
+
+	if len(ops) == 0 {
+		return nil, errors.New("no GraphQL operations found in traffic")
+	}
+
+	// Sort operations by name for deterministic output
+	sort.Slice(ops, func(i, j int) bool {
+		return ops[i].Name < ops[j].Name
+	})
+
+	var sb strings.Builder
+	sb.WriteString("# Inferred from observed traffic (introspection disabled)\n")
+
+	// Group operations by type
+	grouped := make(map[string][]inferredOperation)
+	for _, op := range ops {
+		grouped[op.OpType] = append(grouped[op.OpType], op)
+	}
+
+	// Emit operation types in canonical order
+	for _, opType := range []string{"query", "mutation", "subscription"} {
+		groupOps, ok := grouped[opType]
+		if !ok {
+			continue
+		}
+
+		typeName := strings.ToUpper(opType[:1]) + opType[1:]
+		fmt.Fprintf(&sb, "\ntype %s {\n", typeName)
+		for _, op := range groupOps {
+			sb.WriteString("  ")
+			sb.WriteString(op.Name)
+			if len(op.Args) > 0 {
+				sb.WriteString("(")
+				writeArgs(&sb, op.Args)
+				sb.WriteString(")")
+			}
+			fmt.Fprintf(&sb, ": %s\n", op.ReturnType)
+		}
+		sb.WriteString("}\n")
+	}
+
+	// Emit synthetic return types sorted by name
+	var typeNames []string
+	for name := range syntheticTypes {
+		typeNames = append(typeNames, name)
+	}
+	sort.Strings(typeNames)
+
+	for _, name := range typeNames {
+		st := syntheticTypes[name]
+		fmt.Fprintf(&sb, "\ntype %s {\n", st.Name)
+
+		// Sort fields for determinism
+		var fieldNames []string
+		for fn := range st.Fields {
+			fieldNames = append(fieldNames, fn)
+		}
+		sort.Strings(fieldNames)
+
+		for _, fn := range fieldNames {
+			fmt.Fprintf(&sb, "  %s: %s\n", fn, st.Fields[fn])
+		}
+		sb.WriteString("}\n")
+	}
+
+	return []byte(sb.String()), nil
+}
+
+// writeArgs writes sorted argument definitions.
+func writeArgs(sb *strings.Builder, args map[string]string) {
+	var names []string
+	for k := range args {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	for i, name := range names {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		fmt.Fprintf(sb, "%s: %s", name, args[name])
+	}
+}
+
+// parseGraphQLBody parses a JSON request body as a GraphQL operation.
+func parseGraphQLBody(body []byte) *graphqlBody {
+	if len(body) == 0 {
+		return nil
+	}
+	var gb graphqlBody
+	if err := json.Unmarshal(body, &gb); err != nil {
+		return nil
+	}
+	if gb.Query == "" {
+		return nil
+	}
+	return &gb
+}
+
+// extractOperationInfo extracts the operation type and name from a GraphQL query string.
+func extractOperationInfo(query string) (opType, opName string) {
+	matches := operationRe.FindStringSubmatch(query)
+	if len(matches) >= 3 {
+		return matches[1], matches[2]
+	}
+	return "", ""
+}
+
+// inferTypeFromValue infers a GraphQL type from a JSON value.
+func inferTypeFromValue(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return "String"
+	case bool:
+		return "Boolean"
+	case float64:
+		if val == math.Trunc(val) {
+			return "Int"
+		}
+		return "Float"
+	case nil:
+		return "String"
+	default:
+		return "String"
+	}
+}
+
+// inferFieldsFromResponse parses a GraphQL JSON response and extracts field types
+// from data.<operationName> or data.<firstKey>.
+func inferFieldsFromResponse(body []byte, opName string) map[string]string {
+	if len(body) == 0 {
+		return nil
+	}
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil
+	}
+
+	data, ok := envelope["data"]
+	if !ok {
+		return nil
+	}
+
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Try operation name first, then first key
+	var responseObj map[string]interface{}
+	if obj, ok := dataMap[opName]; ok {
+		responseObj, _ = obj.(map[string]interface{})
+	}
+	if responseObj == nil {
+		// Use first key
+		for _, v := range dataMap {
+			responseObj, _ = v.(map[string]interface{})
+			break
+		}
+	}
+
+	if responseObj == nil {
+		return nil
+	}
+
+	fields := make(map[string]string)
+	for k, v := range responseObj {
+		fields[k] = inferTypeFromValue(v)
+	}
+	return fields
+}

--- a/pkg/generate/graphql/sdl.go
+++ b/pkg/generate/graphql/sdl.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package graphql generates GraphQL SDL specifications from classified requests.
+package graphql
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// builtinScalars are the built-in GraphQL scalar types that should not be emitted.
+var builtinScalars = map[string]bool{
+	"String":  true,
+	"Int":     true,
+	"Float":   true,
+	"Boolean": true,
+	"ID":      true,
+}
+
+// rootTypeNames are the conventional root operation type names.
+var rootTypeNames = map[string]bool{
+	"Query":        true,
+	"Mutation":     true,
+	"Subscription": true,
+}
+
+// Generator produces GraphQL SDL specifications from classified requests.
+type Generator struct{}
+
+// APIType returns the API type this generator supports.
+func (g *Generator) APIType() string {
+	return "graphql"
+}
+
+// DefaultExtension returns the default file extension for GraphQL SDL output.
+func (g *Generator) DefaultExtension() string {
+	return ".graphql"
+}
+
+// Generate produces a GraphQL SDL specification from classified endpoints.
+// Phase 1: If any endpoint has introspection data, generate SDL from it.
+// Phase 2: Fall back to inferring SDL from observed traffic.
+func (g *Generator) Generate(endpoints []classify.ClassifiedRequest) ([]byte, error) {
+	if len(endpoints) == 0 {
+		return nil, errors.New("no endpoints provided")
+	}
+
+	// Phase 1: Use introspection data if available
+	for _, ep := range endpoints {
+		if ep.GraphQLSchema != nil && ep.GraphQLSchema.IntrospectionEnabled && len(ep.GraphQLSchema.Types) > 0 {
+			return generateFromIntrospection(ep.GraphQLSchema)
+		}
+	}
+
+	// Phase 2: Infer from traffic
+	return inferSDL(endpoints)
+}
+
+// generateFromIntrospection builds SDL from parsed introspection types.
+func generateFromIntrospection(schema *classify.GraphQLIntrospection) ([]byte, error) {
+	var sb strings.Builder
+
+	// Collect user-defined types, skip builtins
+	var userTypes []classify.GraphQLType
+	for _, t := range schema.Types {
+		if strings.HasPrefix(t.Name, "__") {
+			continue
+		}
+		if t.Kind == "SCALAR" && builtinScalars[t.Name] {
+			continue
+		}
+		userTypes = append(userTypes, t)
+	}
+
+	if len(userTypes) == 0 {
+		return nil, errors.New("introspection returned no user-defined types")
+	}
+
+	// Sort types by name for deterministic output
+	sort.Slice(userTypes, func(i, j int) bool {
+		return userTypes[i].Name < userTypes[j].Name
+	})
+
+	// Emit schema block if root types are present
+	writeSchemaBlock(&sb, userTypes)
+
+	// Emit type definitions
+	for i, t := range userTypes {
+		if i > 0 || sb.Len() > 0 {
+			sb.WriteString("\n")
+		}
+		writeTypeDefinition(&sb, t)
+	}
+
+	return []byte(sb.String()), nil
+}
+
+// writeSchemaBlock emits a schema { ... } block if any root types exist.
+func writeSchemaBlock(sb *strings.Builder, types []classify.GraphQLType) {
+	var roots []string
+	rootMap := make(map[string]bool)
+	for _, t := range types {
+		if rootTypeNames[t.Name] && (t.Kind == "OBJECT") {
+			rootMap[t.Name] = true
+		}
+	}
+
+	// Emit in canonical order
+	for _, name := range []string{"Query", "Mutation", "Subscription"} {
+		if rootMap[name] {
+			roots = append(roots, name)
+		}
+	}
+
+	if len(roots) == 0 {
+		return
+	}
+
+	sb.WriteString("schema {\n")
+	for _, name := range roots {
+		fmt.Fprintf(sb, "  %s: %s\n", strings.ToLower(name), name)
+	}
+	sb.WriteString("}\n")
+}
+
+// writeTypeDefinition emits a single SDL type definition.
+func writeTypeDefinition(sb *strings.Builder, t classify.GraphQLType) {
+	switch t.Kind {
+	case "OBJECT":
+		fmt.Fprintf(sb, "type %s {\n", t.Name)
+		writeFields(sb, t.Fields)
+		sb.WriteString("}\n")
+	case "INPUT_OBJECT":
+		fmt.Fprintf(sb, "input %s {\n", t.Name)
+		writeFields(sb, t.Fields)
+		sb.WriteString("}\n")
+	case "INTERFACE":
+		fmt.Fprintf(sb, "interface %s {\n", t.Name)
+		writeFields(sb, t.Fields)
+		sb.WriteString("}\n")
+	case "ENUM":
+		fmt.Fprintf(sb, "enum %s {\n", t.Name)
+		for _, f := range t.Fields {
+			fmt.Fprintf(sb, "  %s\n", f.Name)
+		}
+		sb.WriteString("}\n")
+	case "UNION":
+		fmt.Fprintf(sb, "union %s\n", t.Name)
+	case "SCALAR":
+		fmt.Fprintf(sb, "scalar %s\n", t.Name)
+	}
+}
+
+// writeFields emits field definitions for object/input/interface types.
+func writeFields(sb *strings.Builder, fields []classify.GraphQLField) {
+	for _, f := range fields {
+		fmt.Fprintf(sb, "  %s: %s\n", f.Name, typeRefToSDL(f.Type))
+	}
+}
+
+// typeRefToSDL converts a GraphQLTypeRef to its SDL string representation.
+// Handles NON_NULL (Type!), LIST ([Type]), and named types via recursive ofType traversal.
+func typeRefToSDL(ref classify.GraphQLTypeRef) string {
+	switch ref.Kind {
+	case "NON_NULL":
+		if ref.OfType != nil {
+			return typeRefToSDL(*ref.OfType) + "!"
+		}
+		return "Unknown!"
+	case "LIST":
+		if ref.OfType != nil {
+			return "[" + typeRefToSDL(*ref.OfType) + "]"
+		}
+		return "[Unknown]"
+	default:
+		if ref.Name != nil {
+			return *ref.Name
+		}
+		return "Unknown"
+	}
+}

--- a/pkg/generate/graphql/sdl.go
+++ b/pkg/generate/graphql/sdl.go
@@ -97,8 +97,8 @@ func generateFromIntrospection(schema *classify.GraphQLIntrospection) ([]byte, e
 		return userTypes[i].Name < userTypes[j].Name
 	})
 
-	// Emit schema block if root types are present
-	writeSchemaBlock(&sb, userTypes)
+	// Emit schema block using introspection root type names if available
+	writeSchemaBlockFromIntrospection(&sb, schema, userTypes)
 
 	// Emit type definitions
 	for i, t := range userTypes {
@@ -111,20 +111,38 @@ func generateFromIntrospection(schema *classify.GraphQLIntrospection) ([]byte, e
 	return []byte(sb.String()), nil
 }
 
-// writeSchemaBlock emits a schema { ... } block if any root types exist.
-func writeSchemaBlock(sb *strings.Builder, types []classify.GraphQLType) {
-	var roots []string
-	rootMap := make(map[string]bool)
+// writeSchemaBlockFromIntrospection emits a schema { ... } block using introspection
+// root type names when available, falling back to conventional name detection.
+func writeSchemaBlockFromIntrospection(sb *strings.Builder, schema *classify.GraphQLIntrospection, types []classify.GraphQLType) {
+	// Build a set of type names that actually exist
+	typeExists := make(map[string]bool)
 	for _, t := range types {
-		if rootTypeNames[t.Name] && (t.Kind == "OBJECT") {
-			rootMap[t.Name] = true
-		}
+		typeExists[t.Name] = true
 	}
 
-	// Emit in canonical order
-	for _, name := range []string{"Query", "Mutation", "Subscription"} {
-		if rootMap[name] {
-			roots = append(roots, name)
+	type rootEntry struct {
+		op   string
+		name string
+	}
+	var roots []rootEntry
+
+	// Use introspection root type names if available
+	if schema.QueryTypeName != "" && typeExists[schema.QueryTypeName] {
+		roots = append(roots, rootEntry{"query", schema.QueryTypeName})
+	}
+	if schema.MutationTypeName != "" && typeExists[schema.MutationTypeName] {
+		roots = append(roots, rootEntry{"mutation", schema.MutationTypeName})
+	}
+	if schema.SubscriptionTypeName != "" && typeExists[schema.SubscriptionTypeName] {
+		roots = append(roots, rootEntry{"subscription", schema.SubscriptionTypeName})
+	}
+
+	// Fall back to conventional name detection if no root type names from introspection
+	if len(roots) == 0 {
+		for _, name := range []string{"Query", "Mutation", "Subscription"} {
+			if typeExists[name] {
+				roots = append(roots, rootEntry{strings.ToLower(name), name})
+			}
 		}
 	}
 
@@ -133,8 +151,8 @@ func writeSchemaBlock(sb *strings.Builder, types []classify.GraphQLType) {
 	}
 
 	sb.WriteString("schema {\n")
-	for _, name := range roots {
-		fmt.Fprintf(sb, "  %s: %s\n", strings.ToLower(name), name)
+	for _, r := range roots {
+		fmt.Fprintf(sb, "  %s: %s\n", r.op, r.name)
 	}
 	sb.WriteString("}\n")
 }
@@ -143,12 +161,26 @@ func writeSchemaBlock(sb *strings.Builder, types []classify.GraphQLType) {
 func writeTypeDefinition(sb *strings.Builder, t classify.GraphQLType) {
 	switch t.Kind {
 	case "OBJECT":
-		fmt.Fprintf(sb, "type %s {\n", t.Name)
+		if len(t.Interfaces) > 0 {
+			names := make([]string, 0, len(t.Interfaces))
+			for _, iface := range t.Interfaces {
+				if iface.Name != nil {
+					names = append(names, *iface.Name)
+				}
+			}
+			if len(names) > 0 {
+				fmt.Fprintf(sb, "type %s implements %s {\n", t.Name, strings.Join(names, " & "))
+			} else {
+				fmt.Fprintf(sb, "type %s {\n", t.Name)
+			}
+		} else {
+			fmt.Fprintf(sb, "type %s {\n", t.Name)
+		}
 		writeFields(sb, t.Fields)
 		sb.WriteString("}\n")
 	case "INPUT_OBJECT":
 		fmt.Fprintf(sb, "input %s {\n", t.Name)
-		writeFields(sb, t.Fields)
+		writeInputFields(sb, t.InputFields)
 		sb.WriteString("}\n")
 	case "INTERFACE":
 		fmt.Fprintf(sb, "interface %s {\n", t.Name)
@@ -156,22 +188,59 @@ func writeTypeDefinition(sb *strings.Builder, t classify.GraphQLType) {
 		sb.WriteString("}\n")
 	case "ENUM":
 		fmt.Fprintf(sb, "enum %s {\n", t.Name)
-		for _, f := range t.Fields {
-			fmt.Fprintf(sb, "  %s\n", f.Name)
+		if len(t.EnumValues) > 0 {
+			for _, ev := range t.EnumValues {
+				fmt.Fprintf(sb, "  %s\n", ev.Name)
+			}
+		} else {
+			// Fall back to field names for Tier 3 responses
+			for _, f := range t.Fields {
+				fmt.Fprintf(sb, "  %s\n", f.Name)
+			}
 		}
 		sb.WriteString("}\n")
 	case "UNION":
-		fmt.Fprintf(sb, "union %s\n", t.Name)
+		if len(t.PossibleTypes) > 0 {
+			names := make([]string, 0, len(t.PossibleTypes))
+			for _, pt := range t.PossibleTypes {
+				if pt.Name != nil {
+					names = append(names, *pt.Name)
+				}
+			}
+			fmt.Fprintf(sb, "union %s = %s\n", t.Name, strings.Join(names, " | "))
+		} else {
+			fmt.Fprintf(sb, "union %s\n", t.Name)
+		}
 	case "SCALAR":
 		fmt.Fprintf(sb, "scalar %s\n", t.Name)
 	}
 }
 
-// writeFields emits field definitions for object/input/interface types.
+// writeFields emits field definitions with arguments for object/interface types.
 func writeFields(sb *strings.Builder, fields []classify.GraphQLField) {
+	for _, f := range fields {
+		if len(f.Args) > 0 {
+			fmt.Fprintf(sb, "  %s(%s): %s\n", f.Name, formatArgs(f.Args), typeRefToSDL(f.Type))
+		} else {
+			fmt.Fprintf(sb, "  %s: %s\n", f.Name, typeRefToSDL(f.Type))
+		}
+	}
+}
+
+// writeInputFields emits input field definitions.
+func writeInputFields(sb *strings.Builder, fields []classify.GraphQLInputValue) {
 	for _, f := range fields {
 		fmt.Fprintf(sb, "  %s: %s\n", f.Name, typeRefToSDL(f.Type))
 	}
+}
+
+// formatArgs formats a list of input values as SDL argument syntax.
+func formatArgs(args []classify.GraphQLInputValue) string {
+	parts := make([]string, 0, len(args))
+	for _, a := range args {
+		parts = append(parts, fmt.Sprintf("%s: %s", a.Name, typeRefToSDL(a.Type)))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // typeRefToSDL converts a GraphQLTypeRef to its SDL string representation.

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -252,11 +252,18 @@ func TestGenerator_Phase2_InferFromTraffic(t *testing.T) {
 	if !strings.Contains(sdl, "type Query {") {
 		t.Error("missing type Query")
 	}
-	if !strings.Contains(sdl, "GetUser") {
-		t.Error("missing operation name GetUser")
+	// Should use root field name "user" not operation name "GetUser"
+	if !strings.Contains(sdl, "user") {
+		t.Error("missing root field name 'user'")
+	}
+	if strings.Contains(sdl, "GetUser") {
+		t.Error("should not use operation name 'GetUser' as field name")
 	}
 	if !strings.Contains(sdl, "id: String") {
 		t.Error("missing inferred field 'id: String'")
+	}
+	if !strings.Contains(sdl, "name: String") {
+		t.Error("missing inferred field 'name: String'")
 	}
 }
 
@@ -284,8 +291,9 @@ func TestGenerator_Phase2_MutationDetection(t *testing.T) {
 	if !strings.Contains(sdl, "type Mutation {") {
 		t.Errorf("expected 'type Mutation', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "CreateUser") {
-		t.Error("missing operation name CreateUser")
+	// Should use root field name "createUser"
+	if !strings.Contains(sdl, "createUser") {
+		t.Error("missing root field name 'createUser'")
 	}
 }
 
@@ -295,7 +303,7 @@ func TestGenerator_Phase2_VariableTypeInference(t *testing.T) {
 		{
 			ObservedRequest: crawl.ObservedRequest{
 				URL:  "http://example.com/graphql",
-				Body: []byte(`{"query":"query Search { search { id } }","variables":{"term":"hello","limit":10,"active":true,"score":3.14}}`),
+				Body: []byte(`{"query":"query Search($term: String, $limit: Int, $active: Boolean, $score: Float) { search(term: $term, limit: $limit, active: $active, score: $score) { id } }","variables":{"term":"hello","limit":10,"active":true,"score":3.14}}`),
 				Response: crawl.ObservedResponse{
 					Body: []byte(`{"data":{"search":{"id":"1"}}}`),
 				},
@@ -321,6 +329,117 @@ func TestGenerator_Phase2_VariableTypeInference(t *testing.T) {
 	}
 	if !strings.Contains(sdl, "score: Float") {
 		t.Errorf("expected 'score: Float' in args, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_ArrayResponse(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetPastes { pastes { id title content public } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"pastes":[{"id":"1","title":"First","content":"Hello","public":true},{"id":"2","title":"Second","content":"World","public":false}]}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Should use list return type
+	if !strings.Contains(sdl, "[PastesResponse]") {
+		t.Errorf("expected list return type '[PastesResponse]', got:\n%s", sdl)
+	}
+	// Should have the response type with fields from the array elements
+	if !strings.Contains(sdl, "type PastesResponse {") {
+		t.Errorf("expected 'type PastesResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "id: String") {
+		t.Errorf("expected 'id: String' in PastesResponse, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "title: String") {
+		t.Errorf("expected 'title: String' in PastesResponse, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "public: Boolean") {
+		t.Errorf("expected 'public: Boolean' in PastesResponse, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_TypedVariableDefinitions(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation CreatePaste($title: String!, $content: String!, $public: Boolean) { createPaste(title: $title, content: $content, public: $public) { id } }","variables":{"title":"Test","content":"Body","public":true}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"createPaste":{"id":"42"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Should preserve non-null modifier from variable definition
+	if !strings.Contains(sdl, "title: String!") {
+		t.Errorf("expected 'title: String!' (non-null from variable def), got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "content: String!") {
+		t.Errorf("expected 'content: String!' (non-null from variable def), got:\n%s", sdl)
+	}
+	// Boolean without ! should remain nullable
+	if !strings.Contains(sdl, "public: Boolean") {
+		t.Errorf("expected 'public: Boolean' (nullable), got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_NestedSelectionSet(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetUser { user { id name email } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"user":{"id":"1","name":"Alice","email":"alice@example.com","internalField":"secret"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Should include fields from the selection set
+	if !strings.Contains(sdl, "id: String") {
+		t.Errorf("expected 'id: String', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "name: String") {
+		t.Errorf("expected 'name: String', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "email: String") {
+		t.Errorf("expected 'email: String', got:\n%s", sdl)
+	}
+	// Selection set is authoritative — fields not in it should be excluded
+	if strings.Contains(sdl, "internalField") {
+		t.Error("should not include 'internalField' which is not in the selection set")
 	}
 }
 
@@ -352,8 +471,9 @@ func TestGenerator_Phase1_FallsToPhase2(t *testing.T) {
 	if !strings.Contains(sdl, "# Inferred from observed traffic") {
 		t.Error("expected phase 2 inference header")
 	}
-	if !strings.Contains(sdl, "Hello") {
-		t.Error("expected operation name Hello")
+	// Should use root field name "hello"
+	if !strings.Contains(sdl, "hello") {
+		t.Error("expected root field name 'hello'")
 	}
 }
 

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -812,14 +812,61 @@ func TestGenerator_Phase2_InlineFragmentMerging(t *testing.T) {
 	}
 
 	sdl := string(out)
+	// Mixed case: direct field "id" + inline fragments should produce a union
+	if !strings.Contains(sdl, "union UserResult = Admin | Member") && !strings.Contains(sdl, "union UserResult = Member | Admin") {
+		t.Errorf("expected 'union UserResult = Admin | Member', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type Admin {") {
+		t.Errorf("expected 'type Admin' union member, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type Member {") {
+		t.Errorf("expected 'type Member' union member, got:\n%s", sdl)
+	}
+	// Common field "id" should be merged into each union member
 	if !strings.Contains(sdl, "role: String") {
-		t.Errorf("expected 'role: String' from inline fragment, got:\n%s", sdl)
+		t.Errorf("expected 'role: String' in Admin type, got:\n%s", sdl)
 	}
 	if !strings.Contains(sdl, "level: String") {
-		t.Errorf("expected 'level: String' from inline fragment, got:\n%s", sdl)
+		t.Errorf("expected 'level: String' in Member type, got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "id: String") {
-		t.Errorf("expected 'id: String', got:\n%s", sdl)
+}
+
+func TestGenerator_Phase2_NestedMixedInlineFragments(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetOrder { order { item { name ... on BookItem { isbn } ... on FoodItem { calories } } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"order":{"item":{"name":"Test","isbn":"123-456"}}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Nested field "item" has direct field "name" + inline fragments → union
+	if !strings.Contains(sdl, "union Order_ItemResult = BookItem | FoodItem") && !strings.Contains(sdl, "union Order_ItemResult = FoodItem | BookItem") {
+		t.Errorf("expected 'union Order_ItemResult = BookItem | FoodItem', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type BookItem {") {
+		t.Errorf("expected 'type BookItem', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type FoodItem {") {
+		t.Errorf("expected 'type FoodItem', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "isbn: String") {
+		t.Errorf("expected 'isbn: String' in BookItem, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "calories: String") {
+		t.Errorf("expected 'calories: String' in FoodItem, got:\n%s", sdl)
 	}
 }
 

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -87,7 +87,7 @@ func TestGenerator_Phase1_IntrospectionSDL(t *testing.T) {
 					{
 						Name: "CreateUserInput",
 						Kind: "INPUT_OBJECT",
-						Fields: []classify.GraphQLField{
+						InputFields: []classify.GraphQLInputValue{
 							{Name: "name", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
 							{Name: "email", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
 						},
@@ -132,6 +132,10 @@ func TestGenerator_Phase1_IntrospectionSDL(t *testing.T) {
 	// Verify fields
 	if !strings.Contains(sdl, "users: [User]") {
 		t.Error("missing LIST type rendering for users field")
+	}
+	// Verify input fields render
+	if !strings.Contains(sdl, "  name: String") {
+		t.Error("missing input field 'name' in CreateUserInput")
 	}
 }
 
@@ -222,6 +226,254 @@ func TestGenerator_Phase1_HandlesWrappingTypes(t *testing.T) {
 	}
 	if !strings.Contains(sdl, "requiredList: [User]!") {
 		t.Errorf("expected NON_NULL(LIST) rendering '[User]!', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase1_FieldArgs(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			APIType: "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: true,
+				Types: []classify.GraphQLType{
+					{
+						Name: "Query",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{
+								Name: "user",
+								Args: []classify.GraphQLInputValue{
+									{Name: "id", Type: classify.GraphQLTypeRef{Kind: "NON_NULL", OfType: &classify.GraphQLTypeRef{Name: strPtr("ID"), Kind: "SCALAR"}}},
+								},
+								Type: classify.GraphQLTypeRef{Name: strPtr("User"), Kind: "OBJECT"},
+							},
+							{
+								Name: "users",
+								Args: []classify.GraphQLInputValue{
+									{Name: "limit", Type: classify.GraphQLTypeRef{Name: strPtr("Int"), Kind: "SCALAR"}},
+									{Name: "offset", Type: classify.GraphQLTypeRef{Name: strPtr("Int"), Kind: "SCALAR"}},
+								},
+								Type: classify.GraphQLTypeRef{Kind: "LIST", OfType: &classify.GraphQLTypeRef{Name: strPtr("User"), Kind: "OBJECT"}},
+							},
+						},
+					},
+					{
+						Name: "User",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "id", Type: classify.GraphQLTypeRef{Name: strPtr("ID"), Kind: "SCALAR"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "user(id: ID!): User") {
+		t.Errorf("expected field with arg 'user(id: ID!): User', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "users(limit: Int, offset: Int): [User]") {
+		t.Errorf("expected field with multiple args, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase1_EnumValues(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			APIType: "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: true,
+				Types: []classify.GraphQLType{
+					{
+						Name: "Query",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "hello", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
+						},
+					},
+					{
+						Name: "Role",
+						Kind: "ENUM",
+						EnumValues: []classify.GraphQLEnumValue{
+							{Name: "ADMIN"},
+							{Name: "EDITOR"},
+							{Name: "VIEWER"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "enum Role {") {
+		t.Errorf("missing enum Role, got:\n%s", sdl)
+	}
+	for _, val := range []string{"ADMIN", "EDITOR", "VIEWER"} {
+		if !strings.Contains(sdl, "  "+val) {
+			t.Errorf("missing enum value %s, got:\n%s", val, sdl)
+		}
+	}
+}
+
+func TestGenerator_Phase1_UnionPossibleTypes(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			APIType: "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: true,
+				Types: []classify.GraphQLType{
+					{
+						Name: "Query",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "search", Type: classify.GraphQLTypeRef{Name: strPtr("SearchResult"), Kind: "UNION"}},
+						},
+					},
+					{
+						Name: "SearchResult",
+						Kind: "UNION",
+						PossibleTypes: []classify.GraphQLTypeRef{
+							{Name: strPtr("User"), Kind: "OBJECT"},
+							{Name: strPtr("Post"), Kind: "OBJECT"},
+						},
+					},
+					{
+						Name: "User",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "id", Type: classify.GraphQLTypeRef{Name: strPtr("ID"), Kind: "SCALAR"}},
+						},
+					},
+					{
+						Name: "Post",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "id", Type: classify.GraphQLTypeRef{Name: strPtr("ID"), Kind: "SCALAR"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "union SearchResult = User | Post") {
+		t.Errorf("expected union with possible types, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase1_InterfaceImplements(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			APIType: "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: true,
+				Types: []classify.GraphQLType{
+					{
+						Name: "Query",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "node", Type: classify.GraphQLTypeRef{Name: strPtr("Node"), Kind: "INTERFACE"}},
+						},
+					},
+					{
+						Name: "Node",
+						Kind: "INTERFACE",
+						Fields: []classify.GraphQLField{
+							{Name: "id", Type: classify.GraphQLTypeRef{Kind: "NON_NULL", OfType: &classify.GraphQLTypeRef{Name: strPtr("ID"), Kind: "SCALAR"}}},
+						},
+					},
+					{
+						Name: "User",
+						Kind: "OBJECT",
+						Interfaces: []classify.GraphQLTypeRef{
+							{Name: strPtr("Node"), Kind: "INTERFACE"},
+						},
+						Fields: []classify.GraphQLField{
+							{Name: "id", Type: classify.GraphQLTypeRef{Kind: "NON_NULL", OfType: &classify.GraphQLTypeRef{Name: strPtr("ID"), Kind: "SCALAR"}}},
+							{Name: "name", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "type User implements Node {") {
+		t.Errorf("expected 'type User implements Node', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "interface Node {") {
+		t.Errorf("missing interface Node, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase1_RootTypeNamesFromIntrospection(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			APIType: "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: true,
+				QueryTypeName:       "RootQuery",
+				MutationTypeName:    "RootMutation",
+				Types: []classify.GraphQLType{
+					{
+						Name: "RootQuery",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "hello", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
+						},
+					},
+					{
+						Name: "RootMutation",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "doThing", Type: classify.GraphQLTypeRef{Name: strPtr("Boolean"), Kind: "SCALAR"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "query: RootQuery") {
+		t.Errorf("expected 'query: RootQuery' in schema block, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "mutation: RootMutation") {
+		t.Errorf("expected 'mutation: RootMutation' in schema block, got:\n%s", sdl)
 	}
 }
 

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -1,0 +1,405 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graphql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestGenerator_APIType(t *testing.T) {
+	g := &Generator{}
+	if got := g.APIType(); got != "graphql" {
+		t.Errorf("APIType() = %q, want %q", got, "graphql")
+	}
+}
+
+func TestGenerator_DefaultExtension(t *testing.T) {
+	g := &Generator{}
+	if got := g.DefaultExtension(); got != ".graphql" {
+		t.Errorf("DefaultExtension() = %q, want %q", got, ".graphql")
+	}
+}
+
+func TestGenerator_EmptyEndpoints(t *testing.T) {
+	g := &Generator{}
+	_, err := g.Generate(nil)
+	if err == nil {
+		t.Fatal("expected error for empty endpoints")
+	}
+	if !strings.Contains(err.Error(), "no endpoints") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGenerator_Phase1_IntrospectionSDL(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{URL: "http://example.com/graphql"},
+			APIType:         "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: true,
+				Types: []classify.GraphQLType{
+					{
+						Name: "Query",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "user", Type: classify.GraphQLTypeRef{Name: strPtr("User"), Kind: "OBJECT"}},
+							{Name: "users", Type: classify.GraphQLTypeRef{
+								Kind:   "LIST",
+								OfType: &classify.GraphQLTypeRef{Name: strPtr("User"), Kind: "OBJECT"},
+							}},
+						},
+					},
+					{
+						Name: "Mutation",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "createUser", Type: classify.GraphQLTypeRef{Name: strPtr("User"), Kind: "OBJECT"}},
+						},
+					},
+					{
+						Name: "User",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "id", Type: classify.GraphQLTypeRef{Name: strPtr("ID"), Kind: "SCALAR"}},
+							{Name: "name", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
+						},
+					},
+					{
+						Name: "CreateUserInput",
+						Kind: "INPUT_OBJECT",
+						Fields: []classify.GraphQLField{
+							{Name: "name", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
+							{Name: "email", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+
+	// Verify schema block
+	if !strings.Contains(sdl, "schema {") {
+		t.Error("missing schema block")
+	}
+	if !strings.Contains(sdl, "query: Query") {
+		t.Error("missing query root in schema block")
+	}
+	if !strings.Contains(sdl, "mutation: Mutation") {
+		t.Error("missing mutation root in schema block")
+	}
+
+	// Verify type definitions
+	if !strings.Contains(sdl, "type Query {") {
+		t.Error("missing type Query")
+	}
+	if !strings.Contains(sdl, "type Mutation {") {
+		t.Error("missing type Mutation")
+	}
+	if !strings.Contains(sdl, "type User {") {
+		t.Error("missing type User")
+	}
+	if !strings.Contains(sdl, "input CreateUserInput {") {
+		t.Error("missing input CreateUserInput")
+	}
+
+	// Verify fields
+	if !strings.Contains(sdl, "users: [User]") {
+		t.Error("missing LIST type rendering for users field")
+	}
+}
+
+func TestGenerator_Phase1_SkipsBuiltinTypes(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			APIType: "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: true,
+				Types: []classify.GraphQLType{
+					{Name: "Query", Kind: "OBJECT", Fields: []classify.GraphQLField{
+						{Name: "hello", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
+					}},
+					{Name: "__Type", Kind: "OBJECT"},
+					{Name: "__Schema", Kind: "OBJECT"},
+					{Name: "String", Kind: "SCALAR"},
+					{Name: "Int", Kind: "SCALAR"},
+					{Name: "Boolean", Kind: "SCALAR"},
+					{Name: "Float", Kind: "SCALAR"},
+					{Name: "ID", Kind: "SCALAR"},
+				},
+			},
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	for _, builtin := range []string{"__Type", "__Schema", "scalar String", "scalar Int", "scalar Boolean", "scalar Float", "scalar ID"} {
+		if strings.Contains(sdl, builtin) {
+			t.Errorf("output should not contain built-in type %q", builtin)
+		}
+	}
+}
+
+func TestGenerator_Phase1_HandlesWrappingTypes(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			APIType: "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: true,
+				Types: []classify.GraphQLType{
+					{
+						Name: "Query",
+						Kind: "OBJECT",
+						Fields: []classify.GraphQLField{
+							// NON_NULL wrapping a named type: String!
+							{Name: "required", Type: classify.GraphQLTypeRef{
+								Kind:   "NON_NULL",
+								OfType: &classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"},
+							}},
+							// LIST wrapping a named type: [User]
+							{Name: "list", Type: classify.GraphQLTypeRef{
+								Kind:   "LIST",
+								OfType: &classify.GraphQLTypeRef{Name: strPtr("User"), Kind: "OBJECT"},
+							}},
+							// NON_NULL wrapping a LIST: [User]!
+							{Name: "requiredList", Type: classify.GraphQLTypeRef{
+								Kind: "NON_NULL",
+								OfType: &classify.GraphQLTypeRef{
+									Kind:   "LIST",
+									OfType: &classify.GraphQLTypeRef{Name: strPtr("User"), Kind: "OBJECT"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "required: String!") {
+		t.Errorf("expected NON_NULL rendering 'String!', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "list: [User]") {
+		t.Errorf("expected LIST rendering '[User]', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "requiredList: [User]!") {
+		t.Errorf("expected NON_NULL(LIST) rendering '[User]!', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_InferFromTraffic(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetUser { user { id name } }","variables":{"id":"123"}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"user":{"id":"abc","name":"Alice"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "# Inferred from observed traffic") {
+		t.Error("missing inference header comment")
+	}
+	if !strings.Contains(sdl, "type Query {") {
+		t.Error("missing type Query")
+	}
+	if !strings.Contains(sdl, "GetUser") {
+		t.Error("missing operation name GetUser")
+	}
+	if !strings.Contains(sdl, "id: String") {
+		t.Error("missing inferred field 'id: String'")
+	}
+}
+
+func TestGenerator_Phase2_MutationDetection(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation CreateUser { createUser { id } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"createUser":{"id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "type Mutation {") {
+		t.Errorf("expected 'type Mutation', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "CreateUser") {
+		t.Error("missing operation name CreateUser")
+	}
+}
+
+func TestGenerator_Phase2_VariableTypeInference(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Search { search { id } }","variables":{"term":"hello","limit":10,"active":true,"score":3.14}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"search":{"id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "term: String") {
+		t.Errorf("expected 'term: String' in args, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "limit: Int") {
+		t.Errorf("expected 'limit: Int' in args, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "active: Boolean") {
+		t.Errorf("expected 'active: Boolean' in args, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "score: Float") {
+		t.Errorf("expected 'score: Float' in args, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase1_FallsToPhase2(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Hello { hello { message } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"hello":{"message":"world"}}}`),
+				},
+			},
+			APIType: "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: false,
+			},
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Should have fallen through to phase 2
+	if !strings.Contains(sdl, "# Inferred from observed traffic") {
+		t.Error("expected phase 2 inference header")
+	}
+	if !strings.Contains(sdl, "Hello") {
+		t.Error("expected operation name Hello")
+	}
+}
+
+func TestGenerator_DeterministicOutput(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			APIType: "graphql",
+			GraphQLSchema: &classify.GraphQLIntrospection{
+				IntrospectionEnabled: true,
+				Types: []classify.GraphQLType{
+					{Name: "Zebra", Kind: "OBJECT", Fields: []classify.GraphQLField{
+						{Name: "stripes", Type: classify.GraphQLTypeRef{Name: strPtr("Int"), Kind: "SCALAR"}},
+					}},
+					{Name: "Apple", Kind: "OBJECT", Fields: []classify.GraphQLField{
+						{Name: "color", Type: classify.GraphQLTypeRef{Name: strPtr("String"), Kind: "SCALAR"}},
+					}},
+					{Name: "Query", Kind: "OBJECT", Fields: []classify.GraphQLField{
+						{Name: "zebra", Type: classify.GraphQLTypeRef{Name: strPtr("Zebra"), Kind: "OBJECT"}},
+						{Name: "apple", Type: classify.GraphQLTypeRef{Name: strPtr("Apple"), Kind: "OBJECT"}},
+					}},
+				},
+			},
+		},
+	}
+
+	out1, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("first Generate() error: %v", err)
+	}
+
+	out2, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("second Generate() error: %v", err)
+	}
+
+	if string(out1) != string(out2) {
+		t.Errorf("output is not deterministic:\nfirst:\n%s\nsecond:\n%s", out1, out2)
+	}
+
+	// Verify alphabetical ordering: Apple before Query before Zebra
+	sdl := string(out1)
+	appleIdx := strings.Index(sdl, "type Apple")
+	queryIdx := strings.Index(sdl, "type Query")
+	zebraIdx := strings.Index(sdl, "type Zebra")
+	if appleIdx > queryIdx || queryIdx > zebraIdx {
+		t.Error("types should be sorted alphabetically")
+	}
+}

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -726,11 +726,11 @@ func TestGenerator_Phase2_NestedObjectType(t *testing.T) {
 	}
 
 	sdl := string(out)
-	if !strings.Contains(sdl, "profile: User_ProfileResponse") {
-		t.Errorf("expected 'profile: User_ProfileResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "profile: GetUser_ProfileResponse") {
+		t.Errorf("expected 'profile: GetUser_ProfileResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type User_ProfileResponse {") {
-		t.Errorf("expected 'type User_ProfileResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type GetUser_ProfileResponse {") {
+		t.Errorf("expected 'type GetUser_ProfileResponse', got:\n%s", sdl)
 	}
 	if !strings.Contains(sdl, "bio: String") {
 		t.Errorf("expected 'bio: String' in nested type, got:\n%s", sdl)
@@ -764,23 +764,23 @@ func TestGenerator_Phase2_MultiLevelNesting(t *testing.T) {
 	}
 
 	sdl := string(out)
-	if !strings.Contains(sdl, "locale: Viewer_LocaleResponse") {
-		t.Errorf("expected 'locale: Viewer_LocaleResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "locale: GetViewer_LocaleResponse") {
+		t.Errorf("expected 'locale: GetViewer_LocaleResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type Viewer_LocaleResponse {") {
-		t.Errorf("expected 'type Viewer_LocaleResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type GetViewer_LocaleResponse {") {
+		t.Errorf("expected 'type GetViewer_LocaleResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "language: Viewer_Locale_LanguageResponse") {
-		t.Errorf("expected 'language: Viewer_Locale_LanguageResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "language: GetViewer_Locale_LanguageResponse") {
+		t.Errorf("expected 'language: GetViewer_Locale_LanguageResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "currency: Viewer_Locale_CurrencyResponse") {
-		t.Errorf("expected 'currency: Viewer_Locale_CurrencyResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "currency: GetViewer_Locale_CurrencyResponse") {
+		t.Errorf("expected 'currency: GetViewer_Locale_CurrencyResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type Viewer_Locale_LanguageResponse {") {
-		t.Errorf("expected 'type Viewer_Locale_LanguageResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type GetViewer_Locale_LanguageResponse {") {
+		t.Errorf("expected 'type GetViewer_Locale_LanguageResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type Viewer_Locale_CurrencyResponse {") {
-		t.Errorf("expected 'type Viewer_Locale_CurrencyResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type GetViewer_Locale_CurrencyResponse {") {
+		t.Errorf("expected 'type GetViewer_Locale_CurrencyResponse', got:\n%s", sdl)
 	}
 }
 
@@ -837,11 +837,11 @@ func TestGenerator_Phase2_NestedArray(t *testing.T) {
 	}
 
 	sdl := string(out)
-	if !strings.Contains(sdl, "posts: [User_PostsResponse]") {
-		t.Errorf("expected 'posts: [User_PostsResponse]', got:\n%s", sdl)
+	if !strings.Contains(sdl, "posts: [GetUser_PostsResponse]") {
+		t.Errorf("expected 'posts: [GetUser_PostsResponse]', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type User_PostsResponse {") {
-		t.Errorf("expected 'type User_PostsResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type GetUser_PostsResponse {") {
+		t.Errorf("expected 'type GetUser_PostsResponse', got:\n%s", sdl)
 	}
 	if !strings.Contains(sdl, "title: String") {
 		t.Errorf("expected 'title: String' in nested array type, got:\n%s", sdl)
@@ -869,11 +869,11 @@ func TestGenerator_Phase2_NamedFragmentWithNesting(t *testing.T) {
 	}
 
 	sdl := string(out)
-	if !strings.Contains(sdl, "profile: User_ProfileResponse") {
-		t.Errorf("expected 'profile: User_ProfileResponse' from fragment, got:\n%s", sdl)
+	if !strings.Contains(sdl, "profile: GetUser_ProfileResponse") {
+		t.Errorf("expected 'profile: GetUser_ProfileResponse' from fragment, got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type User_ProfileResponse {") {
-		t.Errorf("expected 'type User_ProfileResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type GetUser_ProfileResponse {") {
+		t.Errorf("expected 'type GetUser_ProfileResponse', got:\n%s", sdl)
 	}
 	if !strings.Contains(sdl, "bio: String") {
 		t.Errorf("expected 'bio: String' in nested type from fragment, got:\n%s", sdl)
@@ -909,5 +909,68 @@ func TestGenerator_Phase2_TypenameFiltered(t *testing.T) {
 	}
 	if !strings.Contains(sdl, "name: String") {
 		t.Errorf("expected 'name: String', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_DisambiguationWithNesting(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query StoredPassengers { viewer { passengers { id name } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"passengers":[{"id":"1","name":"Alice"}]}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query FareLocksTabQuery { viewer { fareLocks { id status } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"fareLocks":[{"id":"2","status":"active"}]}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+
+	// First op keeps bare "viewer" field, nested types use op name "StoredPassengers"
+	if !strings.Contains(sdl, "passengers: [StoredPassengers_PassengersResponse]") {
+		t.Errorf("expected 'passengers: [StoredPassengers_PassengersResponse]', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type StoredPassengers_PassengersResponse {") {
+		t.Errorf("expected 'type StoredPassengers_PassengersResponse', got:\n%s", sdl)
+	}
+
+	// Second op gets disambiguated field "viewer_FareLocksTabQuery", nested types use op name "FareLocksTabQuery"
+	if !strings.Contains(sdl, "viewer_FareLocksTabQuery") {
+		t.Errorf("expected disambiguated field 'viewer_FareLocksTabQuery', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "fareLocks: [FareLocksTabQuery_FareLocksResponse]") {
+		t.Errorf("expected 'fareLocks: [FareLocksTabQuery_FareLocksResponse]', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type FareLocksTabQuery_FareLocksResponse {") {
+		t.Errorf("expected 'type FareLocksTabQuery_FareLocksResponse', got:\n%s", sdl)
+	}
+
+	// Assert no cascading rename — no type name should exceed 100 characters
+	for _, line := range strings.Split(sdl, "\n") {
+		if strings.HasPrefix(line, "type ") {
+			typeName := strings.TrimPrefix(line, "type ")
+			typeName = strings.TrimSuffix(typeName, " {")
+			if len(typeName) > 100 {
+				t.Errorf("type name too long (%d chars): %s", len(typeName), typeName)
+			}
+		}
 	}
 }

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -523,3 +523,184 @@ func TestGenerator_DeterministicOutput(t *testing.T) {
 		t.Error("types should be sorted alphabetically")
 	}
 }
+
+func TestGenerator_Phase2_FragmentSpreadResolution(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query FooQuery { ...Foo_root } fragment Foo_root on Query { user { id name } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"user":{"id":"1","name":"Alice"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Should resolve through the fragment spread to find "user" as root field
+	if !strings.Contains(sdl, "user") {
+		t.Errorf("expected root field 'user' resolved from fragment spread, got:\n%s", sdl)
+	}
+	// Should NOT fall back to anonymous naming
+	if strings.Contains(sdl, "anonymous") {
+		t.Errorf("should not have anonymous naming when fragment resolves to a field, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_OperationNameFallback(t *testing.T) {
+	g := &Generator{}
+	// A query where the fragment spread cannot resolve to a field (fragment has no fields, only nested spreads)
+	// but the operation has a name — should use operation name as fallback
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query BaggagePreferencesQuery { ...BaggageRoot } fragment BaggageRoot on Query { preferences { baggage } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"preferences":{"baggage":"carry-on"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Should resolve the fragment to find "preferences" as root field
+	if !strings.Contains(sdl, "preferences") {
+		t.Errorf("expected root field 'preferences', got:\n%s", sdl)
+	}
+	if strings.Contains(sdl, "anonymous") {
+		t.Errorf("should not have anonymous naming, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_DedupPreservesDistinctOperations(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query StoredPassengers { viewer { passengers { id name } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"passengers":[{"id":"1","name":"Alice"}]}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query FareLocksTabQuery { viewer { fareLocks { id status } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"fareLocks":[{"id":"2","status":"active"}]}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Both operations should appear even though they share root field "viewer"
+	if !strings.Contains(sdl, "viewer") {
+		t.Errorf("expected 'viewer' field, got:\n%s", sdl)
+	}
+	// The second operation should be disambiguated with its operation name
+	if !strings.Contains(sdl, "viewer_FareLocksTabQuery") {
+		t.Errorf("expected disambiguated 'viewer_FareLocksTabQuery' field, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_GETRequestWithQueryParams(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "http://example.com/graphql?query=query%20GetStatus%20%7B%20status%20%7B%20healthy%20version%20%7D%20%7D",
+				Body:   nil,
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"status":{"healthy":true,"version":"1.0"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "status") {
+		t.Errorf("expected root field 'status' from GET request, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "healthy: Boolean") {
+		t.Errorf("expected 'healthy: Boolean' field, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_MultipartFormData(t *testing.T) {
+	g := &Generator{}
+	boundary := "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+	multipartBody := "------WebKitFormBoundary7MA4YWxkTrZu0gW\r\n" +
+		"Content-Disposition: form-data; name=\"operations\"\r\n\r\n" +
+		`{"query":"mutation UploadFile($file: Upload!) { uploadFile(file: $file) { id url } }","variables":{"file":null}}` + "\r\n" +
+		"------WebKitFormBoundary7MA4YWxkTrZu0gW\r\n" +
+		"Content-Disposition: form-data; name=\"map\"\r\n\r\n" +
+		`{"0":["variables.file"]}` + "\r\n" +
+		"------WebKitFormBoundary7MA4YWxkTrZu0gW\r\n" +
+		"Content-Disposition: form-data; name=\"0\"; filename=\"test.txt\"\r\n" +
+		"Content-Type: text/plain\r\n\r\n" +
+		"file content\r\n" +
+		"------WebKitFormBoundary7MA4YWxkTrZu0gW--\r\n"
+
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "http://example.com/graphql",
+				Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=" + boundary},
+				Body:    []byte(multipartBody),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"uploadFile":{"id":"42","url":"https://example.com/file.txt"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "type Mutation {") {
+		t.Errorf("expected 'type Mutation', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "uploadFile") {
+		t.Errorf("expected root field 'uploadFile' from multipart request, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "file: Upload!") {
+		t.Errorf("expected 'file: Upload!' argument, got:\n%s", sdl)
+	}
+}

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -704,3 +704,210 @@ func TestGenerator_Phase2_MultipartFormData(t *testing.T) {
 		t.Errorf("expected 'file: Upload!' argument, got:\n%s", sdl)
 	}
 }
+
+func TestGenerator_Phase2_NestedObjectType(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetUser { user { id profile { bio avatar } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"user":{"id":"1","profile":{"bio":"hi","avatar":"pic.png"}}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "profile: User_ProfileResponse") {
+		t.Errorf("expected 'profile: User_ProfileResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type User_ProfileResponse {") {
+		t.Errorf("expected 'type User_ProfileResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "bio: String") {
+		t.Errorf("expected 'bio: String' in nested type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "avatar: String") {
+		t.Errorf("expected 'avatar: String' in nested type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "id: String") {
+		t.Errorf("expected 'id: String' in root type, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_MultiLevelNesting(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetViewer { viewer { locale { language { code } currency { code } } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"locale":{"language":{"code":"en"},"currency":{"code":"USD"}}}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "locale: Viewer_LocaleResponse") {
+		t.Errorf("expected 'locale: Viewer_LocaleResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type Viewer_LocaleResponse {") {
+		t.Errorf("expected 'type Viewer_LocaleResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "language: Viewer_Locale_LanguageResponse") {
+		t.Errorf("expected 'language: Viewer_Locale_LanguageResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "currency: Viewer_Locale_CurrencyResponse") {
+		t.Errorf("expected 'currency: Viewer_Locale_CurrencyResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type Viewer_Locale_LanguageResponse {") {
+		t.Errorf("expected 'type Viewer_Locale_LanguageResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type Viewer_Locale_CurrencyResponse {") {
+		t.Errorf("expected 'type Viewer_Locale_CurrencyResponse', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_InlineFragmentMerging(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetUser { user { id ... on Admin { role } ... on Member { level } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"user":{"id":"1","role":"admin","level":"senior"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "role: String") {
+		t.Errorf("expected 'role: String' from inline fragment, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "level: String") {
+		t.Errorf("expected 'level: String' from inline fragment, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "id: String") {
+		t.Errorf("expected 'id: String', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_NestedArray(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetUser { user { id posts { id title } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"user":{"id":"1","posts":[{"id":"10","title":"Hello"},{"id":"11","title":"World"}]}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "posts: [User_PostsResponse]") {
+		t.Errorf("expected 'posts: [User_PostsResponse]', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type User_PostsResponse {") {
+		t.Errorf("expected 'type User_PostsResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "title: String") {
+		t.Errorf("expected 'title: String' in nested array type, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_NamedFragmentWithNesting(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetUser { user { ...UserFields } } fragment UserFields on User { id profile { bio } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"user":{"id":"1","profile":{"bio":"hello"}}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "profile: User_ProfileResponse") {
+		t.Errorf("expected 'profile: User_ProfileResponse' from fragment, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type User_ProfileResponse {") {
+		t.Errorf("expected 'type User_ProfileResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "bio: String") {
+		t.Errorf("expected 'bio: String' in nested type from fragment, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_TypenameFiltered(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetUser { user { __typename id name } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"user":{"__typename":"User","id":"1","name":"Alice"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if strings.Contains(sdl, "__typename") {
+		t.Errorf("__typename should be filtered from output, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "id: String") {
+		t.Errorf("expected 'id: String', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "name: String") {
+		t.Errorf("expected 'name: String', got:\n%s", sdl)
+	}
+}

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -1397,11 +1397,11 @@ func TestGenerator_Phase2_InlineObjectLiteralInputType(t *testing.T) {
 
 	sdl := string(out)
 	// Should create an input type from the inline object literal
-	if !strings.Contains(sdl, "userData: UserDataInput") {
-		t.Errorf("expected 'userData: UserDataInput' from inline object, got:\n%s", sdl)
+	if !strings.Contains(sdl, "userData: CreateUser_UserDataInput") {
+		t.Errorf("expected 'userData: CreateUser_UserDataInput' from inline object, got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "input UserDataInput {") {
-		t.Errorf("expected 'input UserDataInput' type definition, got:\n%s", sdl)
+	if !strings.Contains(sdl, "input CreateUser_UserDataInput {") {
+		t.Errorf("expected 'input CreateUser_UserDataInput' type definition, got:\n%s", sdl)
 	}
 	if !strings.Contains(sdl, "username: String") {
 		t.Errorf("expected 'username: String' in input type, got:\n%s", sdl)

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -1942,3 +1942,206 @@ func TestGenerator_Phase2_UploadScalarDeclared(t *testing.T) {
 		t.Errorf("expected 'scalar Upload' declaration, got:\n%s", sdl)
 	}
 }
+
+func TestGenerator_Phase2_SingleInlineFragmentUnionPath(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetViewer { viewer { __typename ... on User { travelers { name } } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"__typename":"User","travelers":[{"name":"Alice"}]}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Single inline fragment should create union path with correct type
+	if !strings.Contains(sdl, "union ViewerResult = User") {
+		t.Errorf("expected 'union ViewerResult = User', got:\n%s", sdl)
+	}
+	// Fields should be on User, not on a generic ViewerResponse
+	if !strings.Contains(sdl, "type User {") {
+		t.Errorf("expected 'type User', got:\n%s", sdl)
+	}
+	// Nested types should use User_ prefix, not Viewer_
+	if !strings.Contains(sdl, "travelers: [User_TravelersResponse]") {
+		t.Errorf("expected 'travelers: [User_TravelersResponse]', got:\n%s", sdl)
+	}
+	// Should NOT have ViewerResponse type
+	if strings.Contains(sdl, "type ViewerResponse") {
+		t.Errorf("should not have 'type ViewerResponse', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_NamedFragmentSpreadUnionPath(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetViewer { viewer { ...ViewerFields } } fragment ViewerFields on User { unfinishedBooking { status } cards { last4 } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"unfinishedBooking":{"status":"pending"},"cards":[{"last4":"1234"}]}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Named fragment with TypeCondition should create union with correct member type
+	if !strings.Contains(sdl, "union ViewerResult = User") {
+		t.Errorf("expected 'union ViewerResult = User', got:\n%s", sdl)
+	}
+	// Fields should be on User type
+	if !strings.Contains(sdl, "type User {") {
+		t.Errorf("expected 'type User', got:\n%s", sdl)
+	}
+	// Nested types should use User_ prefix
+	if !strings.Contains(sdl, "unfinishedBooking: User_UnfinishedBookingResponse") {
+		t.Errorf("expected 'unfinishedBooking: User_UnfinishedBookingResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "cards: [User_CardsResponse]") {
+		t.Errorf("expected 'cards: [User_CardsResponse]', got:\n%s", sdl)
+	}
+	// Should NOT have ViewerResponse
+	if strings.Contains(sdl, "type ViewerResponse") {
+		t.Errorf("should not have 'type ViewerResponse', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_MixedSingleAndMultiFragmentOps(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		// Multi-fragment operation: creates union ViewerResult = Unauthorized | User
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Op1 { viewer { ... on Unauthorized { reason } ... on User { name } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"name":"Alice"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		// Single-fragment operation: should merge into existing union
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Op2 { viewer { ... on User { travelers { name } wallet { balance } } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"travelers":[{"name":"Bob"}],"wallet":{"balance":"100"}}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Union should exist with both members
+	if !strings.Contains(sdl, "union ViewerResult") {
+		t.Errorf("expected 'union ViewerResult', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "Unauthorized") {
+		t.Errorf("expected 'Unauthorized' in union, got:\n%s", sdl)
+	}
+	// User should have fields from BOTH operations
+	if !strings.Contains(sdl, "name: String") {
+		t.Errorf("expected 'name: String' on User, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "travelers: [User_TravelersResponse]") {
+		t.Errorf("expected 'travelers: [User_TravelersResponse]' on User, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "wallet: User_WalletResponse") {
+		t.Errorf("expected 'wallet: User_WalletResponse' on User, got:\n%s", sdl)
+	}
+	// Unauthorized should only have reason
+	if !strings.Contains(sdl, "reason: String") {
+		t.Errorf("expected 'reason: String' on Unauthorized, got:\n%s", sdl)
+	}
+	// Should NOT have ViewerResponse
+	if strings.Contains(sdl, "type ViewerResponse") {
+		t.Errorf("should not have 'type ViewerResponse', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_MultipleSingleFragmentOpsAccumulate(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Op1 { viewer { ... on User { name } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"name":"Alice"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Op2 { viewer { ... on User { email } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"email":"alice@example.com"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Op3 { viewer { ... on User { locale } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"locale":"en-US"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// All three operations should create/merge into same union
+	if !strings.Contains(sdl, "union ViewerResult = User") {
+		t.Errorf("expected 'union ViewerResult = User', got:\n%s", sdl)
+	}
+	// User should accumulate fields from all three operations
+	if !strings.Contains(sdl, "name: String") {
+		t.Errorf("expected 'name: String' from Op1, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "email: String") {
+		t.Errorf("expected 'email: String' from Op2, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "locale: String") {
+		t.Errorf("expected 'locale: String' from Op3, got:\n%s", sdl)
+	}
+	// Should be exactly one User type
+	userTypeCount := strings.Count(sdl, "type User {")
+	if userTypeCount != 1 {
+		t.Errorf("expected exactly 1 'type User {', got %d in:\n%s", userTypeCount, sdl)
+	}
+}

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -618,13 +618,20 @@ func TestGenerator_Phase2_DedupPreservesDistinctOperations(t *testing.T) {
 	}
 
 	sdl := string(out)
-	// Both operations should appear even though they share root field "viewer"
+	// Both operations should be merged into a single "viewer" field
 	if !strings.Contains(sdl, "viewer") {
 		t.Errorf("expected 'viewer' field, got:\n%s", sdl)
 	}
-	// The second operation should be disambiguated with its operation name
-	if !strings.Contains(sdl, "viewer_FareLocksTabQuery") {
-		t.Errorf("expected disambiguated 'viewer_FareLocksTabQuery' field, got:\n%s", sdl)
+	// Should NOT have disambiguated fields — they should be merged
+	if strings.Contains(sdl, "viewer_FareLocksTabQuery") {
+		t.Errorf("should not have disambiguated 'viewer_FareLocksTabQuery' — operations should be merged, got:\n%s", sdl)
+	}
+	// The merged ViewerResponse should contain fields from both operations
+	if !strings.Contains(sdl, "passengers") {
+		t.Errorf("expected 'passengers' field from first operation in merged type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "fareLocks") {
+		t.Errorf("expected 'fareLocks' field from second operation in merged type, got:\n%s", sdl)
 	}
 }
 
@@ -726,11 +733,11 @@ func TestGenerator_Phase2_NestedObjectType(t *testing.T) {
 	}
 
 	sdl := string(out)
-	if !strings.Contains(sdl, "profile: GetUser_ProfileResponse") {
-		t.Errorf("expected 'profile: GetUser_ProfileResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "profile: User_ProfileResponse") {
+		t.Errorf("expected 'profile: User_ProfileResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type GetUser_ProfileResponse {") {
-		t.Errorf("expected 'type GetUser_ProfileResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type User_ProfileResponse {") {
+		t.Errorf("expected 'type User_ProfileResponse', got:\n%s", sdl)
 	}
 	if !strings.Contains(sdl, "bio: String") {
 		t.Errorf("expected 'bio: String' in nested type, got:\n%s", sdl)
@@ -764,23 +771,23 @@ func TestGenerator_Phase2_MultiLevelNesting(t *testing.T) {
 	}
 
 	sdl := string(out)
-	if !strings.Contains(sdl, "locale: GetViewer_LocaleResponse") {
-		t.Errorf("expected 'locale: GetViewer_LocaleResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "locale: Viewer_LocaleResponse") {
+		t.Errorf("expected 'locale: Viewer_LocaleResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type GetViewer_LocaleResponse {") {
-		t.Errorf("expected 'type GetViewer_LocaleResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type Viewer_LocaleResponse {") {
+		t.Errorf("expected 'type Viewer_LocaleResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "language: GetViewer_Locale_LanguageResponse") {
-		t.Errorf("expected 'language: GetViewer_Locale_LanguageResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "language: Viewer_Locale_LanguageResponse") {
+		t.Errorf("expected 'language: Viewer_Locale_LanguageResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "currency: GetViewer_Locale_CurrencyResponse") {
-		t.Errorf("expected 'currency: GetViewer_Locale_CurrencyResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "currency: Viewer_Locale_CurrencyResponse") {
+		t.Errorf("expected 'currency: Viewer_Locale_CurrencyResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type GetViewer_Locale_LanguageResponse {") {
-		t.Errorf("expected 'type GetViewer_Locale_LanguageResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type Viewer_Locale_LanguageResponse {") {
+		t.Errorf("expected 'type Viewer_Locale_LanguageResponse', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type GetViewer_Locale_CurrencyResponse {") {
-		t.Errorf("expected 'type GetViewer_Locale_CurrencyResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type Viewer_Locale_CurrencyResponse {") {
+		t.Errorf("expected 'type Viewer_Locale_CurrencyResponse', got:\n%s", sdl)
 	}
 }
 
@@ -837,11 +844,11 @@ func TestGenerator_Phase2_NestedArray(t *testing.T) {
 	}
 
 	sdl := string(out)
-	if !strings.Contains(sdl, "posts: [GetUser_PostsResponse]") {
-		t.Errorf("expected 'posts: [GetUser_PostsResponse]', got:\n%s", sdl)
+	if !strings.Contains(sdl, "posts: [User_PostsResponse]") {
+		t.Errorf("expected 'posts: [User_PostsResponse]', got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type GetUser_PostsResponse {") {
-		t.Errorf("expected 'type GetUser_PostsResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type User_PostsResponse {") {
+		t.Errorf("expected 'type User_PostsResponse', got:\n%s", sdl)
 	}
 	if !strings.Contains(sdl, "title: String") {
 		t.Errorf("expected 'title: String' in nested array type, got:\n%s", sdl)
@@ -869,11 +876,11 @@ func TestGenerator_Phase2_NamedFragmentWithNesting(t *testing.T) {
 	}
 
 	sdl := string(out)
-	if !strings.Contains(sdl, "profile: GetUser_ProfileResponse") {
-		t.Errorf("expected 'profile: GetUser_ProfileResponse' from fragment, got:\n%s", sdl)
+	if !strings.Contains(sdl, "profile: User_ProfileResponse") {
+		t.Errorf("expected 'profile: User_ProfileResponse' from fragment, got:\n%s", sdl)
 	}
-	if !strings.Contains(sdl, "type GetUser_ProfileResponse {") {
-		t.Errorf("expected 'type GetUser_ProfileResponse', got:\n%s", sdl)
+	if !strings.Contains(sdl, "type User_ProfileResponse {") {
+		t.Errorf("expected 'type User_ProfileResponse', got:\n%s", sdl)
 	}
 	if !strings.Contains(sdl, "bio: String") {
 		t.Errorf("expected 'bio: String' in nested type from fragment, got:\n%s", sdl)
@@ -912,7 +919,7 @@ func TestGenerator_Phase2_TypenameFiltered(t *testing.T) {
 	}
 }
 
-func TestGenerator_Phase2_DisambiguationWithNesting(t *testing.T) {
+func TestGenerator_Phase2_MergedFieldsWithNesting(t *testing.T) {
 	g := &Generator{}
 	endpoints := []classify.ClassifiedRequest{
 		{
@@ -944,34 +951,80 @@ func TestGenerator_Phase2_DisambiguationWithNesting(t *testing.T) {
 
 	sdl := string(out)
 
-	// First op keeps bare "viewer" field, nested types use op name "StoredPassengers"
-	if !strings.Contains(sdl, "passengers: [StoredPassengers_PassengersResponse]") {
-		t.Errorf("expected 'passengers: [StoredPassengers_PassengersResponse]', got:\n%s", sdl)
-	}
-	if !strings.Contains(sdl, "type StoredPassengers_PassengersResponse {") {
-		t.Errorf("expected 'type StoredPassengers_PassengersResponse', got:\n%s", sdl)
+	// Should have a single "viewer" field (merged, not disambiguated)
+	if strings.Contains(sdl, "viewer_FareLocksTabQuery") {
+		t.Errorf("should not have disambiguated field — operations should be merged, got:\n%s", sdl)
 	}
 
-	// Second op gets disambiguated field "viewer_FareLocksTabQuery", nested types use op name "FareLocksTabQuery"
-	if !strings.Contains(sdl, "viewer_FareLocksTabQuery") {
-		t.Errorf("expected disambiguated field 'viewer_FareLocksTabQuery', got:\n%s", sdl)
-	}
-	if !strings.Contains(sdl, "fareLocks: [FareLocksTabQuery_FareLocksResponse]") {
-		t.Errorf("expected 'fareLocks: [FareLocksTabQuery_FareLocksResponse]', got:\n%s", sdl)
-	}
-	if !strings.Contains(sdl, "type FareLocksTabQuery_FareLocksResponse {") {
-		t.Errorf("expected 'type FareLocksTabQuery_FareLocksResponse', got:\n%s", sdl)
+	// Merged ViewerResponse should contain fields from both operations
+	if !strings.Contains(sdl, "type ViewerResponse {") {
+		t.Errorf("expected 'type ViewerResponse', got:\n%s", sdl)
 	}
 
-	// Assert no cascading rename — no type name should exceed 100 characters
-	for _, line := range strings.Split(sdl, "\n") {
-		if strings.HasPrefix(line, "type ") {
-			typeName := strings.TrimPrefix(line, "type ")
-			typeName = strings.TrimSuffix(typeName, " {")
-			if len(typeName) > 100 {
-				t.Errorf("type name too long (%d chars): %s", len(typeName), typeName)
-			}
-		}
+	// Both nested types should use Viewer_ prefix (field-name based)
+	if !strings.Contains(sdl, "passengers: [Viewer_PassengersResponse]") {
+		t.Errorf("expected 'passengers: [Viewer_PassengersResponse]', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type Viewer_PassengersResponse {") {
+		t.Errorf("expected 'type Viewer_PassengersResponse', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "fareLocks: [Viewer_FareLocksResponse]") {
+		t.Errorf("expected 'fareLocks: [Viewer_FareLocksResponse]', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type Viewer_FareLocksResponse {") {
+		t.Errorf("expected 'type Viewer_FareLocksResponse', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_MergedArgs(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query SearchA($term: String!) { search(term: $term) { id } }","variables":{"term":"hello"}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"search":{"id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query SearchB($term: String!, $limit: Int) { search(term: $term, limit: $limit) { id title } }","variables":{"term":"world","limit":10}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"search":{"id":"2","title":"Result"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+
+	// Should have a single "search" field with merged args from both operations
+	if !strings.Contains(sdl, "term: String!") {
+		t.Errorf("expected 'term: String!' from first operation, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "limit: Int") {
+		t.Errorf("expected 'limit: Int' from second operation, got:\n%s", sdl)
+	}
+	// Should NOT have disambiguated fields
+	if strings.Contains(sdl, "search_SearchB") {
+		t.Errorf("should not have disambiguated field — operations should be merged, got:\n%s", sdl)
+	}
+	// Merged response should contain fields from both operations
+	if !strings.Contains(sdl, "id: String") {
+		t.Errorf("expected 'id: String' in merged response, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "title: String") {
+		t.Errorf("expected 'title: String' from second operation in merged response, got:\n%s", sdl)
 	}
 }
 

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -1235,3 +1235,296 @@ func TestGenerator_Phase2_InputTypeNullVariableSkipped(t *testing.T) {
 		t.Errorf("should not generate input type for null variable, got:\n%s", sdl)
 	}
 }
+
+func TestGenerator_Phase2_ScalarReturnType(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query { systemHealth }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"systemHealth":"OK"}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query { deleteAllPastes }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"deleteAllPastes":true}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Scalar string return should use String directly, not SystemHealthResponse
+	if !strings.Contains(sdl, "systemHealth: String") {
+		t.Errorf("expected 'systemHealth: String' (scalar return), got:\n%s", sdl)
+	}
+	if strings.Contains(sdl, "SystemHealthResponse") {
+		t.Errorf("should not create SystemHealthResponse for scalar return, got:\n%s", sdl)
+	}
+	// Scalar boolean return
+	if !strings.Contains(sdl, "deleteAllPastes: Boolean") {
+		t.Errorf("expected 'deleteAllPastes: Boolean' (scalar return), got:\n%s", sdl)
+	}
+	if strings.Contains(sdl, "DeleteAllPastesResponse") {
+		t.Errorf("should not create DeleteAllPastesResponse for scalar return, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_InlineLiteralArgTypes(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"{ paste(id: 1) { title } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"paste":{"title":"Hello"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"{ pastes(public: true, limit: 10) { title } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"pastes":[{"title":"Hello"}]}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Inline int literal should be inferred as Int
+	if !strings.Contains(sdl, "id: Int") {
+		t.Errorf("expected 'id: Int' from inline literal, got:\n%s", sdl)
+	}
+	// Inline boolean literal
+	if !strings.Contains(sdl, "public: Boolean") {
+		t.Errorf("expected 'public: Boolean' from inline literal, got:\n%s", sdl)
+	}
+	// Inline int literal
+	if !strings.Contains(sdl, "limit: Int") {
+		t.Errorf("expected 'limit: Int' from inline literal, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_InlineObjectLiteralInputType(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation { createUser(userData: {username: \"test\", email: \"test@test.com\", password: \"pass\"}) { id } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"createUser":{"id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Should create an input type from the inline object literal
+	if !strings.Contains(sdl, "userData: UserDataInput") {
+		t.Errorf("expected 'userData: UserDataInput' from inline object, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "input UserDataInput {") {
+		t.Errorf("expected 'input UserDataInput' type definition, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "username: String") {
+		t.Errorf("expected 'username: String' in input type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "email: String") {
+		t.Errorf("expected 'email: String' in input type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "password: String") {
+		t.Errorf("expected 'password: String' in input type, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_NullResponseFallbackToSelectionTree(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query { paste(id: 1) { id title content public } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"paste":null}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Even with null response, should generate type from selection tree
+	if !strings.Contains(sdl, "type PasteResponse {") {
+		t.Errorf("expected 'type PasteResponse' even with null response, got:\n%s", sdl)
+	}
+	// Fields should default to String when response is null
+	if !strings.Contains(sdl, "id: String") {
+		t.Errorf("expected 'id: String' fallback field, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "title: String") {
+		t.Errorf("expected 'title: String' fallback field, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "content: String") {
+		t.Errorf("expected 'content: String' fallback field, got:\n%s", sdl)
+	}
+	// Arg type from inline literal
+	if !strings.Contains(sdl, "id: Int") {
+		t.Errorf("expected 'id: Int' arg from inline literal, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_UnionTypeFromInlineFragments(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query { search(keyword: \"test\") { ... on PasteObject { id title content } ... on UserObject { id username password } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"search":[{"id":"1","title":"Test","content":"Hello"},{"id":"2","username":"admin","password":"secret"}]}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Should create a union type
+	if !strings.Contains(sdl, "union SearchResult = PasteObject | UserObject") {
+		t.Errorf("expected union declaration, got:\n%s", sdl)
+	}
+	// Return type should reference the union
+	if !strings.Contains(sdl, "search(keyword: String): [SearchResult]") {
+		t.Errorf("expected 'search(...): [SearchResult]', got:\n%s", sdl)
+	}
+	// Separate types for each fragment member
+	if !strings.Contains(sdl, "type PasteObject {") {
+		t.Errorf("expected 'type PasteObject', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "type UserObject {") {
+		t.Errorf("expected 'type UserObject', got:\n%s", sdl)
+	}
+	// PasteObject should have its own fields
+	if !strings.Contains(sdl, "title: String") {
+		t.Errorf("expected 'title: String' in PasteObject, got:\n%s", sdl)
+	}
+	// UserObject should have its own fields
+	if !strings.Contains(sdl, "username: String") {
+		t.Errorf("expected 'username: String' in UserObject, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_MergePreferSpecificTypes(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		// Anonymous operation with inline literals (will infer String for all)
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"{ pastes(public: true, limit: 10) { id title } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"pastes":[{"id":"1","title":"Hello"}]}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		// Named operation with typed variable declarations
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetPastes($public: Boolean, $limit: Int) { pastes(public: $public, limit: $limit) { id title } }","variables":{"public":true,"limit":10}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"pastes":[{"id":"1","title":"Hello"}]}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// The merge should prefer Boolean over the inline-inferred type
+	if !strings.Contains(sdl, "public: Boolean") {
+		t.Errorf("expected 'public: Boolean' after merge (specific over String), got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "limit: Int") {
+		t.Errorf("expected 'limit: Int' after merge (specific over String), got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_ErrorResponseFallbackToSelectionTree(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query { me(token: \"invalid\") { id username } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"errors":[{"message":"Unauthorized"}]}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Even with error response, should generate type from selection tree
+	if !strings.Contains(sdl, "type MeResponse {") {
+		t.Errorf("expected 'type MeResponse' even with error response, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "id: String") {
+		t.Errorf("expected 'id: String' fallback field, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "username: String") {
+		t.Errorf("expected 'username: String' fallback field, got:\n%s", sdl)
+	}
+}

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -1528,3 +1528,170 @@ func TestGenerator_Phase2_ErrorResponseFallbackToSelectionTree(t *testing.T) {
 		t.Errorf("expected 'username: String' fallback field, got:\n%s", sdl)
 	}
 }
+
+func TestGenerator_Phase2_CrossTypeFieldTypePropagation(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		// pastes returns real data with correct types
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query { pastes { id title content burn public ownerId } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"pastes":[{"id":"1","title":"Test","content":"Hello","burn":false,"public":true,"ownerId":1}]}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		// paste returns null — all fields default to String
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query { paste(id: 1) { id title content burn public ownerId } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"paste":null}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// PasteResponse (from null response) should have types propagated from PastesResponse
+	if !strings.Contains(sdl, "type PasteResponse {") {
+		t.Errorf("expected 'type PasteResponse', got:\n%s", sdl)
+	}
+
+	// Check PasteResponse has propagated types, not all-String
+	// Extract PasteResponse block
+	pasteRespIdx := strings.Index(sdl, "type PasteResponse {")
+	if pasteRespIdx < 0 {
+		t.Fatal("PasteResponse not found in output")
+	}
+	pasteRespEnd := strings.Index(sdl[pasteRespIdx:], "}\n")
+	pasteRespBlock := sdl[pasteRespIdx : pasteRespIdx+pasteRespEnd+2]
+
+	if !strings.Contains(pasteRespBlock, "burn: Boolean") {
+		t.Errorf("expected 'burn: Boolean' in PasteResponse (propagated), got:\n%s", pasteRespBlock)
+	}
+	if !strings.Contains(pasteRespBlock, "public: Boolean") {
+		t.Errorf("expected 'public: Boolean' in PasteResponse (propagated), got:\n%s", pasteRespBlock)
+	}
+	if !strings.Contains(pasteRespBlock, "ownerId: Int") {
+		t.Errorf("expected 'ownerId: Int' in PasteResponse (propagated), got:\n%s", pasteRespBlock)
+	}
+}
+
+func TestGenerator_Phase2_CrossTypePropagationSafety(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		// deletePaste has result: Boolean (only 1 field — too few to group)
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation { deletePaste(id: 1) { result } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"deletePaste":{"result":true}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		// importPaste has result: String (only 1 field — should NOT be changed to Boolean)
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation { importPaste(url: \"http://example.com\") { result } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"importPaste":{"result":"success"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+
+	// ImportPasteResponse should keep result: String (not cross-pollinated from DeletePasteResponse)
+	importIdx := strings.Index(sdl, "type ImportPasteResponse {")
+	if importIdx < 0 {
+		t.Fatal("ImportPasteResponse not found in output")
+	}
+	importEnd := strings.Index(sdl[importIdx:], "}\n")
+	importBlock := sdl[importIdx : importIdx+importEnd+2]
+
+	if !strings.Contains(importBlock, "result: String") {
+		t.Errorf("expected 'result: String' in ImportPasteResponse (NOT propagated), got:\n%s", importBlock)
+	}
+}
+
+func TestUnifyStructuralFieldTypes_Unit(t *testing.T) {
+	// Type A has real data: burn=Boolean, public=Boolean, ownerId=Int
+	// Type B has null fallback: burn=String, public=String, ownerId=String
+	// Both share 6 scalar fields with identical names → should unify
+	typeA := &inferredType{
+		Name: "TypeA",
+		Fields: map[string]string{
+			"id":      "String",
+			"title":   "String",
+			"content": "String",
+			"burn":    "Boolean",
+			"public":  "Boolean",
+			"ownerId": "Int",
+		},
+	}
+	typeB := &inferredType{
+		Name: "TypeB",
+		Fields: map[string]string{
+			"id":      "String",
+			"title":   "String",
+			"content": "String",
+			"burn":    "String",
+			"public":  "String",
+			"ownerId": "String",
+		},
+	}
+	// Type C is unrelated (only 1 shared field)
+	typeC := &inferredType{
+		Name: "TypeC",
+		Fields: map[string]string{
+			"result": "Boolean",
+		},
+	}
+
+	types := map[string]*inferredType{
+		"TypeA": typeA,
+		"TypeB": typeB,
+		"TypeC": typeC,
+	}
+
+	unifyStructuralFieldTypes(types)
+
+	// TypeB should have propagated types from TypeA
+	if types["TypeB"].Fields["burn"] != "Boolean" {
+		t.Errorf("expected TypeB.burn = Boolean, got %s", types["TypeB"].Fields["burn"])
+	}
+	if types["TypeB"].Fields["public"] != "Boolean" {
+		t.Errorf("expected TypeB.public = Boolean, got %s", types["TypeB"].Fields["public"])
+	}
+	if types["TypeB"].Fields["ownerId"] != "Int" {
+		t.Errorf("expected TypeB.ownerId = Int, got %s", types["TypeB"].Fields["ownerId"])
+	}
+	// TypeC should be unchanged
+	if types["TypeC"].Fields["result"] != "Boolean" {
+		t.Errorf("expected TypeC.result = Boolean (unchanged), got %s", types["TypeC"].Fields["result"])
+	}
+	// TypeA should be unchanged
+	if types["TypeA"].Fields["burn"] != "Boolean" {
+		t.Errorf("expected TypeA.burn = Boolean (unchanged), got %s", types["TypeA"].Fields["burn"])
+	}
+}

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -974,3 +974,211 @@ func TestGenerator_Phase2_DisambiguationWithNesting(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerator_Phase2_InputTypeScalarFields(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation CreateEvent($input: NewEventsInput!) { createEvent(input: $input) { id } }","variables":{"input":{"title":"Conference","count":5,"active":true,"rating":4.5}}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"createEvent":{"id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "input NewEventsInput {") {
+		t.Errorf("expected 'input NewEventsInput', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "title: String") {
+		t.Errorf("expected 'title: String' in input type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "count: Int") {
+		t.Errorf("expected 'count: Int' in input type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "active: Boolean") {
+		t.Errorf("expected 'active: Boolean' in input type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "rating: Float") {
+		t.Errorf("expected 'rating: Float' in input type, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_InputTypeNestedObjects(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation UpdateIdentity($input: UpdateIdentityInput!) { updateIdentity(input: $input) { id } }","variables":{"input":{"name":"Alice","address":{"street":"123 Main St","city":"Springfield"}}}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"updateIdentity":{"id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "input UpdateIdentityInput {") {
+		t.Errorf("expected 'input UpdateIdentityInput', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "name: String") {
+		t.Errorf("expected 'name: String' in input type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "address: UpdateIdentityInput_Address") {
+		t.Errorf("expected 'address: UpdateIdentityInput_Address' in input type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "input UpdateIdentityInput_Address {") {
+		t.Errorf("expected nested 'input UpdateIdentityInput_Address', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "street: String") {
+		t.Errorf("expected 'street: String' in nested input type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "city: String") {
+		t.Errorf("expected 'city: String' in nested input type, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_InputTypeArrayOfObjects(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation AddItems($items: [ItemInput!]!) { addItems(items: $items) { count } }","variables":{"items":[{"name":"Widget","qty":3},{"name":"Gadget","qty":1}]}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"addItems":{"count":2}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "input ItemInput {") {
+		t.Errorf("expected 'input ItemInput', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "name: String") {
+		t.Errorf("expected 'name: String' in input type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "qty: Int") {
+		t.Errorf("expected 'qty: Int' in input type, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_InputTypeMergeAcrossOperations(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation CreateA($input: SharedInput!) { createA(input: $input) { id } }","variables":{"input":{"name":"Alice"}}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"createA":{"id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation CreateB($input: SharedInput!) { createB(input: $input) { id } }","variables":{"input":{"name":"Bob","email":"bob@example.com"}}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"createB":{"id":"2"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "input SharedInput {") {
+		t.Errorf("expected 'input SharedInput', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "name: String") {
+		t.Errorf("expected 'name: String' in merged input type, got:\n%s", sdl)
+	}
+	// Second op adds "email" field — should be merged in
+	if !strings.Contains(sdl, "email: String") {
+		t.Errorf("expected 'email: String' from second op merged into SharedInput, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_InputTypeCustomScalarSkipped(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation UploadFile($file: Upload!) { uploadFile(file: $file) { id } }","variables":{"file":null}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"uploadFile":{"id":"42"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Upload variable is null — should NOT generate an input type for it
+	if strings.Contains(sdl, "input Upload {") {
+		t.Errorf("should not generate input type for custom scalar Upload, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_InputTypeNullVariableSkipped(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation Update($input: UpdateInput!) { update(input: $input) { id } }","variables":{"input":null}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"update":{"id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Null variable value — should NOT generate an input type
+	if strings.Contains(sdl, "input UpdateInput {") {
+		t.Errorf("should not generate input type for null variable, got:\n%s", sdl)
+	}
+}

--- a/pkg/generate/graphql/sdl_test.go
+++ b/pkg/generate/graphql/sdl_test.go
@@ -1695,3 +1695,250 @@ func TestUnifyStructuralFieldTypes_Unit(t *testing.T) {
 		t.Errorf("expected TypeA.burn = Boolean (unchanged), got %s", types["TypeA"].Fields["burn"])
 	}
 }
+
+func TestGenerator_Phase2_MultiRootQuery(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query SettingsTabQuery { availableCountries { id name } viewer { email billingAddresses { street } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"availableCountries":[{"id":"US","name":"United States"}],"viewer":{"email":"test@example.com","billingAddresses":[{"street":"123 Main St"}]}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Both root fields should be present
+	if !strings.Contains(sdl, "availableCountries") {
+		t.Errorf("expected 'availableCountries' root field from multi-root query, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "viewer") {
+		t.Errorf("expected 'viewer' root field from multi-root query, got:\n%s", sdl)
+	}
+	// The viewer type should have email and billingAddresses
+	if !strings.Contains(sdl, "email: String") {
+		t.Errorf("expected 'email: String' in viewer type, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "billingAddresses") {
+		t.Errorf("expected 'billingAddresses' in viewer type, got:\n%s", sdl)
+	}
+	// availableCountries should be a list
+	if !strings.Contains(sdl, "[AvailableCountriesResponse]") {
+		t.Errorf("expected '[AvailableCountriesResponse]' list return type, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_NoVariableFallbackToArgs(t *testing.T) {
+	g := &Generator{}
+	// Query with variables but root field has NO arguments — variables are used by nested fields only
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query GetViewer($currencyId: String!, $market: String!) { viewer { referFriendPromoValues(currencyId: $currencyId, market: $market) { amount } } }","variables":{"currencyId":"USD","market":"US"}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"referFriendPromoValues":{"amount":10}}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// viewer should NOT have currencyId or market as arguments
+	if strings.Contains(sdl, "viewer(") {
+		t.Errorf("viewer should have no arguments — variables belong to nested fields, got:\n%s", sdl)
+	}
+	// But the nested field should have the arguments
+	if !strings.Contains(sdl, "referFriendPromoValues(") {
+		t.Errorf("expected 'referFriendPromoValues' to have arguments, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "currencyId: String!") {
+		t.Errorf("expected 'currencyId: String!' on nested field, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "market: String!") {
+		t.Errorf("expected 'market: String!' on nested field, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_UnionMemberMergingAcrossOps(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		// First operation: viewer with ... on User and ... on Node
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Op1 { viewer { ... on User { name } ... on Node { id } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"name":"Alice","id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		// Second operation: viewer with ... on User and ... on Unauthorized
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Op2 { viewer { ... on User { email } ... on Unauthorized { reason } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"email":"alice@example.com"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Union should contain all three members from both operations
+	if !strings.Contains(sdl, "union ViewerResult") {
+		t.Errorf("expected 'union ViewerResult', got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "User") {
+		t.Errorf("expected 'User' in union, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "Node") {
+		t.Errorf("expected 'Node' in union, got:\n%s", sdl)
+	}
+	if !strings.Contains(sdl, "Unauthorized") {
+		t.Errorf("expected 'Unauthorized' in union, got:\n%s", sdl)
+	}
+	// Should NOT have a separate "type ViewerResult" — only the union
+	viewerResultTypeCount := strings.Count(sdl, "type ViewerResult")
+	if viewerResultTypeCount > 0 {
+		t.Errorf("should not have 'type ViewerResult' — only union, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_TypeUnionCollisionResolved(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		// Operation that triggers union path (inline fragments only)
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Op1 { viewer { ... on User { name } ... on Node { id } } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"name":"Alice","id":"1"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+		// Operation that triggers regular type path (direct fields)
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"query Op2 { viewer { email locale } }","variables":{}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"viewer":{"email":"alice@example.com","locale":"en-US"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Should have union ViewerResult (not both type and union)
+	if !strings.Contains(sdl, "union ViewerResult") {
+		t.Errorf("expected 'union ViewerResult', got:\n%s", sdl)
+	}
+	// Should NOT have both "type ViewerResult" and "union ViewerResult"
+	if strings.Contains(sdl, "type ViewerResult") {
+		t.Errorf("should not have 'type ViewerResult' when union exists, got:\n%s", sdl)
+	}
+	// Should NOT have empty ViewerResponse type
+	if strings.Contains(sdl, "type ViewerResponse {") {
+		t.Errorf("should not have empty 'type ViewerResponse' — should be merged/removed, got:\n%s", sdl)
+	}
+	// Fields from the direct-fields operation should be merged into the first union member
+	if !strings.Contains(sdl, "type User {") {
+		t.Errorf("expected 'type User', got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_EmptyReturnTypeStillDefined(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:  "http://example.com/graphql",
+				Body: []byte(`{"query":"mutation UpdateLocale($input: UpdateLocaleInput!) { updateLocale(input: $input) { __typename } }","variables":{"input":{"locale":"en"}}}`),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"updateLocale":{"__typename":"UpdateLocalePayload"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	// Even though only __typename was returned, the return type should be defined
+	if !strings.Contains(sdl, "type UpdateLocaleResponse {") {
+		t.Errorf("expected 'type UpdateLocaleResponse' even with only __typename fields, got:\n%s", sdl)
+	}
+	// The mutation should reference it
+	if !strings.Contains(sdl, "updateLocale(input: UpdateLocaleInput!): UpdateLocaleResponse") {
+		t.Errorf("expected mutation to reference UpdateLocaleResponse, got:\n%s", sdl)
+	}
+}
+
+func TestGenerator_Phase2_UploadScalarDeclared(t *testing.T) {
+	g := &Generator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				URL:     "http://example.com/graphql",
+				Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=----WebKitFormBoundary"},
+				Body: []byte("------WebKitFormBoundary\r\n" +
+					"Content-Disposition: form-data; name=\"operations\"\r\n\r\n" +
+					`{"query":"mutation Upload($file: Upload!) { uploadProfilePicture(file: $file) { url } }","variables":{"file":null}}` + "\r\n" +
+					"------WebKitFormBoundary\r\n" +
+					"Content-Disposition: form-data; name=\"map\"\r\n\r\n" +
+					`{"0":["variables.file"]}` + "\r\n" +
+					"------WebKitFormBoundary--\r\n"),
+				Response: crawl.ObservedResponse{
+					Body: []byte(`{"data":{"uploadProfilePicture":{"url":"https://example.com/pic.jpg"}}}`),
+				},
+			},
+			APIType: "graphql",
+		},
+	}
+
+	out, err := g.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	sdl := string(out)
+	if !strings.Contains(sdl, "scalar Upload") {
+		t.Errorf("expected 'scalar Upload' declaration, got:\n%s", sdl)
+	}
+}

--- a/pkg/generate/registry.go
+++ b/pkg/generate/registry.go
@@ -17,6 +17,7 @@ package generate
 import (
 	"fmt"
 
+	"github.com/praetorian-inc/vespasian/pkg/generate/graphql"
 	"github.com/praetorian-inc/vespasian/pkg/generate/rest"
 	"github.com/praetorian-inc/vespasian/pkg/generate/wsdl"
 )
@@ -28,7 +29,9 @@ func Get(apiType string) (SpecGenerator, error) {
 		return &rest.OpenAPIGenerator{}, nil
 	case "wsdl":
 		return &wsdl.Generator{}, nil
+	case "graphql":
+		return &graphql.Generator{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported API type: %q (supported: rest, wsdl)", apiType)
+		return nil, fmt.Errorf("unsupported API type: %q (supported: rest, wsdl, graphql)", apiType)
 	}
 }

--- a/pkg/generate/registry_test.go
+++ b/pkg/generate/registry_test.go
@@ -28,7 +28,7 @@ func TestGet(t *testing.T) {
 		errContain string
 	}{
 		{"rest", "rest", "rest", false, ""},
-		{"unsupported graphql", "graphql", "", true, "unsupported API type"},
+		{"graphql", "graphql", "graphql", false, ""},
 		{"empty", "", "", true, "unsupported API type"},
 	}
 

--- a/pkg/probe/graphql.go
+++ b/pkg/probe/graphql.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+)
+
+// maxIntrospectionBodySize limits the response body read for GraphQL introspection.
+const maxIntrospectionBodySize = 5 << 20 // 5 MB
+
+// introspectionQuery is the GraphQL introspection query sent to discovered endpoints.
+const introspectionQuery = `{"query":"{ __schema { types { name kind fields { name type { name kind ofType { name } } } } } }"}`
+
+// GraphQLProbe sends an introspection query to discovered GraphQL endpoints
+// and parses the response into a structured schema representation.
+type GraphQLProbe struct {
+	config Config
+}
+
+// NewGraphQLProbe creates a GraphQLProbe with the given configuration.
+func NewGraphQLProbe(cfg Config) *GraphQLProbe {
+	return &GraphQLProbe{config: cfg.withDefaults()}
+}
+
+// Name returns the probe name.
+func (p *GraphQLProbe) Name() string {
+	return "graphql"
+}
+
+// Probe sends introspection queries to GraphQL endpoints and enriches them
+// with schema information. Only endpoints with APIType=="graphql" are probed.
+// Endpoints are deduplicated by URL to avoid redundant requests.
+func (p *GraphQLProbe) Probe(ctx context.Context, endpoints []classify.ClassifiedRequest) ([]classify.ClassifiedRequest, error) {
+	// Deduplicate: probe each unique URL once
+	schemas := make(map[string]*classify.GraphQLIntrospection)
+	seen := make(map[string]bool)
+
+	for _, ep := range endpoints {
+		if ep.APIType != "graphql" {
+			continue
+		}
+
+		if seen[ep.URL] {
+			continue
+		}
+		if len(seen) >= p.config.MaxEndpoints {
+			break
+		}
+		seen[ep.URL] = true
+
+		result := p.probeEndpoint(ctx, ep.URL)
+		if result != nil {
+			schemas[ep.URL] = result
+		}
+	}
+
+	// Copy endpoints to avoid mutating the caller's slice
+	result := make([]classify.ClassifiedRequest, len(endpoints))
+	copy(result, endpoints)
+
+	for i := range result {
+		if result[i].APIType != "graphql" {
+			continue
+		}
+		if schema, ok := schemas[result[i].URL]; ok {
+			result[i].GraphQLSchema = schema
+		}
+	}
+
+	return result, nil
+}
+
+// probeEndpoint sends an introspection query to the given URL and parses the response.
+func (p *GraphQLProbe) probeEndpoint(ctx context.Context, targetURL string) *classify.GraphQLIntrospection {
+	if err := p.config.URLValidator(targetURL); err != nil {
+		slog.DebugContext(ctx, "graphql probe: URL validation failed", "url", targetURL, "error", err)
+		return nil
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, p.config.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, targetURL, bytes.NewReader([]byte(introspectionQuery)))
+	if err != nil {
+		return nil
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range p.config.AuthHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := p.config.Client.Do(req)
+	if err != nil {
+		slog.DebugContext(ctx, "graphql probe: request failed", "url", targetURL, "error", err)
+		return nil
+	}
+	defer func() {
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck // best-effort drain
+		resp.Body.Close()                                     //nolint:errcheck // best-effort close
+	}()
+
+	if resp.StatusCode >= 400 {
+		slog.DebugContext(ctx, "graphql probe: non-success status", "url", targetURL, "status", resp.StatusCode)
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxIntrospectionBodySize))
+	if err != nil {
+		return nil
+	}
+
+	return parseIntrospectionResponse(body)
+}
+
+// parseIntrospectionResponse parses a GraphQL introspection JSON response.
+func parseIntrospectionResponse(body []byte) *classify.GraphQLIntrospection {
+	var envelope struct {
+		Data struct {
+			Schema struct {
+				Types []struct {
+					Name   string `json:"name"`
+					Kind   string `json:"kind"`
+					Fields []struct {
+						Name string `json:"name"`
+						Type struct {
+							Name   *string `json:"name"`
+							Kind   string  `json:"kind"`
+							OfType *struct {
+								Name *string `json:"name"`
+							} `json:"ofType"`
+						} `json:"type"`
+					} `json:"fields"`
+				} `json:"types"`
+			} `json:"__schema"`
+		} `json:"data"`
+		Errors []interface{} `json:"errors"`
+	}
+
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return &classify.GraphQLIntrospection{IntrospectionEnabled: false}
+	}
+
+	// If errors are present and no types, introspection is disabled
+	if len(envelope.Errors) > 0 && len(envelope.Data.Schema.Types) == 0 {
+		return &classify.GraphQLIntrospection{IntrospectionEnabled: false}
+	}
+
+	if len(envelope.Data.Schema.Types) == 0 {
+		return &classify.GraphQLIntrospection{IntrospectionEnabled: false}
+	}
+
+	types := make([]classify.GraphQLType, 0, len(envelope.Data.Schema.Types))
+	for _, t := range envelope.Data.Schema.Types {
+		gt := classify.GraphQLType{
+			Name: t.Name,
+			Kind: t.Kind,
+		}
+		for _, f := range t.Fields {
+			gf := classify.GraphQLField{
+				Name: f.Name,
+				Type: classify.GraphQLTypeRef{
+					Name: f.Type.Name,
+					Kind: f.Type.Kind,
+				},
+			}
+			if f.Type.OfType != nil {
+				gf.Type.OfType = &classify.GraphQLTypeRef{
+					Name: f.Type.OfType.Name,
+				}
+			}
+			gt.Fields = append(gt.Fields, gf)
+		}
+		types = append(types, gt)
+	}
+
+	return &classify.GraphQLIntrospection{
+		IntrospectionEnabled: true,
+		Types:                types,
+		RawResponse:          body,
+	}
+}

--- a/pkg/probe/graphql.go
+++ b/pkg/probe/graphql.go
@@ -29,7 +29,8 @@ import (
 const maxIntrospectionBodySize = 5 << 20 // 5 MB
 
 // introspectionQuery is the GraphQL introspection query sent to discovered endpoints.
-const introspectionQuery = `{"query":"{ __schema { types { name kind fields { name type { name kind ofType { name } } } } } }"}`
+// The ofType fragment recurses 7 levels deep to handle deeply nested wrappers like [User!]!.
+const introspectionQuery = `{"query":"{ __schema { types { name kind fields { name type { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } } } } } } } }"}`
 
 // GraphQLProbe sends an introspection query to discovered GraphQL endpoints
 // and parses the response into a structured schema representation.
@@ -142,14 +143,8 @@ func parseIntrospectionResponse(body []byte) *classify.GraphQLIntrospection {
 					Name   string `json:"name"`
 					Kind   string `json:"kind"`
 					Fields []struct {
-						Name string `json:"name"`
-						Type struct {
-							Name   *string `json:"name"`
-							Kind   string  `json:"kind"`
-							OfType *struct {
-								Name *string `json:"name"`
-							} `json:"ofType"`
-						} `json:"type"`
+						Name string          `json:"name"`
+						Type json.RawMessage `json:"type"`
 					} `json:"fields"`
 				} `json:"types"`
 			} `json:"__schema"`
@@ -177,17 +172,13 @@ func parseIntrospectionResponse(body []byte) *classify.GraphQLIntrospection {
 			Kind: t.Kind,
 		}
 		for _, f := range t.Fields {
+			var typeRef classify.GraphQLTypeRef
+			if err := json.Unmarshal(f.Type, &typeRef); err != nil {
+				continue
+			}
 			gf := classify.GraphQLField{
 				Name: f.Name,
-				Type: classify.GraphQLTypeRef{
-					Name: f.Type.Name,
-					Kind: f.Type.Kind,
-				},
-			}
-			if f.Type.OfType != nil {
-				gf.Type.OfType = &classify.GraphQLTypeRef{
-					Name: f.Type.OfType.Name,
-				}
+				Type: typeRef,
 			}
 			gt.Fields = append(gt.Fields, gf)
 		}

--- a/pkg/probe/graphql.go
+++ b/pkg/probe/graphql.go
@@ -116,8 +116,8 @@ func (p *GraphQLProbe) probeEndpoint(ctx context.Context, targetURL string) *cla
 		return nil
 	}
 	defer func() {
-		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck // best-effort drain
-		resp.Body.Close()                                     //nolint:errcheck // best-effort close
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
+		resp.Body.Close()                                    //nolint:errcheck,gosec // best-effort close
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/pkg/probe/graphql.go
+++ b/pkg/probe/graphql.go
@@ -28,9 +28,157 @@ import (
 // maxIntrospectionBodySize limits the response body read for GraphQL introspection.
 const maxIntrospectionBodySize = 5 << 20 // 5 MB
 
-// introspectionQuery is the GraphQL introspection query sent to discovered endpoints.
-// The ofType fragment recurses 7 levels deep to handle deeply nested wrappers like [User!]!.
-const introspectionQuery = `{"query":"{ __schema { types { name kind fields { name type { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } } } } } } } }"}`
+// Tiered introspection queries, tried in order from most complete to least.
+// Some servers reject large introspection queries via WAFs or custom validation,
+// so we fall back to progressively simpler queries.
+
+// introspectionQueryTier1 is the canonical full introspection query matching
+// graphql-js getIntrospectionQuery(). Includes descriptions, deprecation info,
+// directives, and 9-level TypeRef depth.
+var introspectionQueryTier1 = mustMarshalQuery(`query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`)
+
+// introspectionQueryTier2 is a minimal-complete query. Strips descriptions,
+// deprecation, and directives but retains all structurally important fields
+// (args, inputFields, enumValues, interfaces, possibleTypes).
+var introspectionQueryTier2 = mustMarshalQuery(`{ __schema {
+  queryType { name }
+  mutationType { name }
+  subscriptionType { name }
+  types {
+    kind
+    name
+    fields(includeDeprecated: true) {
+      name
+      args { name type { ...TypeRef } }
+      type { ...TypeRef }
+    }
+    inputFields { name type { ...TypeRef } }
+    interfaces { ...TypeRef }
+    enumValues { name }
+    possibleTypes { ...TypeRef }
+  }
+}}
+
+fragment TypeRef on __Type {
+  kind name ofType { kind name ofType { kind name ofType { kind name
+  ofType { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } } }
+}`)
+
+// introspectionQueryTier3 is the minimal last-resort query. Smallest payload,
+// most likely to pass restrictive filters. Produces partial SDL (no args/enums/inputs)
+// but useful for type and field name discovery.
+const introspectionQueryTier3 = `{"query":"{ __schema { types { name kind fields { name type { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } } } } } } } }"}`
+
+// mustMarshalQuery wraps a GraphQL query string as a JSON {"query": "..."} body.
+// Panics if marshalling fails (only called with compile-time constants).
+func mustMarshalQuery(query string) string {
+	b, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		panic("failed to marshal introspection query: " + err.Error())
+	}
+	return string(b)
+}
+
+// introspectionQueries lists queries from most to least complete for tiered fallback.
+var introspectionQueries = []string{
+	introspectionQueryTier1,
+	introspectionQueryTier2,
+	introspectionQueryTier3,
+}
 
 // GraphQLProbe sends an introspection query to discovered GraphQL endpoints
 // and parses the response into a structured schema representation.
@@ -91,19 +239,42 @@ func (p *GraphQLProbe) Probe(ctx context.Context, endpoints []classify.Classifie
 	return result, nil
 }
 
-// probeEndpoint sends an introspection query to the given URL and parses the response.
+// probeEndpoint sends tiered introspection queries to the given URL.
+// It tries each tier in order, returning the first successful result.
+// If all tiers are rejected, returns IntrospectionEnabled: false so that
+// downstream code can distinguish "probed but disabled" from "not probed".
 func (p *GraphQLProbe) probeEndpoint(ctx context.Context, targetURL string) *classify.GraphQLIntrospection {
 	if err := p.config.URLValidator(targetURL); err != nil {
 		slog.DebugContext(ctx, "graphql probe: URL validation failed", "url", targetURL, "error", err)
 		return nil
 	}
 
+	var lastParsed *classify.GraphQLIntrospection
+	for tier, query := range introspectionQueries {
+		result, parsed := p.sendIntrospection(ctx, targetURL, query, tier+1)
+		if result != nil {
+			return result
+		}
+		if parsed != nil {
+			lastParsed = parsed
+		}
+	}
+
+	// All tiers were rejected — return the last parsed response (IntrospectionEnabled: false)
+	// so the caller can distinguish "probed but disabled" from "not probed at all".
+	return lastParsed
+}
+
+// sendIntrospection sends a single introspection query and parses the response.
+// Returns (result, parsed) where result is non-nil only on success (IntrospectionEnabled: true),
+// and parsed is the raw parse result (may have IntrospectionEnabled: false) for fallback tracking.
+func (p *GraphQLProbe) sendIntrospection(ctx context.Context, targetURL, query string, tier int) (result *classify.GraphQLIntrospection, parsed *classify.GraphQLIntrospection) {
 	reqCtx, cancel := context.WithTimeout(ctx, p.config.Timeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, targetURL, bytes.NewReader([]byte(introspectionQuery)))
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, targetURL, bytes.NewReader([]byte(query)))
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -113,25 +284,32 @@ func (p *GraphQLProbe) probeEndpoint(ctx context.Context, targetURL string) *cla
 
 	resp, err := p.config.Client.Do(req)
 	if err != nil {
-		slog.DebugContext(ctx, "graphql probe: request failed", "url", targetURL, "error", err)
-		return nil
+		slog.DebugContext(ctx, "graphql probe: request failed", "url", targetURL, "tier", tier, "error", err)
+		return nil, nil
 	}
 	defer func() {
 		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
-		resp.Body.Close()                                    //nolint:errcheck,gosec // best-effort close
+		resp.Body.Close()                                     //nolint:errcheck,gosec // best-effort close
 	}()
 
 	if resp.StatusCode >= 400 {
-		slog.DebugContext(ctx, "graphql probe: non-success status", "url", targetURL, "status", resp.StatusCode)
-		return nil
+		slog.DebugContext(ctx, "graphql probe: non-success status", "url", targetURL, "tier", tier, "status", resp.StatusCode)
+		return nil, nil
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxIntrospectionBodySize))
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
-	return parseIntrospectionResponse(body)
+	p2 := parseIntrospectionResponse(body)
+	if p2 == nil || !p2.IntrospectionEnabled {
+		slog.DebugContext(ctx, "graphql probe: tier rejected or empty", "url", targetURL, "tier", tier)
+		return nil, p2
+	}
+
+	slog.DebugContext(ctx, "graphql probe: introspection succeeded", "url", targetURL, "tier", tier, "types", len(p2.Types))
+	return p2, p2
 }
 
 // parseIntrospectionResponse parses a GraphQL introspection JSON response.
@@ -139,13 +317,30 @@ func parseIntrospectionResponse(body []byte) *classify.GraphQLIntrospection {
 	var envelope struct {
 		Data struct {
 			Schema struct {
-				Types []struct {
-					Name   string `json:"name"`
-					Kind   string `json:"kind"`
-					Fields []struct {
-						Name string          `json:"name"`
-						Type json.RawMessage `json:"type"`
+				QueryType        *struct{ Name string } `json:"queryType"`
+				MutationType     *struct{ Name string } `json:"mutationType"`
+				SubscriptionType *struct{ Name string } `json:"subscriptionType"`
+				Types            []struct {
+					Name        string `json:"name"`
+					Kind        string `json:"kind"`
+					Description string `json:"description"`
+					Fields      []struct {
+						Name              string              `json:"name"`
+						Description       string              `json:"description"`
+						Type              json.RawMessage     `json:"type"`
+						Args              []json.RawMessage   `json:"args"`
+						IsDeprecated      bool                `json:"isDeprecated"`
+						DeprecationReason string              `json:"deprecationReason"`
 					} `json:"fields"`
+					InputFields   []json.RawMessage `json:"inputFields"`
+					EnumValues    []struct {
+						Name              string `json:"name"`
+						Description       string `json:"description"`
+						IsDeprecated      bool   `json:"isDeprecated"`
+						DeprecationReason string `json:"deprecationReason"`
+					} `json:"enumValues"`
+					Interfaces    []json.RawMessage `json:"interfaces"`
+					PossibleTypes []json.RawMessage `json:"possibleTypes"`
 				} `json:"types"`
 			} `json:"__schema"`
 		} `json:"data"`
@@ -165,29 +360,113 @@ func parseIntrospectionResponse(body []byte) *classify.GraphQLIntrospection {
 		return &classify.GraphQLIntrospection{IntrospectionEnabled: false}
 	}
 
+	result := &classify.GraphQLIntrospection{
+		IntrospectionEnabled: true,
+		RawResponse:          body,
+	}
+
+	// Extract root type names
+	if envelope.Data.Schema.QueryType != nil {
+		result.QueryTypeName = envelope.Data.Schema.QueryType.Name
+	}
+	if envelope.Data.Schema.MutationType != nil {
+		result.MutationTypeName = envelope.Data.Schema.MutationType.Name
+	}
+	if envelope.Data.Schema.SubscriptionType != nil {
+		result.SubscriptionTypeName = envelope.Data.Schema.SubscriptionType.Name
+	}
+
 	types := make([]classify.GraphQLType, 0, len(envelope.Data.Schema.Types))
 	for _, t := range envelope.Data.Schema.Types {
 		gt := classify.GraphQLType{
-			Name: t.Name,
-			Kind: t.Kind,
+			Name:        t.Name,
+			Kind:        t.Kind,
+			Description: t.Description,
 		}
+
+		// Parse fields
 		for _, f := range t.Fields {
 			var typeRef classify.GraphQLTypeRef
 			if err := json.Unmarshal(f.Type, &typeRef); err != nil {
 				continue
 			}
 			gf := classify.GraphQLField{
-				Name: f.Name,
-				Type: typeRef,
+				Name:              f.Name,
+				Description:       f.Description,
+				Type:              typeRef,
+				IsDeprecated:      f.IsDeprecated,
+				DeprecationReason: f.DeprecationReason,
+			}
+			// Parse field args
+			for _, rawArg := range f.Args {
+				iv := parseInputValue(rawArg)
+				if iv != nil {
+					gf.Args = append(gf.Args, *iv)
+				}
 			}
 			gt.Fields = append(gt.Fields, gf)
 		}
+
+		// Parse inputFields
+		for _, rawIF := range t.InputFields {
+			iv := parseInputValue(rawIF)
+			if iv != nil {
+				gt.InputFields = append(gt.InputFields, *iv)
+			}
+		}
+
+		// Parse enumValues
+		for _, ev := range t.EnumValues {
+			gt.EnumValues = append(gt.EnumValues, classify.GraphQLEnumValue{
+				Name:              ev.Name,
+				Description:       ev.Description,
+				IsDeprecated:      ev.IsDeprecated,
+				DeprecationReason: ev.DeprecationReason,
+			})
+		}
+
+		// Parse interfaces
+		for _, rawIface := range t.Interfaces {
+			var ref classify.GraphQLTypeRef
+			if err := json.Unmarshal(rawIface, &ref); err == nil {
+				gt.Interfaces = append(gt.Interfaces, ref)
+			}
+		}
+
+		// Parse possibleTypes
+		for _, rawPT := range t.PossibleTypes {
+			var ref classify.GraphQLTypeRef
+			if err := json.Unmarshal(rawPT, &ref); err == nil {
+				gt.PossibleTypes = append(gt.PossibleTypes, ref)
+			}
+		}
+
 		types = append(types, gt)
 	}
 
-	return &classify.GraphQLIntrospection{
-		IntrospectionEnabled: true,
-		Types:                types,
-		RawResponse:          body,
+	result.Types = types
+	return result
+}
+
+// parseInputValue parses a raw JSON input value (arg or input field).
+func parseInputValue(raw json.RawMessage) *classify.GraphQLInputValue {
+	var v struct {
+		Name         string          `json:"name"`
+		Description  string          `json:"description"`
+		Type         json.RawMessage `json:"type"`
+		DefaultValue *string         `json:"defaultValue"`
+	}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil
+	}
+	var typeRef classify.GraphQLTypeRef
+	if err := json.Unmarshal(v.Type, &typeRef); err != nil {
+		return nil
+	}
+	return &classify.GraphQLInputValue{
+		Name:         v.Name,
+		Description:  v.Description,
+		Type:         typeRef,
+		DefaultValue: v.DefaultValue,
 	}
 }

--- a/pkg/probe/graphql_test.go
+++ b/pkg/probe/graphql_test.go
@@ -74,7 +74,7 @@ func TestGraphQLProbe_Name(t *testing.T) {
 func TestGraphQLProbe_SuccessfulIntrospection(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(validIntrospectionResponse))
+		w.Write([]byte(validIntrospectionResponse)) //nolint:gosec // test handler
 	}))
 	defer srv.Close()
 
@@ -127,7 +127,7 @@ func TestGraphQLProbe_SuccessfulIntrospection(t *testing.T) {
 func TestGraphQLProbe_IntrospectionDisabled(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"errors":[{"message":"introspection is disabled"}]}`))
+		w.Write([]byte(`{"errors":[{"message":"introspection is disabled"}]}`)) //nolint:gosec // test handler
 	}))
 	defer srv.Close()
 
@@ -211,7 +211,7 @@ func TestGraphQLProbe_DeduplicatesByURL(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(validIntrospectionResponse))
+		w.Write([]byte(validIntrospectionResponse)) //nolint:gosec // test handler
 	}))
 	defer srv.Close()
 
@@ -250,7 +250,7 @@ func TestGraphQLProbe_MaxEndpointsRespected(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(validIntrospectionResponse))
+		w.Write([]byte(validIntrospectionResponse)) //nolint:gosec // test handler
 	}))
 	defer srv.Close()
 
@@ -281,7 +281,7 @@ func TestGraphQLProbe_MaxEndpointsRespected(t *testing.T) {
 func TestGraphQLProbe_DoesNotMutateInput(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(validIntrospectionResponse))
+		w.Write([]byte(validIntrospectionResponse)) //nolint:gosec // test handler
 	}))
 	defer srv.Close()
 
@@ -308,7 +308,7 @@ func TestGraphQLProbe_DoesNotMutateInput(t *testing.T) {
 func TestGraphQLProbe_MalformedJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{not valid json`))
+		w.Write([]byte(`{not valid json`)) //nolint:gosec // test handler
 	}))
 	defer srv.Close()
 

--- a/pkg/probe/graphql_test.go
+++ b/pkg/probe/graphql_test.go
@@ -334,3 +334,390 @@ func TestGraphQLProbe_MalformedJSON(t *testing.T) {
 		t.Error("IntrospectionEnabled should be false for malformed JSON")
 	}
 }
+
+// fullIntrospectionResponse is a realistic introspection response with args,
+// inputFields, enumValues, interfaces, possibleTypes, and root type names.
+const fullIntrospectionResponse = `{
+  "data": {
+    "__schema": {
+      "queryType": { "name": "Query" },
+      "mutationType": { "name": "Mutation" },
+      "subscriptionType": null,
+      "types": [
+        {
+          "name": "Query",
+          "kind": "OBJECT",
+          "description": "Root query type",
+          "fields": [
+            {
+              "name": "user",
+              "description": "Fetch a user by ID",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "The user ID",
+                  "type": { "kind": "NON_NULL", "name": null, "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null } },
+                  "defaultValue": null
+                }
+              ],
+              "type": { "name": "User", "kind": "OBJECT", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "users",
+              "description": "",
+              "args": [
+                {
+                  "name": "limit",
+                  "description": "",
+                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+                  "defaultValue": "10"
+                }
+              ],
+              "type": { "kind": "NON_NULL", "name": null, "ofType": { "kind": "LIST", "name": null, "ofType": { "kind": "NON_NULL", "name": null, "ofType": { "kind": "OBJECT", "name": "User", "ofType": null } } } },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "search",
+              "description": "",
+              "args": [
+                {
+                  "name": "query",
+                  "description": "",
+                  "type": { "kind": "NON_NULL", "name": null, "ofType": { "kind": "SCALAR", "name": "String", "ofType": null } },
+                  "defaultValue": null
+                }
+              ],
+              "type": { "kind": "OBJECT", "name": "SearchResult", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "name": "Mutation",
+          "kind": "OBJECT",
+          "description": "",
+          "fields": [
+            {
+              "name": "createUser",
+              "description": "",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": { "kind": "NON_NULL", "name": null, "ofType": { "kind": "INPUT_OBJECT", "name": "CreateUserInput", "ofType": null } },
+                  "defaultValue": null
+                }
+              ],
+              "type": { "kind": "OBJECT", "name": "User", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "name": "User",
+          "kind": "OBJECT",
+          "description": "A user in the system",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": { "kind": "NON_NULL", "name": null, "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null } },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": "",
+              "args": [],
+              "type": { "kind": "ENUM", "name": "Role", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            { "kind": "INTERFACE", "name": "Node", "ofType": null }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "name": "Node",
+          "kind": "INTERFACE",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": { "kind": "NON_NULL", "name": null, "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null } },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            { "kind": "OBJECT", "name": "User", "ofType": null }
+          ]
+        },
+        {
+          "name": "Role",
+          "kind": "ENUM",
+          "description": "User roles",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            { "name": "ADMIN", "description": "", "isDeprecated": false, "deprecationReason": null },
+            { "name": "EDITOR", "description": "", "isDeprecated": false, "deprecationReason": null },
+            { "name": "VIEWER", "description": "", "isDeprecated": true, "deprecationReason": "Use READER" }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "name": "CreateUserInput",
+          "kind": "INPUT_OBJECT",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "name",
+              "description": "",
+              "type": { "kind": "NON_NULL", "name": null, "ofType": { "kind": "SCALAR", "name": "String", "ofType": null } },
+              "defaultValue": null
+            },
+            {
+              "name": "email",
+              "description": "",
+              "type": { "kind": "NON_NULL", "name": null, "ofType": { "kind": "SCALAR", "name": "String", "ofType": null } },
+              "defaultValue": null
+            },
+            {
+              "name": "role",
+              "description": "",
+              "type": { "kind": "ENUM", "name": "Role", "ofType": null },
+              "defaultValue": "\"VIEWER\""
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "name": "SearchResult",
+          "kind": "UNION",
+          "description": "",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            { "kind": "OBJECT", "name": "User", "ofType": null },
+            { "kind": "OBJECT", "name": "Post", "ofType": null }
+          ]
+        }
+      ]
+    }
+  }
+}`
+
+func TestGraphQLProbe_FullIntrospectionParsing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(fullIntrospectionResponse)) //nolint:gosec // test handler
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql"},
+		IsAPI:           true, APIType: "graphql",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	schema := result[0].GraphQLSchema
+	if schema == nil {
+		t.Fatal("GraphQLSchema should not be nil")
+	}
+	if !schema.IntrospectionEnabled {
+		t.Fatal("IntrospectionEnabled should be true")
+	}
+
+	// Root type names
+	if schema.QueryTypeName != "Query" {
+		t.Errorf("QueryTypeName = %q, want %q", schema.QueryTypeName, "Query")
+	}
+	if schema.MutationTypeName != "Mutation" {
+		t.Errorf("MutationTypeName = %q, want %q", schema.MutationTypeName, "Mutation")
+	}
+	if schema.SubscriptionTypeName != "" {
+		t.Errorf("SubscriptionTypeName = %q, want empty", schema.SubscriptionTypeName)
+	}
+
+	// Find types by name for assertions
+	typeMap := make(map[string]classify.GraphQLType)
+	for _, tt := range schema.Types {
+		typeMap[tt.Name] = tt
+	}
+
+	// Query.user should have args
+	query := typeMap["Query"]
+	if len(query.Fields) != 3 {
+		t.Fatalf("Query should have 3 fields, got %d", len(query.Fields))
+	}
+	userField := query.Fields[0]
+	if userField.Name != "user" {
+		t.Fatalf("first Query field = %q, want %q", userField.Name, "user")
+	}
+	if len(userField.Args) != 1 {
+		t.Fatalf("user field should have 1 arg, got %d", len(userField.Args))
+	}
+	if userField.Args[0].Name != "id" {
+		t.Errorf("user arg name = %q, want %q", userField.Args[0].Name, "id")
+	}
+	if userField.Args[0].Type.Kind != "NON_NULL" {
+		t.Errorf("user arg type kind = %q, want NON_NULL", userField.Args[0].Type.Kind)
+	}
+
+	// Role enum values
+	roleType := typeMap["Role"]
+	if len(roleType.EnumValues) != 3 {
+		t.Fatalf("Role should have 3 enum values, got %d", len(roleType.EnumValues))
+	}
+	if roleType.EnumValues[0].Name != "ADMIN" {
+		t.Errorf("first enum value = %q, want ADMIN", roleType.EnumValues[0].Name)
+	}
+	if !roleType.EnumValues[2].IsDeprecated {
+		t.Error("VIEWER should be deprecated")
+	}
+
+	// CreateUserInput input fields
+	inputType := typeMap["CreateUserInput"]
+	if len(inputType.InputFields) != 3 {
+		t.Fatalf("CreateUserInput should have 3 input fields, got %d", len(inputType.InputFields))
+	}
+	if inputType.InputFields[0].Name != "name" {
+		t.Errorf("first input field = %q, want name", inputType.InputFields[0].Name)
+	}
+
+	// User implements Node
+	userType := typeMap["User"]
+	if len(userType.Interfaces) != 1 {
+		t.Fatalf("User should implement 1 interface, got %d", len(userType.Interfaces))
+	}
+	if userType.Interfaces[0].Name == nil || *userType.Interfaces[0].Name != "Node" {
+		t.Error("User should implement Node")
+	}
+
+	// SearchResult union possible types
+	searchResult := typeMap["SearchResult"]
+	if len(searchResult.PossibleTypes) != 2 {
+		t.Fatalf("SearchResult should have 2 possible types, got %d", len(searchResult.PossibleTypes))
+	}
+}
+
+func TestGraphQLProbe_TieredFallback(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		// Reject first two tiers with errors, succeed on tier 3
+		if count <= 2 {
+			w.Write([]byte(`{"errors":[{"message":"query too complex"}]}`)) //nolint:gosec // test handler
+			return
+		}
+		w.Write([]byte(validIntrospectionResponse)) //nolint:gosec // test handler
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql"},
+		IsAPI:           true, APIType: "graphql",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if requestCount.Load() != 3 {
+		t.Errorf("expected 3 requests (fallback through tiers), got %d", requestCount.Load())
+	}
+
+	schema := result[0].GraphQLSchema
+	if schema == nil {
+		t.Fatal("GraphQLSchema should not be nil after tier 3 fallback")
+	}
+	if !schema.IntrospectionEnabled {
+		t.Error("IntrospectionEnabled should be true after successful tier 3")
+	}
+}
+
+func TestGraphQLProbe_Tier1SucceedsImmediately(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(fullIntrospectionResponse)) //nolint:gosec // test handler
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql"},
+		IsAPI:           true, APIType: "graphql",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	// Should succeed on first attempt, no fallback needed
+	if requestCount.Load() != 1 {
+		t.Errorf("expected 1 request (tier 1 success), got %d", requestCount.Load())
+	}
+
+	schema := result[0].GraphQLSchema
+	if schema == nil {
+		t.Fatal("GraphQLSchema should not be nil")
+	}
+	if schema.QueryTypeName != "Query" {
+		t.Errorf("QueryTypeName = %q, want %q", schema.QueryTypeName, "Query")
+	}
+}

--- a/pkg/probe/graphql_test.go
+++ b/pkg/probe/graphql_test.go
@@ -1,0 +1,336 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/vespasian/pkg/classify"
+	"github.com/praetorian-inc/vespasian/pkg/crawl"
+	"github.com/praetorian-inc/vespasian/pkg/probe"
+)
+
+const validIntrospectionResponse = `{
+  "data": {
+    "__schema": {
+      "types": [
+        {
+          "name": "Query",
+          "kind": "OBJECT",
+          "fields": [
+            {
+              "name": "user",
+              "type": { "name": "User", "kind": "OBJECT", "ofType": null }
+            },
+            {
+              "name": "users",
+              "type": { "name": null, "kind": "LIST", "ofType": { "name": "User" } }
+            }
+          ]
+        },
+        {
+          "name": "User",
+          "kind": "OBJECT",
+          "fields": [
+            {
+              "name": "id",
+              "type": { "name": "ID", "kind": "SCALAR", "ofType": null }
+            },
+            {
+              "name": "name",
+              "type": { "name": "String", "kind": "SCALAR", "ofType": null }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}`
+
+func TestGraphQLProbe_Name(t *testing.T) {
+	p := probe.NewGraphQLProbe(probe.DefaultConfig())
+	if p.Name() != "graphql" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "graphql")
+	}
+}
+
+func TestGraphQLProbe_SuccessfulIntrospection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(validIntrospectionResponse))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{
+			Method: "POST",
+			URL:    srv.URL + "/graphql",
+		},
+		IsAPI:   true,
+		APIType: "graphql",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	schema := result[0].GraphQLSchema
+	if schema == nil {
+		t.Fatal("GraphQLSchema should not be nil")
+	}
+	if !schema.IntrospectionEnabled {
+		t.Error("IntrospectionEnabled should be true")
+	}
+	if len(schema.Types) != 2 {
+		t.Fatalf("expected 2 types, got %d", len(schema.Types))
+	}
+	if schema.Types[0].Name != "Query" {
+		t.Errorf("first type name = %q, want %q", schema.Types[0].Name, "Query")
+	}
+	if len(schema.Types[0].Fields) != 2 {
+		t.Errorf("Query type should have 2 fields, got %d", len(schema.Types[0].Fields))
+	}
+	if schema.RawResponse == nil {
+		t.Error("RawResponse should not be nil")
+	}
+	// Check ofType parsing
+	usersField := schema.Types[0].Fields[1]
+	if usersField.Type.OfType == nil {
+		t.Fatal("users field ofType should not be nil")
+	}
+	if usersField.Type.OfType.Name == nil || *usersField.Type.OfType.Name != "User" {
+		t.Error("users field ofType.Name should be 'User'")
+	}
+}
+
+func TestGraphQLProbe_IntrospectionDisabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"errors":[{"message":"introspection is disabled"}]}`))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql"},
+		IsAPI:           true,
+		APIType:         "graphql",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	schema := result[0].GraphQLSchema
+	if schema == nil {
+		t.Fatal("GraphQLSchema should not be nil when introspection is disabled")
+	}
+	if schema.IntrospectionEnabled {
+		t.Error("IntrospectionEnabled should be false")
+	}
+}
+
+func TestGraphQLProbe_404Response(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql"},
+		IsAPI:           true,
+		APIType:         "graphql",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if result[0].GraphQLSchema != nil {
+		t.Error("expected nil GraphQLSchema for 404 response")
+	}
+}
+
+func TestGraphQLProbe_SkipsNonGraphQL(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: srv.URL + "/api/users"},
+		IsAPI:           true,
+		APIType:         "rest",
+	}}
+
+	_, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if requestCount.Load() != 0 {
+		t.Errorf("expected 0 requests for non-GraphQL endpoint, got %d", requestCount.Load())
+	}
+}
+
+func TestGraphQLProbe_DeduplicatesByURL(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(validIntrospectionResponse))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql"},
+			IsAPI:           true, APIType: "graphql",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql"},
+			IsAPI:           true, APIType: "graphql",
+		},
+	}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if requestCount.Load() != 1 {
+		t.Errorf("expected 1 request (deduplicated by URL), got %d", requestCount.Load())
+	}
+	if result[0].GraphQLSchema == nil {
+		t.Error("result[0].GraphQLSchema should not be nil")
+	}
+	if result[1].GraphQLSchema == nil {
+		t.Error("result[1].GraphQLSchema should not be nil")
+	}
+}
+
+func TestGraphQLProbe_MaxEndpointsRespected(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(validIntrospectionResponse))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{
+		Client:       srv.Client(),
+		Timeout:      5 * time.Second,
+		URLValidator: func(string) error { return nil },
+		MaxEndpoints: 2,
+	}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql1"}, IsAPI: true, APIType: "graphql"},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql2"}, IsAPI: true, APIType: "graphql"},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql3"}, IsAPI: true, APIType: "graphql"},
+	}
+
+	_, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	if requestCount.Load() > 2 {
+		t.Errorf("expected at most 2 requests (MaxEndpoints=2), got %d", requestCount.Load())
+	}
+}
+
+func TestGraphQLProbe_DoesNotMutateInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(validIntrospectionResponse))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	original := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql"},
+		IsAPI:           true, APIType: "graphql",
+	}}
+
+	result, err := p.Probe(context.Background(), original)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+	if original[0].GraphQLSchema != nil {
+		t.Error("original slice should not be mutated")
+	}
+	if result[0].GraphQLSchema == nil {
+		t.Error("result slice should have GraphQLSchema")
+	}
+}
+
+func TestGraphQLProbe_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{not valid json`))
+	}))
+	defer srv.Close()
+
+	cfg := probe.Config{Client: srv.Client(), Timeout: 5 * time.Second, URLValidator: func(string) error { return nil }}
+	p := probe.NewGraphQLProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{{
+		ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: srv.URL + "/graphql"},
+		IsAPI:           true,
+		APIType:         "graphql",
+	}}
+
+	result, err := p.Probe(context.Background(), endpoints)
+	if err != nil {
+		t.Fatalf("Probe() error: %v", err)
+	}
+
+	schema := result[0].GraphQLSchema
+	if schema == nil {
+		t.Fatal("GraphQLSchema should not be nil for malformed JSON")
+	}
+	if schema.IntrospectionEnabled {
+		t.Error("IntrospectionEnabled should be false for malformed JSON")
+	}
+}


### PR DESCRIPTION
## Description

### GraphQL Support

These changes add end-to-end GraphQL API detection, probing, and spec generation to Vespasian, along with supporting infrastructure improvements.

### Core Features

- GraphQL Classifier (pkg/classify/graphql.go) — Dedicated heuristic classifier that identifies GraphQL traffic using layered signals: URL path matching (/graphql), request body analysis (detecting
query/mutation/subscription syntax), and response structure inspection (data/errors top-level keys). Produces confidence scores from 0.70 (path only) to 0.95+ (multiple signals).
- GraphQL Probe (pkg/probe/graphql.go) — Introspection-based schema discovery probe that sends a standard GraphQL introspection query to classified endpoints and parses the full type system response
into structured schema data.
- GraphQL Generator (pkg/generate/graphql/) — Two-path SDL spec generation: prefers introspection results when available, falls back to traffic-based inference. The inference engine (infer.go) uses
gqlparser for proper AST-level query parsing to extract operation types, field names, arguments (with declared variable types), and return types from observed request/response pairs. The SDL emitter
(sdl.go) renders the introspection schema into canonical GraphQL SDL.

### CLI Integration

- Added graphql as a recognized API type in the generate and scan commands.
- Added --deduplicate flag to the generate and scan commands.
- Updated help text to list all available --api-type options.

### Dependencies

- Upgraded katana from v1.4.0 to v1.5.0.
- Added github.com/vektah/gqlparser/v2 for GraphQL query parsing.

### Lint & Quality

- Fixed gofmt, goimports, errcheck, gosec, and gocritic warnings across all new GraphQL files.
- Reduced cyclomatic complexity in ClassifyDetail, inferSDL, and inferFieldsFromResponse by extracting helper functions.

## Changes

- Add GraphQLClassifier with multi-signal heuristic detection (path, body syntax, response structure) and confidence scoring
- Add GraphQLProbe for introspection-based schema discovery against classified endpoints
- Add GraphQLGenerator with two-path SDL output: full introspection schema rendering, or traffic-based inference using gqlparser AST parsing
- Add graphql as a recognized --api-type in generate and scan CLI commands
- Add --deduplicate flag to generate and scan commands
- List available API type options in generate --help text
- Upgrade katana dependency from v1.4.0 to v1.5.0
- Add gqlparser/v2 dependency for GraphQL query parsing
- Fix lint issues (gofmt, goimports, errcheck, gosec, gocritic) across all new GraphQL files
- Reduce cyclomatic complexity in ClassifyDetail, inferSDL, and inferFieldsFromResponse via helper extraction

## Testing

<!-- How was this tested? -->

- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manual verification (describe below)

The feature produces accurate GraphQL given /graphql HTTP transactions as input.

## Checklist

- [ ] Code follows project conventions
- [ ] Tests added/updated for new functionality
- [ ] Documentation updated (if applicable)
