### PR TITLE
Add Claude PR Assistant workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,16 @@
+name: Claude PR Assistant
+
+on:
+  pull_request:
+    types: [synchronize, opened]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-code-action:
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds the standard `claude-code.yml` GitHub Actions workflow used across our other repos (guard-core, guard-tabularium, guard-cli, janus-framework)
- Uses the shared reusable workflow from `praetorian-inc/public-workflows`
- Triggers on PR open/synchronize and review comments

## Test plan
- [ ] Verify the `ANTHROPIC_API_KEY` secret is configured in the repo settings
- [ ] Open a test PR to confirm the workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)