### PR TITLE
fix: meet 80% coverage threshold in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ vet:
 check: fmt vet lint test
 
 coverage:
-	go test -race -coverprofile=coverage.out ./...
+	go test -race -coverprofile=coverage.out $$(go list ./... | grep -v '/test/')
 	go tool cover -func=coverage.out
 
 deps:

--- a/pkg/classify/graphql_test.go
+++ b/pkg/classify/graphql_test.go
@@ -342,6 +342,39 @@ func TestGraphQLClassifier_Classify(t *testing.T) {
 	}
 }
 
+func TestGraphQLClassifier_Name(t *testing.T) {
+	c := &GraphQLClassifier{}
+	assert.Equal(t, "graphql", c.Name())
+}
+
+func TestGraphQLClassifier_ClassifyWrapper(t *testing.T) {
+	c := &GraphQLClassifier{}
+
+	// Positive: POST to /graphql with GraphQL body should be detected.
+	pos := crawl.ObservedRequest{
+		Method: "POST",
+		URL:    "https://example.com/graphql",
+		Body:   []byte(`{"query":"{ users { id } }"}`),
+	}
+	isAPI, confidence := c.Classify(pos)
+	assert.True(t, isAPI, "expected GraphQL request to be classified as API")
+	assert.GreaterOrEqual(t, confidence, GraphQLFullMatchConfidence)
+
+	// Negative: plain REST JSON endpoint should not be detected.
+	neg := crawl.ObservedRequest{
+		Method: "GET",
+		URL:    "https://example.com/api/users",
+		Response: crawl.ObservedResponse{
+			StatusCode:  200,
+			ContentType: "application/json",
+			Body:        []byte(`{"users":[]}`),
+		},
+	}
+	isAPI, confidence = c.Classify(neg)
+	assert.False(t, isAPI, "expected REST request to not be classified as GraphQL")
+	assert.Equal(t, 0.0, confidence)
+}
+
 func TestGraphQLClassifier_ImplementsDetailedClassifier(t *testing.T) {
 	var c APIClassifier = &GraphQLClassifier{}
 	assert.Implements(t, (*DetailedClassifier)(nil), c)

--- a/pkg/classify/rest_test.go
+++ b/pkg/classify/rest_test.go
@@ -370,6 +370,37 @@ func TestRESTClassifier_Classify(t *testing.T) {
 	}
 }
 
+func TestRESTClassifier_ClassifyWrapper(t *testing.T) {
+	c := &RESTClassifier{}
+
+	// Positive: JSON content-type response should be detected as REST API.
+	pos := crawl.ObservedRequest{
+		Method: "GET",
+		URL:    "https://example.com/data",
+		Response: crawl.ObservedResponse{
+			StatusCode:  200,
+			ContentType: "application/json",
+		},
+	}
+	isAPI, confidence := c.Classify(pos)
+	assert.True(t, isAPI, "expected JSON API response to be classified as REST")
+	assert.GreaterOrEqual(t, confidence, ContentTypeConfidence)
+
+	// Negative: HTML response should not be detected as REST API.
+	neg := crawl.ObservedRequest{
+		Method: "GET",
+		URL:    "https://example.com/page",
+		Response: crawl.ObservedResponse{
+			StatusCode:  200,
+			ContentType: "text/html",
+			Body:        []byte(`<html><body>Hello</body></html>`),
+		},
+	}
+	isAPI, confidence = c.Classify(neg)
+	assert.False(t, isAPI, "expected HTML response to not be classified as REST")
+	assert.Equal(t, 0.0, confidence)
+}
+
 func TestRESTClassifier_ImplementsDetailedClassifier(t *testing.T) {
 	var c APIClassifier = &RESTClassifier{}
 	assert.Implements(t, (*DetailedClassifier)(nil), c)

--- a/pkg/classify/wsdl_test.go
+++ b/pkg/classify/wsdl_test.go
@@ -232,6 +232,41 @@ func TestWSDLClassifier_Classify(t *testing.T) {
 	}
 }
 
+func TestWSDLClassifier_Name(t *testing.T) {
+	c := &WSDLClassifier{}
+	assert.Equal(t, "wsdl", c.Name())
+}
+
+func TestWSDLClassifier_ClassifyWrapper(t *testing.T) {
+	c := &WSDLClassifier{}
+
+	// Positive: request with SOAPAction header should be detected.
+	pos := crawl.ObservedRequest{
+		Method: "POST",
+		URL:    "https://example.com/service",
+		Headers: map[string]string{
+			"SOAPAction": `"urn:GetUser"`,
+		},
+	}
+	isAPI, confidence := c.Classify(pos)
+	assert.True(t, isAPI, "expected SOAP request to be classified as API")
+	assert.GreaterOrEqual(t, confidence, 0.95)
+
+	// Negative: plain JSON endpoint should not be detected as WSDL.
+	neg := crawl.ObservedRequest{
+		Method: "GET",
+		URL:    "https://example.com/api/users",
+		Response: crawl.ObservedResponse{
+			StatusCode:  200,
+			ContentType: "application/json",
+			Body:        []byte(`{"users":[]}`),
+		},
+	}
+	isAPI, confidence = c.Classify(neg)
+	assert.False(t, isAPI, "expected REST request to not be classified as WSDL")
+	assert.Equal(t, 0.0, confidence)
+}
+
 func TestWSDLClassifier_ImplementsDetailedClassifier(t *testing.T) {
 	var c APIClassifier = &WSDLClassifier{}
 	assert.Implements(t, (*DetailedClassifier)(nil), c)


### PR DESCRIPTION
## Summary
- Exclude test server fixtures (`test/rest-api`, `test/soap-service`) from coverage — they're test infrastructure with no test files, not production code
- Add tests for `Classify()` and `Name()` wrapper methods in `pkg/classify` to push total from 79.8% → 80.0%

## Test plan
- [x] `make coverage` — 80.0% total coverage
- [x] `make lint` — 0 issues
- [x] `make test` — all 9 packages pass with race detection