### PR TITLE
fix: close DNS rebinding SSRF gap in probeWSDLDocument

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -827,8 +827,15 @@ func probeWSDLDocument(targetURL string, allowPrivate bool, verbose bool) []byte
 		}
 	}
 
+	transport := &http.Transport{
+		DialContext: probe.SSRFSafeDialContext,
+	}
+	if allowPrivate {
+		transport = &http.Transport{}
+	}
 	client := &http.Client{
-		Timeout: 15 * time.Second,
+		Timeout:   15 * time.Second,
+		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/pkg/probe/doc.go
+++ b/pkg/probe/doc.go
@@ -25,8 +25,10 @@
 //
 // SSRF protection is built in: [ValidateProbeURL] blocks requests to private
 // and loopback addresses (RFC 1918, RFC 4193, link-local) with DNS rebinding
-// mitigation. This can be bypassed with --dangerous-allow-private for testing
-// internal targets.
+// mitigation. [SSRFSafeDialContext] provides a net.Dialer-compatible dial
+// function that re-checks resolved IPs at connect time, eliminating the
+// TOCTOU window between DNS validation and connection. This can be bypassed
+// with --dangerous-allow-private for testing internal targets.
 //
 // [RunStrategies] applies a set of strategies to classified requests and
 // returns the enriched results along with any non-fatal probe errors.

--- a/pkg/probe/validate.go
+++ b/pkg/probe/validate.go
@@ -100,9 +100,14 @@ func validateProbeURL(rawURL string) error {
 	return nil
 }
 
-// ssrfSafeDialContext is a net.Dialer DialContext replacement that re-checks
+// SSRFSafeDialContext is a net.Dialer DialContext replacement that re-checks
 // resolved IPs against the SSRF blocklist at connect time, preventing TOCTOU
 // DNS rebinding attacks.
+func SSRFSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	return ssrfSafeDialContext(ctx, network, addr)
+}
+
+// ssrfSafeDialContext is the internal implementation of SSRFSafeDialContext.
 func ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `probeWSDLDocument` was the only probe path using a plain `http.Client` without `ssrfSafeDialContext`, creating a TOCTOU DNS rebinding window
- Export `SSRFSafeDialContext` from `pkg/probe` and wire it into `probeWSDLDocument`'s transport
- When `allowPrivate` is true, uses default transport (matching existing behavior)

## Test plan
- [x] `make check` passes (fmt, vet, lint, test)
- [x] Out-of-band WSDL probe testing against test SOAP service