### PR TITLE
fix: prevent data race on Katana's global CustomFieldsMap (LAB-1650)

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -229,12 +229,14 @@ func doCrawl(ctx context.Context, stderr io.Writer, targetURL string, opts crawl
 	}
 
 	if err != nil {
-		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && len(requests) > 0 {
-			noun := "results"
-			if len(requests) == 1 {
-				noun = "result"
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if len(requests) > 0 {
+				noun := "results"
+				if len(requests) == 1 {
+					noun = "result"
+				}
+				fmt.Fprintf(stderr, "returning %d partial %s\n", len(requests), noun)
 			}
-			fmt.Fprintf(stderr, "returning %d partial %s\n", len(requests), noun)
 			return requests, nil
 		}
 		return nil, fmt.Errorf("crawl failed: %w", err)

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -95,6 +95,17 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		return nil, fmt.Errorf("invalid target URL: %q", targetURL)
 	}
 
+	// Early return if the parent context is already cancelled. This avoids
+	// initialising Katana (LevelDB, filters, output writer) only to tear
+	// everything down immediately, and prevents internal goroutine leaks
+	// that cause data races on Katana's global CustomFieldsMap.
+	if ctx.Err() != nil {
+		if c.opts.Stderr != nil {
+			fmt.Fprintf(c.opts.Stderr, "\ninterrupt received, stopping crawl...\n")
+		}
+		return nil, ctx.Err()
+	}
+
 	// Use caller-provided browser or launch Chrome under vespasian's control.
 	// This lets us kill the browser immediately on signal, stopping all
 	// outbound requests — Katana's internal context is disconnected from ours.


### PR DESCRIPTION
## Summary

- Add early context check in `Crawl()` before Katana initialization to prevent goroutine leaks that cause data races on the unprotected global `CustomFieldsMap`
- Treat context cancellation with zero results as graceful shutdown in `doCrawl()` (previously required partial results)

## Root Cause

Katana's `output.CustomFieldsMap` is a global `map[string]CustomFieldConfig` without synchronization. Signal-path tests cancel the context before calling `Crawl()`, but `Crawl()` still launches `engine.Crawl()` which spawns parser goroutines. These goroutines leak past the test boundary and race with the next test's `NewCrawlerOptions()` → `loadCustomFields()` write.

## Test plan

- [x] `make test` (`go test -race ./...`) passes consistently
- [x] 15 consecutive runs with `-race -count=1` show zero failures
- [x] All existing tests pass including `TestDoCrawl_GracefulShutdown*` and `TestCrawl_SignalPath_*`

Fixes [LAB-1650](https://linear.app/praetorianlabs/issue/LAB-1650/fix-data-race-in-crawl-tests-caused-by-katanas-global-customfieldsmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)