### PR TITLE
Pin version tags instead of hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -31,9 +31,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -53,7 +53,7 @@ jobs:
           awk -v cov="$total" -v thr="$threshold" 'BEGIN { if (cov+0 < thr+0) { printf "FAIL: coverage %.1f%% < %d%% threshold\n", cov, thr; exit 1 } }'
 
       - name: Upload coverage
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.out
@@ -63,14 +63,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
 
@@ -78,9 +78,9 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  # v7.0.0
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: v2.13.3
           args: release --clean


### PR DESCRIPTION
## Description

Pin version tags instead of hashes. Required to comply with our org-level approved workflows in GHA.

## Changes

- Pinned specific versions in .github/workflows/*.yml.

## Testing

- [ ] Manual verification

## Checklist

- [ ] Verify CI passes in PR