### PR TITLE
docs: add CLAUDE.md, package doc.go files, remove unused crawl format flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ The CLI (`cmd/vespasian`) uses Kong for argument parsing. Each command (crawl, i
 - **cmd/vespasian**: CLI entry point, command definitions, signal handling, browser lifecycle management
 - **pkg/crawl**: Headless browser crawling via Katana, capture file I/O (`ObservedRequest` JSON format), browser manager with Chrome lifecycle
 - **pkg/classify**: Request classification engine with confidence-based heuristics; classifiers for REST, GraphQL, and WSDL; deduplication
-- **pkg/probe**: Active endpoint probing strategies (OPTIONS discovery, JSON schema inference, WSDL document fetching, GraphQL introspection with 4-tier WAF bypass); SSRF protection with DNS rebinding mitigation
+- **pkg/probe**: Active endpoint probing strategies (OPTIONS discovery, JSON schema inference, WSDL document fetching, GraphQL introspection with 3-tier WAF bypass); SSRF protection with DNS rebinding mitigation
 - **pkg/generate**: Spec generation interface and registry; delegates to sub-packages by API type
 - **pkg/generate/rest**: OpenAPI 3.0 generation, path normalization (UUID detection, context-aware parameter naming), JSON schema inference
 - **pkg/generate/graphql**: GraphQL SDL generation from introspection results or traffic-based inference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,10 +101,20 @@ The `test/` directory contains live test targets:
 - **test/rest-api/**: Go HTTP server exposing REST endpoints for end-to-end testing
 - **test/soap-service/**: Go HTTP server exposing SOAP/WSDL endpoints
 - **test/graphql-server/**: Node.js GraphQL server with Apollo
-- **test/run-live-tests.sh**: End-to-end test runner that starts servers, runs vespasian, and validates output
-- **test/validate.sh**: Output validation helpers
 
-Each test target includes reference captures and expected output specs for regression testing.
+## Code Conventions
+
+- Go file naming: lowercase with underscores (e.g., `rest_classifier.go`, not `restClassifier.go`)
+- Test files match source files (`foo.go` → `foo_test.go`)
+- Formatting enforced by `gofmt -s` (run `make fmt`)
+- Linting via `golangci-lint` with gocritic, misspell, revive (run `make lint`)
+- Package-level documentation lives in `doc.go` files
+
+## Development Workflow
+
+- After implementing a feature or fix, run `make check` to ensure all tests and the linter pass.
+- After modifying a Go source file, update its package's `doc.go` if the change affects the package's public API or purpose.
+- After adding or changing features, review `README.md` and `CLAUDE.md` for accuracy and update them if needed.
 
 ## CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Vespasian is an API discovery and specification generation tool for security assessments. It captures HTTP traffic through headless browser crawling or imports it from existing sources (Burp Suite XML, HAR, mitmproxy), classifies requests by API type (REST, GraphQL, SOAP/WSDL), probes discovered endpoints, and generates specifications in the native format for each type: OpenAPI 3.0, GraphQL SDL, or WSDL.
+
+## Build and Test Commands
+
+```bash
+# Build
+make build                    # Build binary to bin/vespasian
+
+# Run all tests with race detection
+make test                     # Equivalent to: go test -race ./...
+
+# Run tests for a specific package
+go test ./pkg/classify/...
+
+# Run a single test
+go test -run TestFunctionName ./pkg/package/...
+
+# Lint
+make lint                     # Runs golangci-lint (gocritic, misspell, revive)
+
+# Format
+make fmt                      # Runs gofmt -s -w .
+
+# All checks (format, vet, lint, test)
+make check
+
+# Coverage
+make coverage                 # Generates coverage.out and prints per-function coverage
+
+# Dependencies
+make deps                     # go mod download && go mod tidy
+
+# Clean
+make clean                    # Remove bin/, dist/, coverage.out
+```
+
+## Architecture
+
+### Two-Stage Pipeline
+
+Vespasian separates traffic capture from specification generation:
+
+1. **Capture**: Crawl a target with a headless browser or import traffic from Burp/HAR/mitmproxy → produces `capture.json` (array of `ObservedRequest`)
+2. **Generate**: Classify requests → probe endpoints → generate specification (OpenAPI 3.0, GraphQL SDL, or WSDL)
+
+The `scan` command combines both stages. The `crawl`/`import` and `generate` commands run them independently.
+
+### Core Flow
+
+The CLI (`cmd/vespasian`) uses Kong for argument parsing. Each command (crawl, import, generate, scan) has a `Run()` method. The scan pipeline:
+
+1. Crawl target URL → `[]crawl.ObservedRequest`
+2. Auto-detect API type (or use explicit `--api-type`)
+3. Classify requests via `classify.RunClassifiers()` with confidence threshold
+4. Deduplicate classified endpoints
+5. Probe endpoints via `probe.RunStrategies()` (OPTIONS, schema, WSDL fetch, GraphQL introspection)
+6. Generate spec via `generate.Get(apiType).Generate()`
+
+### Key Packages
+
+- **cmd/vespasian**: CLI entry point, command definitions, signal handling, browser lifecycle management
+- **pkg/crawl**: Headless browser crawling via Katana, capture file I/O (`ObservedRequest` JSON format), browser manager with Chrome lifecycle
+- **pkg/classify**: Request classification engine with confidence-based heuristics; classifiers for REST, GraphQL, and WSDL; deduplication
+- **pkg/probe**: Active endpoint probing strategies (OPTIONS discovery, JSON schema inference, WSDL document fetching, GraphQL introspection with 4-tier WAF bypass); SSRF protection with DNS rebinding mitigation
+- **pkg/generate**: Spec generation interface and registry; delegates to sub-packages by API type
+- **pkg/generate/rest**: OpenAPI 3.0 generation, path normalization (UUID detection, context-aware parameter naming), JSON schema inference
+- **pkg/generate/graphql**: GraphQL SDL generation from introspection results or traffic-based inference
+- **pkg/generate/wsdl**: WSDL generation from SOAP traffic, WSDL document parsing, type inference from SOAP envelopes
+- **pkg/importer**: Traffic importers for Burp Suite XML, HAR 1.2, and mitmproxy dumps; format registry with size limits (500MB)
+
+### Key Patterns
+
+- **Registry pattern**: Both `pkg/importer` and `pkg/generate` use a registry map to look up implementations by name (`Get()` function)
+- **Strategy pattern**: `pkg/probe` defines `ProbeStrategy` interface; each probe type (Options, Schema, WSDL, GraphQL) is a separate implementation
+- **Classifier interface**: `pkg/classify` defines `APIClassifier` interface; each API type has its own classifier with heuristic rules and confidence scores
+
+### Capture Format
+
+The intermediate `capture.json` file is a JSON array of `crawl.ObservedRequest` structs. Each entry contains method, URL, headers, body, and response data. This format is shared between crawl output, importer output, and generator input.
+
+## CLI Commands
+
+| Command   | Purpose |
+|-----------|---------|
+| `scan`    | Full pipeline: crawl + classify + probe + generate |
+| `crawl`   | Capture traffic via headless browser → capture.json |
+| `import`  | Convert Burp XML / HAR / mitmproxy → capture.json |
+| `generate` | Produce spec from capture.json (REST→OpenAPI, GraphQL→SDL, WSDL→WSDL) |
+| `version` | Show version information |
+
+## Test Infrastructure
+
+The `test/` directory contains live test targets:
+
+- **test/rest-api/**: Go HTTP server exposing REST endpoints for end-to-end testing
+- **test/soap-service/**: Go HTTP server exposing SOAP/WSDL endpoints
+- **test/graphql-server/**: Node.js GraphQL server with Apollo
+- **test/run-live-tests.sh**: End-to-end test runner that starts servers, runs vespasian, and validates output
+- **test/validate.sh**: Output validation helpers
+
+Each test target includes reference captures and expected output specs for regression testing.
+
+## CI
+
+GitHub Actions runs on push to main and PRs: build, test (with 80% coverage threshold), lint (golangci-lint v2), and format check.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ Captures HTTP traffic by driving a headless browser through the target applicati
 vespasian crawl <url> [flags]
   -H, --header       Auth headers to inject (repeatable)
   -o, --output       Capture output file (default: stdout)
-  --format           Capture format: json, yaml (default: json)
   --depth            Max crawl depth (default: 3)
   --max-pages        Max pages to visit (default: 100)
   --timeout          Maximum duration for the entire crawl (default: 10m)

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -470,14 +470,14 @@ func (c *ImportCmd) Run() error {
 
 // GenerateCmd generates API specifications from captured traffic.
 type GenerateCmd struct {
-	APIType     string  `arg:"" enum:"rest,wsdl,graphql" help:"API type to generate (rest, wsdl, graphql)"`
-	Capture     string  `arg:"" help:"Capture file path"`
-	Output      string  `short:"o" help:"Output file path"`
-	Confidence  float64 `default:"0.5" help:"Minimum confidence threshold"`
-	Probe       bool    `default:"true" help:"Enable endpoint probing"`
-	Deduplicate bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
+	APIType               string  `arg:"" enum:"rest,wsdl,graphql" help:"API type to generate (rest, wsdl, graphql)"`
+	Capture               string  `arg:"" help:"Capture file path"`
+	Output                string  `short:"o" help:"Output file path"`
+	Confidence            float64 `default:"0.5" help:"Minimum confidence threshold"`
+	Probe                 bool    `default:"true" help:"Enable endpoint probing"`
+	Deduplicate           bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
 	DangerousAllowPrivate bool    `help:"Disable SSRF protection for probes, allowing private/localhost targets. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
-	Verbose     bool    `short:"v" help:"Enable verbose logging"`
+	Verbose               bool    `short:"v" help:"Enable verbose logging"`
 }
 
 // API type constants used for classification routing and generation.
@@ -524,7 +524,6 @@ func (c *GenerateCmd) Run() (err error) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-
 	spec, err := generateSpec(ctx, requests, generateSpecOptions{
 		APIType:      c.APIType,
 		Confidence:   c.Confidence,
@@ -545,11 +544,11 @@ func (c *GenerateCmd) Run() (err error) {
 
 // ScanCmd runs the full pipeline: crawl, classify, and generate.
 type ScanCmd struct {
-	URL         string  `arg:"" help:"Target URL to scan"`
-	APIType     string  `default:"auto" enum:"auto,rest,wsdl,graphql" help:"API type to generate (auto detects from traffic)" name:"api-type"`
-	Confidence  float64 `default:"0.5" help:"Minimum confidence threshold"`
-	Probe       bool    `default:"true" help:"Enable endpoint probing"`
-	Deduplicate bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
+	URL                   string  `arg:"" help:"Target URL to scan"`
+	APIType               string  `default:"auto" enum:"auto,rest,wsdl,graphql" help:"API type to generate (auto detects from traffic)" name:"api-type"`
+	Confidence            float64 `default:"0.5" help:"Minimum confidence threshold"`
+	Probe                 bool    `default:"true" help:"Enable endpoint probing"`
+	Deduplicate           bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
 	DangerousAllowPrivate bool    `help:"Disable SSRF protection for probes, allowing private/localhost targets. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
 
 	CrawlOptions
@@ -844,7 +843,7 @@ func probeWSDLDocument(targetURL string, allowPrivate bool, verbose bool) []byte
 	}
 	defer func() {
 		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck
-		resp.Body.Close()                                     //nolint:errcheck
+		resp.Body.Close()                                    //nolint:errcheck
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -384,8 +384,7 @@ func setupBrowserAndSignals(rawHeaders []string, crawlOpts CrawlOptions, extraOp
 
 // CrawlCmd crawls a web application to capture HTTP traffic.
 type CrawlCmd struct {
-	URL    string `arg:"" help:"Target URL to crawl"`
-	Format string `default:"json" enum:"json,yaml" help:"Output format"`
+	URL string `arg:"" help:"Target URL to crawl"`
 	CrawlOptions
 }
 

--- a/pkg/classify/doc.go
+++ b/pkg/classify/doc.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package classify separates API calls from static assets and other non-API
+// traffic using confidence-based heuristic rules. Each classifier implements
+// [APIClassifier] and returns a boolean plus a confidence score (0.0–1.0).
+//
+// Supported API types:
+//   - REST: detected via content-type, path patterns (/api/, /v1/), HTTP
+//     methods, and response structure. Static assets are excluded.
+//   - GraphQL: detected via /graphql path, query syntax in POST body, and
+//     data/errors keys in response JSON.
+//   - WSDL/SOAP: detected via SOAPAction header, SOAP envelope in body, and
+//     ?wsdl URL parameter.
+//
+// [RunClassifiers] applies one or more classifiers to a slice of observed
+// requests, returning only those that exceed the confidence threshold.
+// [Deduplicate] removes duplicate endpoints based on method and normalized URL.
+package classify

--- a/pkg/classify/types.go
+++ b/pkg/classify/types.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package classify provides API classification for observed HTTP requests.
 package classify
 
 import (

--- a/pkg/crawl/doc.go
+++ b/pkg/crawl/doc.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package crawl drives a headless Chrome browser via [Katana] to capture HTTP
+// traffic from web applications. It intercepts all outbound requests—including
+// XHR, fetch, and dynamically constructed calls from JavaScript—and records
+// them as [ObservedRequest] values.
+//
+// The package also defines the capture file format: a JSON array of
+// ObservedRequest structs that serves as the interchange format between the
+// capture stage (crawl or import) and the generation stage.
+//
+// Key types:
+//   - [Crawler] orchestrates a headless browser crawl with configurable depth,
+//     page limits, timeouts, and scope restrictions.
+//   - [BrowserManager] manages Chrome process lifecycle, including proxy
+//     configuration and graceful shutdown.
+//   - [ObservedRequest] and [ObservedResponse] represent captured HTTP traffic.
+//
+// [Katana]: https://github.com/projectdiscovery/katana
+package crawl

--- a/pkg/crawl/types.go
+++ b/pkg/crawl/types.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package crawl provides types and utilities for capturing HTTP traffic.
 package crawl
 
 // ObservedRequest represents a captured HTTP request and its response.

--- a/pkg/generate/doc.go
+++ b/pkg/generate/doc.go
@@ -12,20 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package generate defines the [SpecGenerator] interface for producing API
+// specifications from classified requests, and provides a registry for looking
+// up generators by API type.
+//
+// Generators are implemented in sub-packages:
+//   - [rest]: OpenAPI 3.0 (YAML) from REST traffic
+//   - [graphql]: GraphQL SDL from introspection or traffic inference
+//   - [wsdl]: WSDL XML from SOAP traffic
+//
+// Use [Get] to retrieve a generator by API type name, and [SupportedTypes] to
+// list all registered generators.
 package generate
-
-import (
-	"github.com/praetorian-inc/vespasian/pkg/classify"
-)
-
-// SpecGenerator generates API specifications from classified requests.
-type SpecGenerator interface {
-	// APIType returns the API type this generator supports (e.g., "rest", "graphql").
-	APIType() string
-
-	// Generate produces an API specification from the endpoints.
-	Generate(endpoints []classify.ClassifiedRequest) ([]byte, error)
-
-	// DefaultExtension returns the default file extension for the generated spec.
-	DefaultExtension() string
-}

--- a/pkg/generate/doc.go
+++ b/pkg/generate/doc.go
@@ -21,6 +21,5 @@
 //   - [graphql]: GraphQL SDL from introspection or traffic inference
 //   - [wsdl]: WSDL XML from SOAP traffic
 //
-// Use [Get] to retrieve a generator by API type name, and [SupportedTypes] to
-// list all registered generators.
+// Use [Get] to retrieve a generator by API type name.
 package generate

--- a/pkg/generate/graphql/doc.go
+++ b/pkg/generate/graphql/doc.go
@@ -12,20 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package generate
-
-import (
-	"github.com/praetorian-inc/vespasian/pkg/classify"
-)
-
-// SpecGenerator generates API specifications from classified requests.
-type SpecGenerator interface {
-	// APIType returns the API type this generator supports (e.g., "rest", "graphql").
-	APIType() string
-
-	// Generate produces an API specification from the endpoints.
-	Generate(endpoints []classify.ClassifiedRequest) ([]byte, error)
-
-	// DefaultExtension returns the default file extension for the generated spec.
-	DefaultExtension() string
-}
+// Package graphql generates GraphQL SDL (Schema Definition Language)
+// specifications from classified requests. It supports two generation modes:
+//
+//   - Introspection-based: when the probe stage successfully runs a GraphQL
+//     introspection query, the full type system is converted to SDL.
+//   - Traffic-based inference: when introspection is disabled, the package
+//     infers a partial schema from observed queries and mutations in the
+//     captured traffic.
+//
+// The [Generator] type implements the [generate.SpecGenerator] interface.
+package graphql

--- a/pkg/generate/graphql/sdl.go
+++ b/pkg/generate/graphql/sdl.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package graphql generates GraphQL SDL specifications from classified requests.
 package graphql
 
 import (

--- a/pkg/generate/rest/doc.go
+++ b/pkg/generate/rest/doc.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rest generates OpenAPI 3.0 specifications from classified REST
+// requests. It handles path normalization (collapsing /users/42 and /users/87
+// into /users/{id}), UUID detection, context-aware parameter naming, and JSON
+// schema inference from response bodies.
+//
+// Key components:
+//   - [OpenAPIGenerator] produces a valid OpenAPI 3.0 document in YAML format.
+//   - Path normalization replaces numeric and UUID path segments with
+//     parameterized templates while preserving known literals (/me, /self).
+//   - Schema inference examines response JSON to generate OpenAPI schema
+//     objects with depth and property guards.
+package rest

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package rest generates OpenAPI 3.0 specifications from classified REST requests.
 package rest
 
 import (

--- a/pkg/generate/wsdl/doc.go
+++ b/pkg/generate/wsdl/doc.go
@@ -12,20 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package generate
-
-import (
-	"github.com/praetorian-inc/vespasian/pkg/classify"
-)
-
-// SpecGenerator generates API specifications from classified requests.
-type SpecGenerator interface {
-	// APIType returns the API type this generator supports (e.g., "rest", "graphql").
-	APIType() string
-
-	// Generate produces an API specification from the endpoints.
-	Generate(endpoints []classify.ClassifiedRequest) ([]byte, error)
-
-	// DefaultExtension returns the default file extension for the generated spec.
-	DefaultExtension() string
-}
+// Package wsdl generates WSDL specifications from classified SOAP requests.
+// It supports two generation modes:
+//
+//   - Document-based: when a ?wsdl probe fetches an existing WSDL document,
+//     it is returned directly after validation.
+//   - Inference-based: when no WSDL document is available, the package infers
+//     WSDL operations from observed SOAPAction headers and SOAP envelope
+//     structures in the captured traffic.
+//
+// The package also provides [ParseWSDL] for parsing and validating WSDL XML
+// documents, and type definitions for WSDL XML unmarshaling.
+package wsdl

--- a/pkg/importer/doc.go
+++ b/pkg/importer/doc.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package importer converts traffic captures from external tools into the
+// vespasian [crawl.ObservedRequest] format. Each importer implements the
+// [TrafficImporter] interface.
+//
+// Supported formats:
+//   - Burp Suite XML: exported proxy history from Burp Suite.
+//   - HAR 1.2: HTTP Archive files from browser dev tools or other proxies.
+//   - mitmproxy: flow dumps from mitmproxy's JSON export.
+//
+// Use [Get] to retrieve an importer by format name, and [SupportedFormats]
+// to list all registered importers.
+//
+// Safety limits: files larger than 500 MB or containing more than 100,000
+// entries are rejected to prevent resource exhaustion.
+package importer

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package importer defines the interface for converting external traffic
-// captures into the vespasian ObservedRequest format.
 package importer
 
 import (

--- a/pkg/probe/doc.go
+++ b/pkg/probe/doc.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package probe enriches classified API endpoints with additional information
+// gathered through active HTTP requests. Each probe strategy implements
+// [ProbeStrategy] and targets a specific API type.
+//
+// Strategies:
+//   - [OptionsProbe]: sends OPTIONS requests to discover allowed HTTP methods.
+//   - [SchemaProbe]: infers JSON schema from endpoint responses.
+//   - [WSDLProbe]: fetches ?wsdl documents from SOAP service URLs.
+//   - [GraphQLProbe]: runs tiered introspection queries (4 tiers for WAF bypass)
+//     and falls back to traffic-based inference when introspection is disabled.
+//
+// SSRF protection is built in: [ValidateProbeURL] blocks requests to private
+// and loopback addresses (RFC 1918, RFC 4193, link-local) with DNS rebinding
+// mitigation. This can be bypassed with --dangerous-allow-private for testing
+// internal targets.
+//
+// [RunStrategies] applies a set of strategies to classified requests and
+// returns the enriched results along with any non-fatal probe errors.
+package probe

--- a/pkg/probe/doc.go
+++ b/pkg/probe/doc.go
@@ -20,7 +20,7 @@
 //   - [OptionsProbe]: sends OPTIONS requests to discover allowed HTTP methods.
 //   - [SchemaProbe]: infers JSON schema from endpoint responses.
 //   - [WSDLProbe]: fetches ?wsdl documents from SOAP service URLs.
-//   - [GraphQLProbe]: runs tiered introspection queries (4 tiers for WAF bypass)
+//   - [GraphQLProbe]: runs tiered introspection queries (3 tiers for WAF bypass)
 //     and falls back to traffic-based inference when introspection is disabled.
 //
 // SSRF protection is built in: [ValidateProbeURL] blocks requests to private

--- a/pkg/probe/prober.go
+++ b/pkg/probe/prober.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package probe provides strategies for enriching discovered API endpoints.
 package probe
 
 import (


### PR DESCRIPTION
## Summary

Implements documentation deliverables from [LAB-1251](https://linear.app/praetorianlabs/issue/LAB-1251/update-documentation-and-rationalize-filenames):

- **CLAUDE.md**: Created with build/test commands, two-stage pipeline architecture, key package descriptions, CLI command reference, test infrastructure overview, and CI details. Modeled after [Hadrian's CLAUDE.md](https://github.com/praetorian-inc/hadrian/blob/main/CLAUDE.md).
- **doc.go files**: Added for all 8 packages (`crawl`, `classify`, `probe`, `generate`, `generate/rest`, `generate/graphql`, `generate/wsdl`, `importer`). Moved existing package comments from source files to doc.go as the canonical location.
- **Removed unused `Format` field**: `CrawlCmd.Format` was defined with `enum:"json,yaml"` but never used in `Run()` — output was hardcoded to JSON. Removed the dead field to avoid confusing users with a non-functional `--format` flag.

### Filename audit results

All filenames already follow Go conventions (snake_case, test files match source, packages match directories). No renames needed.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (all 9 packages)
- [x] `make lint` — no new issues (all failures are pre-existing on main)
- [x] Verified no duplicate package comments after doc.go migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)