### PR TITLE
feat: replace Katana headless crawl with concurrent go-rod engine

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -385,7 +385,8 @@ func setupBrowserAndSignals(rawHeaders []string, crawlOpts CrawlOptions, extraOp
 
 // CrawlCmd crawls a web application to capture HTTP traffic.
 type CrawlCmd struct {
-	URL string `arg:"" help:"Target URL to crawl"`
+	URL                   string `arg:"" help:"Target URL to crawl"`
+	DangerousAllowPrivate bool   `help:"Disable SSRF protection for crawling, allowing private/localhost targets. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
 	CrawlOptions
 }
 
@@ -396,13 +397,14 @@ func (c *CrawlCmd) Run() error {
 	}
 
 	bs, err := setupBrowserAndSignals(c.Header, c.CrawlOptions, crawl.CrawlerOptions{
-		Depth:       c.Depth,
-		MaxPages:    c.MaxPages,
-		Timeout:     c.Timeout,
-		Scope:       c.Scope,
-		Headless:    c.Headless,
-		Proxy:       c.Proxy,
-		Concurrency: c.Concurrency,
+		Depth:        c.Depth,
+		MaxPages:     c.MaxPages,
+		Timeout:      c.Timeout,
+		Scope:        c.Scope,
+		Headless:     c.Headless,
+		Proxy:        c.Proxy,
+		Concurrency:  c.Concurrency,
+		AllowPrivate: c.DangerousAllowPrivate,
 	})
 	if err != nil {
 		return err

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -563,13 +563,14 @@ func (c *ScanCmd) Run() error { //nolint:gocyclo // top-level orchestration
 	}
 
 	bs, err := setupBrowserAndSignals(c.Header, c.CrawlOptions, crawl.CrawlerOptions{
-		Depth:       c.Depth,
-		MaxPages:    c.MaxPages,
-		Timeout:     c.Timeout,
-		Scope:       c.Scope,
-		Headless:    c.Headless,
-		Proxy:       c.Proxy,
-		Concurrency: c.Concurrency,
+		Depth:        c.Depth,
+		MaxPages:     c.MaxPages,
+		Timeout:      c.Timeout,
+		Scope:        c.Scope,
+		Headless:     c.Headless,
+		Proxy:        c.Proxy,
+		Concurrency:  c.Concurrency,
+		AllowPrivate: c.DangerousAllowPrivate,
 	})
 	if err != nil {
 		return err

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -275,6 +275,7 @@ type CrawlOptions struct {
 	Scope       string        `default:"same-origin" enum:"same-origin,same-domain" help:"Crawl scope"`
 	Headless    bool          `default:"true" help:"Use headless browser"`
 	Proxy       string        `help:"Proxy address for headless browser (e.g., http://127.0.0.1:8080). Note: TLS certificate verification is disabled during crawls."`
+	Concurrency int           `default:"10" help:"Number of concurrent browser tabs for headless crawling"`
 	NoRequestID bool          `name:"no-request-id" help:"Disable automatic X-Vespasian-Request-Id header"`
 	Verbose     bool          `short:"v" help:"Enable verbose logging"`
 }
@@ -395,12 +396,13 @@ func (c *CrawlCmd) Run() error {
 	}
 
 	bs, err := setupBrowserAndSignals(c.Header, c.CrawlOptions, crawl.CrawlerOptions{
-		Depth:    c.Depth,
-		MaxPages: c.MaxPages,
-		Timeout:  c.Timeout,
-		Scope:    c.Scope,
-		Headless: c.Headless,
-		Proxy:    c.Proxy,
+		Depth:       c.Depth,
+		MaxPages:    c.MaxPages,
+		Timeout:     c.Timeout,
+		Scope:       c.Scope,
+		Headless:    c.Headless,
+		Proxy:       c.Proxy,
+		Concurrency: c.Concurrency,
 	})
 	if err != nil {
 		return err
@@ -561,12 +563,13 @@ func (c *ScanCmd) Run() error { //nolint:gocyclo // top-level orchestration
 	}
 
 	bs, err := setupBrowserAndSignals(c.Header, c.CrawlOptions, crawl.CrawlerOptions{
-		Depth:    c.Depth,
-		MaxPages: c.MaxPages,
-		Timeout:  c.Timeout,
-		Scope:    c.Scope,
-		Headless: c.Headless,
-		Proxy:    c.Proxy,
+		Depth:       c.Depth,
+		MaxPages:    c.MaxPages,
+		Timeout:     c.Timeout,
+		Scope:       c.Scope,
+		Headless:    c.Headless,
+		Proxy:       c.Proxy,
+		Concurrency: c.Concurrency,
 	})
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,9 @@ require (
 	github.com/projectdiscovery/goflags v0.1.74
 	github.com/projectdiscovery/katana v1.5.0
 	github.com/stretchr/testify v1.11.1
+	github.com/vektah/gqlparser/v2 v2.5.32
+	github.com/ysmood/gson v0.7.3
+	golang.org/x/net v0.51.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -19,7 +22,6 @@ require (
 	github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809 // indirect
 	github.com/PuerkitoBio/goquery v1.11.0 // indirect
 	github.com/STARRY-S/zip v0.2.3 // indirect
-	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/akrylysov/pogreb v0.10.1 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
@@ -111,7 +113,6 @@ require (
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
-	github.com/vektah/gqlparser/v2 v2.5.32 // indirect
 	github.com/vulncheck-oss/go-exploit v1.51.0 // indirect
 	github.com/weppos/publicsuffix-go v0.40.3-0.20250408071509-6074bbe7fd39 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
@@ -119,7 +120,6 @@ require (
 	github.com/ysmood/fetchup v0.2.3 // indirect
 	github.com/ysmood/goob v0.4.0 // indirect
 	github.com/ysmood/got v0.40.0 // indirect
-	github.com/ysmood/gson v0.7.3 // indirect
 	github.com/ysmood/leakless v0.9.0 // indirect
 	github.com/zmap/rc2 v0.0.0-20190804163417-abaa70531248 // indirect
 	github.com/zmap/zcrypto v0.0.0-20230422215203-9a665e1e9968 // indirect
@@ -129,7 +129,6 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/mod v0.32.0 // indirect
-	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/praetorian-inc/vespasian
 go 1.25.8
 
 require (
+	github.com/BishopFox/jsluice v0.0.0-20240110145140-0ddfab153e06
 	github.com/alecthomas/kong v1.14.0
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/go-rod/rod v0.116.2
@@ -16,7 +17,6 @@ require (
 )
 
 require (
-	github.com/BishopFox/jsluice v0.0.0-20240110145140-0ddfab153e06 // indirect
 	github.com/Knetic/govaluate v3.0.0+incompatible // indirect
 	github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057 // indirect
 	github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHf
 github.com/RumbleDiscovery/rumble-tools v0.0.0-20201105153123-f2adbb3244d2/go.mod h1:jD2+mU+E2SZUuAOHZvZj4xP4frlOo+N/YrXDvASFhkE=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=
-github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
-github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/akrylysov/pogreb v0.10.1 h1:FqlR8VR7uCbJdfUob916tPM+idpKgeESDXOA1K0DK4w=
 github.com/akrylysov/pogreb v0.10.1/go.mod h1:pNs6QmpQ1UlTJKDezuRWmaqkgUE2TuU0YTWyqJZ7+lI=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
@@ -41,6 +39,8 @@ github.com/alecthomas/kong v1.14.0 h1:gFgEUZWu2ZmZ+UhyZ1bDhuutbKN1nTtJTwh19Wsn21
 github.com/alecthomas/kong v1.14.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
@@ -296,6 +296,8 @@ github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d h1:hrujxIzL1woJ7
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/sashabaranov/go-openai v1.37.0 h1:hQQowgYm4OXJ1Z/wTrE+XZaO20BYsL0R3uRPSpfNZkY=
 github.com/sashabaranov/go-openai v1.37.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -50,15 +50,16 @@ const (
 
 // CrawlerOptions configures the crawler behavior.
 type CrawlerOptions struct {
-	Depth       int
-	MaxPages    int
-	Timeout     time.Duration
-	Scope       string
-	Headless    bool
-	Headers     map[string]string
-	Proxy       string    // optional: proxy address for Chrome (e.g., "http://127.0.0.1:8080")
-	Concurrency int       // headless tab concurrency; 0 uses DefaultConcurrency (10)
-	Stderr      io.Writer // user-facing status messages; nil disables output
+	Depth        int
+	MaxPages     int
+	Timeout      time.Duration
+	Scope        string
+	Headless     bool
+	Headers      map[string]string
+	Proxy        string    // optional: proxy address for Chrome (e.g., "http://127.0.0.1:8080")
+	Concurrency  int       // headless tab concurrency; 0 uses DefaultConcurrency (10)
+	AllowPrivate bool      // disable SSRF protection, allowing private/internal targets
+	Stderr       io.Writer // user-facing status messages; nil disables output
 
 	// BrowserMgr provides a caller-owned Chrome instance. When set, Crawl()
 	// connects to this browser instead of launching its own. Callers who want
@@ -132,7 +133,7 @@ func (c *Crawler) crawlHeadless(ctx context.Context, targetURL string, maxPages 
 		defer cancel()
 	}
 
-	scopeFn, err := scopeChecker(targetURL, c.opts.Scope)
+	scopeFn, err := scopeChecker(targetURL, c.opts.Scope, c.opts.AllowPrivate)
 	if err != nil {
 		return nil, fmt.Errorf("scope setup: %w", err)
 	}

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/projectdiscovery/goflags"
-	"github.com/projectdiscovery/katana/pkg/engine/hybrid"
 	"github.com/projectdiscovery/katana/pkg/engine/standard"
 	"github.com/projectdiscovery/katana/pkg/output"
 	"github.com/projectdiscovery/katana/pkg/types"
@@ -51,14 +50,15 @@ const (
 
 // CrawlerOptions configures the crawler behavior.
 type CrawlerOptions struct {
-	Depth    int
-	MaxPages int
-	Timeout  time.Duration
-	Scope    string
-	Headless bool
-	Headers  map[string]string
-	Proxy    string    // optional: proxy address for Chrome (e.g., "http://127.0.0.1:8080")
-	Stderr   io.Writer // user-facing status messages; nil disables output
+	Depth       int
+	MaxPages    int
+	Timeout     time.Duration
+	Scope       string
+	Headless    bool
+	Headers     map[string]string
+	Proxy       string    // optional: proxy address for Chrome (e.g., "http://127.0.0.1:8080")
+	Concurrency int       // headless tab concurrency; 0 uses DefaultConcurrency (10)
+	Stderr      io.Writer // user-facing status messages; nil disables output
 
 	// BrowserMgr provides a caller-owned Chrome instance. When set, Crawl()
 	// connects to this browser instead of launching its own. Callers who want
@@ -80,7 +80,7 @@ func NewCrawler(opts CrawlerOptions) *Crawler {
 }
 
 // Crawl crawls the target URL and returns observed requests.
-func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedRequest, error) { //nolint:gocyclo // top-level crawl orchestration
+func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedRequest, error) {
 	maxPages := c.opts.MaxPages
 	if maxPages <= 0 {
 		maxPages = DefaultMaxPages
@@ -95,10 +95,7 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		return nil, fmt.Errorf("invalid target URL: %q", targetURL)
 	}
 
-	// Early return if the parent context is already canceled. This avoids
-	// initializing Katana (LevelDB, filters, output writer) only to tear
-	// everything down immediately, and prevents internal goroutine leaks
-	// that cause data races on Katana's global CustomFieldsMap.
+	// Early return if the parent context is already canceled.
 	if ctx.Err() != nil {
 		if c.opts.Stderr != nil {
 			fmt.Fprintf(c.opts.Stderr, "\ninterrupt received, stopping crawl...\n") //nolint:errcheck // best-effort status message
@@ -107,12 +104,9 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	}
 
 	// Use caller-provided browser or launch Chrome under vespasian's control.
-	// This lets us kill the browser immediately on signal, stopping all
-	// outbound requests — Katana's internal context is disconnected from ours.
 	var browserMgr *BrowserManager
 	if c.opts.BrowserMgr != nil {
 		browserMgr = c.opts.BrowserMgr
-		// Caller owns lifecycle — don't defer Close here.
 	} else if c.opts.Headless {
 		browserMgr, err = NewBrowserManager(BrowserOptions{Headless: true, Proxy: c.opts.Proxy})
 		if err != nil {
@@ -121,83 +115,129 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 		defer browserMgr.Close()
 	}
 
-	// Create a cancellable context to stop Katana when MaxPages is reached.
+	if c.opts.Headless {
+		return c.crawlHeadless(ctx, targetURL, maxPages, browserMgr)
+	}
+	return c.crawlStandard(ctx, targetURL, maxPages, browserMgr)
+}
+
+// crawlHeadless runs a concurrent headless crawl using go-rod directly,
+// bypassing Katana's serial hybrid engine. This enables overlapping DOM
+// stability waits across multiple browser tabs for significantly faster crawls.
+func (c *Crawler) crawlHeadless(ctx context.Context, targetURL string, maxPages int, browserMgr *BrowserManager) ([]ObservedRequest, error) {
+	// Apply the overall crawl timeout if configured.
+	if c.opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.opts.Timeout)
+		defer cancel()
+	}
+
+	scopeFn, err := scopeChecker(targetURL, c.opts.Scope)
+	if err != nil {
+		return nil, fmt.Errorf("scope setup: %w", err)
+	}
+
+	engine, err := newRodEngine(browserMgr.wsURL(), engineOptions{
+		Concurrency:   c.opts.Concurrency,
+		MaxPages:      maxPages,
+		MaxDepth:      c.opts.Depth,
+		PageTimeout:   time.Duration(PageTimeout) * time.Second,
+		StableTimeout: DefaultStableWait,
+		Headers:       c.opts.Headers,
+		ScopeCheck:    scopeFn,
+		Stderr:        c.opts.Stderr,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create engine: %w", err)
+	}
+	defer engine.Close() //nolint:errcheck // best-effort cleanup
+
+	results := make([]ObservedRequest, 0, min(maxPages, 1000))
+	var mu sync.Mutex
+
+	err = engine.Crawl(ctx, targetURL, func(req ObservedRequest) {
+		mu.Lock()
+		results = append(results, req)
+		mu.Unlock()
+	})
+
+	// On signal, kill Chrome immediately to stop all outbound requests.
+	if ctx.Err() != nil {
+		if c.opts.Stderr != nil {
+			fmt.Fprintf(c.opts.Stderr, "\ninterrupt received, stopping crawl...\n") //nolint:errcheck // best-effort status message
+		}
+		if browserMgr != nil {
+			browserMgr.Kill()
+		}
+	}
+
+	mu.Lock()
+	snapshot := make([]ObservedRequest, len(results))
+	copy(snapshot, results)
+	mu.Unlock()
+
+	if err != nil && ctx.Err() == nil {
+		return snapshot, err
+	}
+	return snapshot, ctx.Err()
+}
+
+// crawlStandard runs the non-headless crawl using Katana's standard HTTP engine.
+// This path is unchanged from the original implementation and will be removed
+// when Katana is fully replaced in a separate ticket.
+func (c *Crawler) crawlStandard(ctx context.Context, targetURL string, maxPages int, browserMgr *BrowserManager) ([]ObservedRequest, error) { //nolint:gocyclo // legacy Katana orchestration
 	crawlCtx, crawlCancel := context.WithCancel(ctx)
 	defer crawlCancel()
 
-	// Pre-allocate results slice with capacity, capped at 1000 to limit initial allocation
 	results := make([]ObservedRequest, 0, min(maxPages, 1000))
 	var mu sync.Mutex
 	pageCount := 0
 
-	// Build Katana options
 	katanaOpts := &types.Options{
-		MaxDepth:      c.opts.Depth,
-		Timeout:       PageTimeout,
-		CrawlDuration: c.opts.Timeout,
-		FieldScope:    MapScope(c.opts.Scope),
-		Headless:      c.opts.Headless,
-		CustomHeaders: ToStringSlice(c.opts.Headers),
-		Strategy:      "depth-first",
-		// BodyReadSize (10 MB) is intentionally larger than MaxResponseBodySize (1 MB).
-		// Katana needs the full body for link extraction and JS parsing to maximize
-		// crawl coverage; we only retain MaxResponseBodySize for classification.
-		// Peak memory: up to Concurrency × BodyReadSize (100 MB with 10 workers).
+		MaxDepth:               c.opts.Depth,
+		Timeout:                PageTimeout,
+		CrawlDuration:          c.opts.Timeout,
+		FieldScope:             MapScope(c.opts.Scope),
+		Headless:               false,
+		CustomHeaders:          ToStringSlice(c.opts.Headers),
+		Strategy:               "depth-first",
 		BodyReadSize:           10 * 1024 * 1024,
 		Concurrency:            10,
 		Parallelism:            10,
 		RateLimit:              150,
-		TimeStable:             3, // seconds to wait for DOM stability; 0 causes go-rod panic in time.NewTicker
+		TimeStable:             3,
 		ScrapeJSResponses:      true,
 		ScrapeJSLuiceResponses: true,
 		XhrExtraction:          true,
 		Silent:                 true,
 		OnResult: func(result output.Result) {
-			// Map result outside the lock — MapResult may do URL parsing
-			// and body truncation, which is wasted work under contention.
 			mapped := MapResult(result)
 
 			mu.Lock()
 			defer mu.Unlock()
 
-			// Check MaxPages limit (using resolved maxPages)
 			if pageCount >= maxPages {
 				return
 			}
 			pageCount++
-
 			results = append(results, mapped)
-			// Stop Katana once MaxPages is reached to avoid wasting resources.
 			if pageCount >= maxPages {
 				crawlCancel()
 			}
 		},
 	}
 
-	// When vespasian owns the browser, pass the WS URL to Katana so it
-	// connects to our Chrome instance instead of launching its own.
 	if browserMgr != nil {
 		katanaOpts.ChromeWSUrl = browserMgr.wsURL()
 	}
 
-	// Initialize crawler options
 	crawlerOpts, err := types.NewCrawlerOptions(katanaOpts)
 	if err != nil {
 		return nil, err
 	}
 	defer crawlerOpts.Close() //nolint:errcheck // best-effort cleanup
 
-	// Create engine based on headless mode
-	var engine interface {
-		Crawl(string) error
-		Close() error
-	}
-
-	if c.opts.Headless {
-		engine, err = hybrid.New(crawlerOpts)
-	} else {
-		engine, err = standard.New(crawlerOpts)
-	}
+	engine, err := standard.New(crawlerOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +245,6 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 	closeEngine := func() { closeOnce.Do(func() { engine.Close() }) } //nolint:errcheck,gosec // best-effort cleanup
 	defer closeEngine()
 
-	// Run crawl in goroutine with context cancellation
 	crawlErr := make(chan error, 1)
 	go func() {
 		crawlErr <- engine.Crawl(targetURL)
@@ -221,40 +260,27 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			return snapshot, err
 		}
 	case <-crawlCtx.Done():
-		// crawlCtx fires for both MaxPages (crawlCancel in OnResult) and
-		// signal (parent ctx canceled). Check which case we're in.
 		if ctx.Err() != nil {
-			// Signal received (SIGINT/SIGTERM or programmatic cancel).
-			// Notify the user immediately before any cleanup.
 			if c.opts.Stderr != nil {
 				fmt.Fprintf(c.opts.Stderr, "\ninterrupt received, stopping crawl...\n") //nolint:errcheck // best-effort status message
 			}
 
-			// Kill Chrome immediately to stop all outbound requests.
 			if browserMgr != nil {
 				browserMgr.Kill()
 			}
 
-			// Bounded wait: drain Katana's internal result buffer.
-			// Chrome is dead — no network activity — we're just collecting
-			// already-buffered results.
 			timer := time.NewTimer(ShutdownGracePeriod)
 			var timerExpired bool
 			select {
 			case <-crawlErr:
-				// Crawl goroutine exited cleanly.
 			case <-timer.C:
 				timerExpired = true
 			}
 			timer.Stop()
 
-			// Close engine with a bounded wait — engine.Close() may block
-			// if the killed Chrome process left the engine in a bad state.
 			boundedRun(closeEngine, DrainTimeout)
 
 			if timerExpired {
-				// engine.Close() causes engine.Crawl() to return shortly.
-				// Wait briefly to prevent goroutine leak.
 				drainTimer := time.NewTimer(DrainTimeout)
 				select {
 				case <-crawlErr:
@@ -263,8 +289,6 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 				drainTimer.Stop()
 			}
 
-			// Snapshot results under lock — Katana's internal goroutines
-			// may still be calling OnResult during shutdown.
 			mu.Lock()
 			snapshot := make([]ObservedRequest, len(results))
 			copy(snapshot, results)
@@ -272,8 +296,6 @@ func (c *Crawler) Crawl(ctx context.Context, targetURL string) ([]ObservedReques
 			return snapshot, ctx.Err()
 		}
 
-		// MaxPages reached — close engine with bounded wait, then drain
-		// crawl goroutine to match the signal path's timeout discipline.
 		boundedRun(closeEngine, DrainTimeout)
 
 		drainTimer := time.NewTimer(ShutdownGracePeriod)

--- a/pkg/crawl/doc.go
+++ b/pkg/crawl/doc.go
@@ -12,21 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package crawl drives a headless Chrome browser via [Katana] to capture HTTP
-// traffic from web applications. It intercepts all outbound requests—including
-// XHR, fetch, and dynamically constructed calls from JavaScript—and records
-// them as [ObservedRequest] values.
+// Package crawl drives a headless Chrome browser to capture HTTP traffic from
+// web applications. It intercepts all outbound requests—including XHR, fetch,
+// and dynamically constructed calls from JavaScript—and records them as
+// [ObservedRequest] values.
+//
+// In headless mode (default), the package uses [go-rod] directly to run
+// concurrent browser tabs, overlapping DOM stability waits for significantly
+// faster crawls. In non-headless mode (--headless=false), it falls back to
+// [Katana]'s standard HTTP engine.
 //
 // The package also defines the capture file format: a JSON array of
 // ObservedRequest structs that serves as the interchange format between the
 // capture stage (crawl or import) and the generation stage.
 //
 // Key types:
-//   - [Crawler] orchestrates a headless browser crawl with configurable depth,
-//     page limits, timeouts, and scope restrictions.
+//   - [Crawler] orchestrates a browser crawl with configurable depth,
+//     page limits, timeouts, concurrency, and scope restrictions.
 //   - [BrowserManager] manages Chrome process lifecycle, including proxy
 //     configuration and graceful shutdown.
 //   - [ObservedRequest] and [ObservedResponse] represent captured HTTP traffic.
 //
+// [go-rod]: https://github.com/go-rod/rod
 // [Katana]: https://github.com/projectdiscovery/katana
 package crawl

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -260,12 +260,43 @@ func (e *rodEngine) visitPage(ctx context.Context, target urlEntry) ([]ObservedR
 		return capture.Results(), nil, nil
 	}
 
-	// Extract links from the stabilized DOM.
+	// Extract links, run jsluice, and discover forms from the stabilized page.
+	capturedResults := capture.Results()
+	results, links := enrichFromPage(page, capturedResults, target.URL)
+	return results, links, nil
+}
+
+// enrichFromPage extracts links from the DOM, runs jsluice on JS sources and
+// inline scripts, and discovers forms. It returns the enriched results and all
+// discovered links for the frontier.
+func enrichFromPage(page *rod.Page, captured []ObservedRequest, pageURL string) ([]ObservedRequest, []string) {
+	// Extract links from the DOM.
 	links, err := extractLinks(page)
 	if err != nil {
-		// Non-fatal: return captured network requests even if link extraction fails.
-		return capture.Results(), nil, nil //nolint:nilerr // link extraction failure is non-fatal
+		return captured, nil
 	}
 
-	return capture.Results(), links, nil
+	// Run jsluice on captured JS response bodies.
+	jsFromResponses := extractURLsFromResponses(captured)
+	if len(jsFromResponses) > 0 {
+		links = append(links, jsExtractedToLinks(jsFromResponses, pageURL)...)
+	}
+
+	// Run jsluice on inline <script> tags.
+	jsFromInline := extractURLsFromInlineScripts(page)
+	if len(jsFromInline) > 0 {
+		links = append(links, jsExtractedToLinks(jsFromInline, pageURL)...)
+	}
+
+	// Extract forms and emit synthetic ObservedRequests for POST endpoints.
+	forms, err := extractForms(page)
+	if err == nil && len(forms) > 0 {
+		formRequests := formsToObservedRequests(forms, pageURL)
+		captured = append(captured, formRequests...)
+		for _, f := range forms {
+			links = append(links, f.Action)
+		}
+	}
+
+	return captured, links
 }

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+)
+
+// DefaultConcurrency is the default number of concurrent browser tabs.
+const DefaultConcurrency = 10
+
+// DefaultStableWait is the default DOM stability wait duration.
+const DefaultStableWait = 3 * time.Second
+
+// engineOptions configures the concurrent headless crawl engine.
+type engineOptions struct {
+	Concurrency   int               // concurrent tabs (0 → DefaultConcurrency)
+	MaxPages      int               // max pages to visit (0 → unlimited)
+	MaxDepth      int               // max crawl depth
+	PageTimeout   time.Duration     // per-page navigation timeout (0 → 30s)
+	StableTimeout time.Duration     // DOM stability wait (0 → DefaultStableWait)
+	Headers       map[string]string // custom headers injected into every page
+	ScopeCheck    func(string) bool // returns true if a URL is in scope
+	Stderr        io.Writer         // user-facing status messages
+}
+
+// rodEngine implements a concurrent headless crawl using go-rod. It connects
+// to an existing Chrome instance (managed by BrowserManager) and runs N worker
+// goroutines, each operating its own browser tab.
+type rodEngine struct {
+	browser  *rod.Browser
+	opts     engineOptions
+	frontier *urlFrontier
+}
+
+// newRodEngine connects to the Chrome instance at wsURL and returns a crawl
+// engine ready to start. The caller must call Close() when done.
+func newRodEngine(wsURL string, opts engineOptions) (*rodEngine, error) {
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = DefaultConcurrency
+	}
+	if opts.PageTimeout <= 0 {
+		opts.PageTimeout = time.Duration(PageTimeout) * time.Second
+	}
+	if opts.StableTimeout <= 0 {
+		opts.StableTimeout = DefaultStableWait
+	}
+
+	browser := rod.New().ControlURL(wsURL)
+	if err := browser.Connect(); err != nil {
+		return nil, fmt.Errorf("connect to browser: %w", err)
+	}
+
+	frontier := newURLFrontier(opts.MaxDepth, opts.ScopeCheck)
+
+	return &rodEngine{
+		browser:  browser,
+		opts:     opts,
+		frontier: frontier,
+	}, nil
+}
+
+// Crawl starts the concurrent crawl from seedURL. It blocks until the crawl
+// completes (frontier exhausted, maxPages reached, or ctx canceled). Each
+// captured network request is passed to onResult as it is observed.
+func (e *rodEngine) Crawl(ctx context.Context, seedURL string, onResult func(ObservedRequest)) error {
+	// Seed the frontier.
+	e.frontier.Push([]urlEntry{{URL: seedURL, Depth: 0}})
+
+	// Track page count for MaxPages enforcement. The onResult callback in
+	// Crawler.crawlHeadless also tracks this, but we need our own counter
+	// here to stop launching new pages.
+	var (
+		mu        sync.Mutex
+		pageCount int
+	)
+
+	crawlCtx, crawlCancel := context.WithCancel(ctx)
+	defer crawlCancel()
+
+	// wrappedOnResult passes results to the caller and tracks page count.
+	wrappedOnResult := func(req ObservedRequest) {
+		mu.Lock()
+		if e.opts.MaxPages > 0 && pageCount >= e.opts.MaxPages {
+			mu.Unlock()
+			return
+		}
+		pageCount++
+		hitMax := e.opts.MaxPages > 0 && pageCount >= e.opts.MaxPages
+		mu.Unlock()
+
+		onResult(req)
+
+		if hitMax {
+			crawlCancel()
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i := range e.opts.Concurrency {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			e.worker(crawlCtx, id, wrappedOnResult)
+		}(i)
+	}
+
+	wg.Wait()
+	e.frontier.Close()
+	return ctx.Err()
+}
+
+// Close disconnects from the browser. It does NOT kill Chrome — BrowserManager
+// owns that lifecycle.
+func (e *rodEngine) Close() error {
+	return e.browser.Close()
+}
+
+// worker is the per-tab goroutine. It takes URLs from the frontier, visits
+// each one in a fresh tab, captures network events, extracts links, and pushes
+// discovered URLs back to the frontier.
+func (e *rodEngine) worker(ctx context.Context, id int, onResult func(ObservedRequest)) {
+	for {
+		// Check context before blocking on Pop.
+		if ctx.Err() != nil {
+			return
+		}
+
+		entry, ok := e.frontier.Pop()
+		if !ok {
+			return // frontier exhausted
+		}
+		e.frontier.MarkActive()
+
+		requests, links, err := e.visitPage(ctx, entry)
+		if err != nil {
+			if ctx.Err() != nil {
+				e.frontier.MarkIdle()
+				return
+			}
+			if e.opts.Stderr != nil {
+				fmt.Fprintf(e.opts.Stderr, "worker %d: error visiting %s: %v\n", id, entry.URL, err) //nolint:errcheck // best-effort
+			}
+			e.frontier.MarkIdle()
+			continue
+		}
+
+		// Emit captured requests.
+		for _, req := range requests {
+			if ctx.Err() != nil {
+				e.frontier.MarkIdle()
+				return
+			}
+			onResult(req)
+		}
+
+		// Push discovered links at depth+1.
+		if len(links) > 0 {
+			entries := make([]urlEntry, len(links))
+			for i, link := range links {
+				entries[i] = urlEntry{URL: link, Depth: entry.Depth + 1}
+			}
+			e.frontier.Push(entries)
+		}
+
+		e.frontier.MarkIdle()
+	}
+}
+
+// visitPage navigates a fresh tab to the given URL, captures network events,
+// waits for DOM stability, and extracts links.
+func (e *rodEngine) visitPage(ctx context.Context, target urlEntry) ([]ObservedRequest, []string, error) {
+	// Create a new tab for each visit to avoid stale state.
+	page, err := e.browser.Page(proto.TargetCreateTarget{URL: "about:blank"})
+	if err != nil {
+		return nil, nil, fmt.Errorf("create tab: %w", err)
+	}
+	defer func() {
+		page.Close() //nolint:errcheck,gosec // best-effort close; page may already be closed
+	}()
+
+	// Apply context and per-page timeout.
+	page = page.Context(ctx).Timeout(e.opts.PageTimeout)
+
+	// Enable the Network domain for capturing requests.
+	enableNetwork := proto.NetworkEnable{}
+	if err := enableNetwork.Call(page); err != nil {
+		return nil, nil, fmt.Errorf("enable network: %w", err)
+	}
+
+	// Set custom headers if configured.
+	if len(e.opts.Headers) > 0 {
+		headerPairs := make([]string, 0, len(e.opts.Headers)*2)
+		for k, v := range e.opts.Headers {
+			headerPairs = append(headerPairs, k, v)
+		}
+		cleanup, err := page.SetExtraHeaders(headerPairs)
+		if err != nil {
+			return nil, nil, fmt.Errorf("set headers: %w", err)
+		}
+		defer cleanup()
+	}
+
+	// Wire up network capture before navigation.
+	capture, waitEvents := newPageNetworkCapture(page, target.URL)
+
+	// Start the event listener in a goroutine.
+	go waitEvents()
+
+	// Navigate to the target URL.
+	if err := page.Navigate(target.URL); err != nil {
+		return nil, nil, fmt.Errorf("navigate: %w", err)
+	}
+
+	// Wait for page load event.
+	if err := page.WaitLoad(); err != nil {
+		// Non-fatal: some pages may not fire load event before timeout.
+		// Continue to collect whatever network events were captured.
+		if ctx.Err() != nil {
+			return capture.Results(), nil, nil
+		}
+	}
+
+	// Wait for DOM stability — the key optimization: these waits overlap
+	// across concurrent workers instead of serializing.
+	if err := page.WaitStable(e.opts.StableTimeout); err != nil {
+		// Non-fatal: collect partial results.
+		if ctx.Err() != nil {
+			return capture.Results(), nil, nil
+		}
+	}
+
+	// Give network events a brief moment to settle after DOM stability.
+	// This catches late XHR/fetch calls triggered by mutation observers
+	// or intersection observers that fire during DOM stabilization.
+	settle := time.NewTimer(200 * time.Millisecond)
+	select {
+	case <-settle.C:
+	case <-ctx.Done():
+		settle.Stop()
+		return capture.Results(), nil, nil
+	}
+
+	// Extract links from the stabilized DOM.
+	links, err := extractLinks(page)
+	if err != nil {
+		// Non-fatal: return captured network requests even if link extraction fails.
+		return capture.Results(), nil, nil //nolint:nilerr // link extraction failure is non-fatal
+	}
+
+	return capture.Results(), links, nil
+}

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -234,7 +234,10 @@ func (e *rodEngine) visitPage(ctx context.Context, target urlEntry) ([]ObservedR
 	// Wire up network capture before navigation.
 	capture, waitEvents := newPageNetworkCapture(page, target.URL)
 
-	// Start the event listener in a goroutine.
+	// Start the event listener in a goroutine. The goroutine exits when
+	// the page is closed (deferred above) or the page context expires.
+	// go-rod's EachEvent internally listens on the page's CDP session,
+	// which is torn down by page.Close().
 	go waitEvents()
 
 	// Navigate to the target URL.
@@ -273,17 +276,21 @@ func (e *rodEngine) visitPage(ctx context.Context, target urlEntry) ([]ObservedR
 
 	// Extract links, run jsluice, and discover forms from the stabilized page.
 	capturedResults := capture.Results()
-	results, links := enrichFromPage(page, capturedResults, target.URL)
+	results, links := enrichFromPage(page, capturedResults, target.URL, e.opts.Stderr)
 	return results, links, nil
 }
 
 // enrichFromPage extracts links from the DOM, runs jsluice on JS sources and
 // inline scripts, and discovers forms. It returns the enriched results and all
-// discovered links for the frontier.
-func enrichFromPage(page *rod.Page, captured []ObservedRequest, pageURL string) ([]ObservedRequest, []string) {
+// discovered links for the frontier. Errors are logged to stderr (if non-nil)
+// but are non-fatal — captured network results are always returned.
+func enrichFromPage(page *rod.Page, captured []ObservedRequest, pageURL string, stderr io.Writer) ([]ObservedRequest, []string) {
 	// Extract links from the DOM.
 	links, err := extractLinks(page)
 	if err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "link extraction failed for %s: %v\n", pageURL, err) //nolint:errcheck // best-effort
+		}
 		return captured, nil
 	}
 

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -28,6 +28,11 @@ import (
 // DefaultConcurrency is the default number of concurrent browser tabs.
 const DefaultConcurrency = 10
 
+// MaxConcurrency is the upper bound on concurrent browser tabs. Each tab
+// consumes significant Chrome process memory (~50 MB), so unbounded values
+// could exhaust system resources.
+const MaxConcurrency = 50
+
 // DefaultStableWait is the default DOM stability wait duration.
 const DefaultStableWait = 3 * time.Second
 
@@ -57,6 +62,12 @@ type rodEngine struct {
 func newRodEngine(wsURL string, opts engineOptions) (*rodEngine, error) {
 	if opts.Concurrency <= 0 {
 		opts.Concurrency = DefaultConcurrency
+	}
+	if opts.Concurrency > MaxConcurrency {
+		if opts.Stderr != nil {
+			fmt.Fprintf(opts.Stderr, "warning: --concurrency %d exceeds maximum (%d), capping\n", opts.Concurrency, MaxConcurrency) //nolint:errcheck // best-effort
+		}
+		opts.Concurrency = MaxConcurrency
 	}
 	if opts.PageTimeout <= 0 {
 		opts.PageTimeout = time.Duration(PageTimeout) * time.Second

--- a/pkg/crawl/engine_integration_test.go
+++ b/pkg/crawl/engine_integration_test.go
@@ -1,0 +1,352 @@
+//go:build integration
+
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// launchTestBrowser creates a headless Chrome instance for integration tests.
+func launchTestBrowser(t *testing.T) *BrowserManager {
+	t.Helper()
+	bm, err := NewBrowserManager(BrowserOptions{Headless: true})
+	if err != nil {
+		t.Fatalf("failed to launch browser: %v", err)
+	}
+	t.Cleanup(func() { bm.Close() })
+	return bm
+}
+
+func TestRodEngine_BasicCrawl(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		switch r.URL.Path {
+		case "/":
+			fmt.Fprint(w, `<html><body><a href="/page1">Page 1</a><a href="/page2">Page 2</a></body></html>`)
+		case "/page1":
+			fmt.Fprint(w, `<html><body><h1>Page 1</h1><a href="/page3">Page 3</a></body></html>`)
+		case "/page2":
+			fmt.Fprint(w, `<html><body><h1>Page 2</h1></body></html>`)
+		case "/page3":
+			fmt.Fprint(w, `<html><body><h1>Page 3</h1></body></html>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	bm := launchTestBrowser(t)
+	engine, err := newRodEngine(bm.wsURL(), engineOptions{
+		Concurrency:   2,
+		MaxPages:      100,
+		MaxDepth:      3,
+		PageTimeout:   10 * time.Second,
+		StableTimeout: 1 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("newRodEngine: %v", err)
+	}
+	defer engine.Close()
+
+	var mu sync.Mutex
+	var results []ObservedRequest
+
+	err = engine.Crawl(context.Background(), srv.URL+"/", func(req ObservedRequest) {
+		mu.Lock()
+		results = append(results, req)
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatalf("Crawl error: %v", err)
+	}
+
+	mu.Lock()
+	count := len(results)
+	mu.Unlock()
+
+	// We should capture network requests from visiting all pages.
+	if count == 0 {
+		t.Fatal("Crawl returned 0 results, expected at least some network requests")
+	}
+
+	// Verify all results have Source = "browser"
+	mu.Lock()
+	for _, r := range results {
+		if r.Source != "browser" {
+			t.Errorf("Source = %q, want %q", r.Source, "browser")
+		}
+		if r.Method == "" {
+			t.Error("Method is empty")
+		}
+	}
+	mu.Unlock()
+}
+
+func TestRodEngine_Concurrency(t *testing.T) {
+	// Each page has a 500ms delay. With 5 concurrent workers, 10 pages should
+	// take ~1-2 seconds. Serial would take ~5+ seconds.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/html")
+		if r.URL.Path == "/" {
+			body := `<html><body>`
+			for i := range 10 {
+				body += fmt.Sprintf(`<a href="/page%d">Page %d</a>`, i, i)
+			}
+			body += `</body></html>`
+			fmt.Fprint(w, body)
+		} else {
+			fmt.Fprint(w, `<html><body><h1>Leaf</h1></body></html>`)
+		}
+	}))
+	defer srv.Close()
+
+	bm := launchTestBrowser(t)
+	engine, err := newRodEngine(bm.wsURL(), engineOptions{
+		Concurrency:   5,
+		MaxPages:      100,
+		MaxDepth:      2,
+		PageTimeout:   10 * time.Second,
+		StableTimeout: 500 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("newRodEngine: %v", err)
+	}
+	defer engine.Close()
+
+	var mu sync.Mutex
+	var results []ObservedRequest
+
+	start := time.Now()
+	err = engine.Crawl(context.Background(), srv.URL+"/", func(req ObservedRequest) {
+		mu.Lock()
+		results = append(results, req)
+		mu.Unlock()
+	})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Crawl error: %v", err)
+	}
+
+	// Concurrent crawl should be significantly faster than serial.
+	// 11 pages * 500ms serial = 5.5s. With 5 workers ≈ 2-3s.
+	if elapsed > 8*time.Second {
+		t.Errorf("Crawl took %v, expected less than 8s (concurrency not working?)", elapsed)
+	}
+	t.Logf("Crawl completed in %v with %d results", elapsed, len(results))
+}
+
+func TestRodEngine_MaxPages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// Each page links to the next — infinite chain.
+		fmt.Fprintf(w, `<html><body><a href="%s/next%d">next</a></body></html>`,
+			r.URL.Path, time.Now().UnixNano())
+	}))
+	defer srv.Close()
+
+	bm := launchTestBrowser(t)
+	engine, err := newRodEngine(bm.wsURL(), engineOptions{
+		Concurrency:   2,
+		MaxPages:      5,
+		MaxDepth:      100,
+		PageTimeout:   10 * time.Second,
+		StableTimeout: 500 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("newRodEngine: %v", err)
+	}
+	defer engine.Close()
+
+	var mu sync.Mutex
+	var pageVisits int
+
+	err = engine.Crawl(context.Background(), srv.URL+"/", func(req ObservedRequest) {
+		mu.Lock()
+		pageVisits++
+		mu.Unlock()
+	})
+
+	// Context should have been canceled by MaxPages.
+	mu.Lock()
+	count := pageVisits
+	mu.Unlock()
+
+	// Due to concurrency, we may get slightly more than MaxPages results
+	// (workers that were already navigating when cancel fired). But it
+	// should be bounded.
+	t.Logf("Got %d results with MaxPages=5", count)
+	if count == 0 {
+		t.Error("Got 0 results, expected at least 1")
+	}
+}
+
+func TestRodEngine_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second) // slow server
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><a href="/page2">link</a></body></html>`)
+	}))
+	defer srv.Close()
+
+	bm := launchTestBrowser(t)
+	engine, err := newRodEngine(bm.wsURL(), engineOptions{
+		Concurrency:   2,
+		MaxPages:      100,
+		MaxDepth:      3,
+		PageTimeout:   10 * time.Second,
+		StableTimeout: 1 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("newRodEngine: %v", err)
+	}
+	defer engine.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	var results []ObservedRequest
+	var mu sync.Mutex
+
+	err = engine.Crawl(ctx, srv.URL+"/", func(req ObservedRequest) {
+		mu.Lock()
+		results = append(results, req)
+		mu.Unlock()
+	})
+
+	// Should return within roughly the timeout, not hang.
+	if err != nil && err != context.DeadlineExceeded {
+		t.Logf("Crawl returned error (expected): %v", err)
+	}
+}
+
+func TestRodEngine_ScopeFiltering(t *testing.T) {
+	// In-scope server.
+	inScope := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><h1>In Scope</h1></body></html>`)
+	}))
+	defer inScope.Close()
+
+	// Out-of-scope server.
+	outOfScope := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><h1>Out of Scope</h1></body></html>`)
+	}))
+	defer outOfScope.Close()
+
+	// Root page links to both.
+	root := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body>
+			<a href="%s/in">in-scope</a>
+			<a href="%s/out">out-of-scope</a>
+		</body></html>`, inScope.URL, outOfScope.URL)
+	}))
+	defer root.Close()
+
+	scopeFn, err := scopeChecker(root.URL, "same-origin")
+	if err != nil {
+		t.Fatalf("scopeChecker: %v", err)
+	}
+
+	bm := launchTestBrowser(t)
+	engine, err := newRodEngine(bm.wsURL(), engineOptions{
+		Concurrency:   2,
+		MaxPages:      100,
+		MaxDepth:      2,
+		PageTimeout:   10 * time.Second,
+		StableTimeout: 500 * time.Millisecond,
+		ScopeCheck:    scopeFn,
+	})
+	if err != nil {
+		t.Fatalf("newRodEngine: %v", err)
+	}
+	defer engine.Close()
+
+	var mu sync.Mutex
+	visitedURLs := make(map[string]bool)
+
+	err = engine.Crawl(context.Background(), root.URL+"/", func(req ObservedRequest) {
+		mu.Lock()
+		visitedURLs[req.URL] = true
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Logf("Crawl error (may be expected): %v", err)
+	}
+
+	// The out-of-scope server URL should NOT appear as a visited page.
+	// (It may appear in network requests if the browser loaded it, but
+	// the frontier should not have enqueued it for crawling.)
+	mu.Lock()
+	for url := range visitedURLs {
+		t.Logf("Visited: %s", url)
+	}
+	mu.Unlock()
+}
+
+func TestRodEngine_DepthLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// Each page links to the next level.
+		fmt.Fprintf(w, `<html><body><a href="%s/deeper">deeper</a></body></html>`, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	bm := launchTestBrowser(t)
+	engine, err := newRodEngine(bm.wsURL(), engineOptions{
+		Concurrency:   1,
+		MaxPages:      100,
+		MaxDepth:      1, // Only visit root (depth 0) and its direct links (depth 1)
+		PageTimeout:   10 * time.Second,
+		StableTimeout: 500 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("newRodEngine: %v", err)
+	}
+	defer engine.Close()
+
+	var mu sync.Mutex
+	var results []ObservedRequest
+
+	err = engine.Crawl(context.Background(), srv.URL+"/", func(req ObservedRequest) {
+		mu.Lock()
+		results = append(results, req)
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Logf("Crawl error: %v", err)
+	}
+
+	mu.Lock()
+	count := len(results)
+	mu.Unlock()
+
+	// With depth=1, we visit root + one level of links. Not an infinite chain.
+	t.Logf("Got %d results with MaxDepth=1", count)
+	if count == 0 {
+		t.Error("Got 0 results, expected at least 1")
+	}
+}

--- a/pkg/crawl/engine_integration_test.go
+++ b/pkg/crawl/engine_integration_test.go
@@ -266,7 +266,7 @@ func TestRodEngine_ScopeFiltering(t *testing.T) {
 	}))
 	defer root.Close()
 
-	scopeFn, err := scopeChecker(root.URL, "same-origin")
+	scopeFn, err := scopeChecker(root.URL, "same-origin", true)
 	if err != nil {
 		t.Fatalf("scopeChecker: %v", err)
 	}

--- a/pkg/crawl/forms.go
+++ b/pkg/crawl/forms.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/go-rod/rod"
+)
+
+// discoveredForm represents a form found in the DOM with its action, method,
+// and input fields extracted.
+type discoveredForm struct {
+	Action      string            // resolved absolute URL
+	Method      string            // GET or POST
+	ContentType string            // application/x-www-form-urlencoded (default)
+	Fields      map[string]string // name → value (defaults or placeholders)
+}
+
+// extractForms finds all <form> elements in the page DOM and extracts their
+// action, method, and input fields. Form actions are resolved to absolute URLs
+// against the page's current URL. This enables discovery of POST endpoints that
+// would otherwise be invisible to pure link extraction.
+func extractForms(page *rod.Page) ([]discoveredForm, error) {
+	pageInfo, err := page.Info()
+	if err != nil {
+		return nil, err
+	}
+	baseURL := pageInfo.URL
+
+	formElements, err := page.Elements("form")
+	if err != nil {
+		return nil, err
+	}
+
+	var forms []discoveredForm
+	for _, form := range formElements {
+		df := discoveredForm{
+			ContentType: "application/x-www-form-urlencoded",
+			Fields:      make(map[string]string),
+		}
+
+		// Extract method (default GET).
+		method, err := form.Attribute("method")
+		if err == nil && method != nil {
+			df.Method = strings.ToUpper(strings.TrimSpace(*method))
+		}
+		if df.Method == "" {
+			df.Method = "GET"
+		}
+
+		// Extract and resolve action URL.
+		action, err := form.Attribute("action")
+		if err == nil && action != nil && *action != "" {
+			resolved, err := resolveURL(baseURL, *action)
+			if err != nil {
+				continue // skip forms with unparseable actions
+			}
+			df.Action = resolved
+		} else {
+			// No action attribute — form submits to the current page URL.
+			df.Action = baseURL
+		}
+
+		// Extract enctype if specified.
+		enctype, err := form.Attribute("enctype")
+		if err == nil && enctype != nil && *enctype != "" {
+			df.ContentType = strings.TrimSpace(*enctype)
+		}
+
+		// Extract input fields: <input>, <select>, <textarea>.
+		extractFormFields(form, df.Fields)
+
+		forms = append(forms, df)
+	}
+
+	return forms, nil
+}
+
+// formsToObservedRequests converts discovered forms into synthetic
+// ObservedRequest entries. For GET forms, the fields become query parameters.
+// For POST forms, the fields become a URL-encoded body.
+func formsToObservedRequests(forms []discoveredForm, pageURL string) []ObservedRequest {
+	var results []ObservedRequest
+	for _, f := range forms {
+		obs := ObservedRequest{
+			Method:  f.Method,
+			URL:     f.Action,
+			Source:  "form",
+			PageURL: pageURL,
+			Headers: map[string]string{},
+		}
+
+		if f.Method == "POST" {
+			// Encode fields as URL-encoded form body.
+			formData := url.Values{}
+			for k, v := range f.Fields {
+				formData.Set(k, v)
+			}
+			obs.Body = []byte(formData.Encode())
+			obs.Headers["content-type"] = f.ContentType
+
+			// Parse query params from the action URL.
+			if u, err := url.Parse(f.Action); err == nil {
+				obs.QueryParams = make(map[string]string)
+				for key, values := range u.Query() {
+					if len(values) > 0 {
+						obs.QueryParams[key] = values[0]
+					}
+				}
+			}
+		} else {
+			// GET form: merge fields into query params.
+			if u, err := url.Parse(f.Action); err == nil {
+				q := u.Query()
+				for k, v := range f.Fields {
+					q.Set(k, v)
+				}
+				u.RawQuery = q.Encode()
+				obs.URL = u.String()
+
+				obs.QueryParams = make(map[string]string)
+				for key, values := range u.Query() {
+					if len(values) > 0 {
+						obs.QueryParams[key] = values[0]
+					}
+				}
+			}
+		}
+
+		results = append(results, obs)
+	}
+	return results
+}
+
+// extractFormFields populates the fields map from a form element's input,
+// select, and textarea children.
+func extractFormFields(form *rod.Element, fields map[string]string) {
+	inputs, err := form.Elements("input[name], select[name], textarea[name]")
+	if err != nil {
+		return
+	}
+	for _, input := range inputs {
+		name, err := input.Attribute("name")
+		if err != nil || name == nil || *name == "" {
+			continue
+		}
+
+		if isSkippableInputType(input) {
+			continue
+		}
+
+		fields[*name] = getInputValue(input)
+	}
+}
+
+// isSkippableInputType returns true for input types that don't carry API data
+// (submit, button, image, file, reset).
+func isSkippableInputType(input *rod.Element) bool {
+	inputType, err := input.Attribute("type")
+	if err != nil || inputType == nil {
+		return false
+	}
+	switch strings.ToLower(*inputType) {
+	case "submit", "button", "image", "file", "reset":
+		return true
+	}
+	return false
+}
+
+// getInputValue returns the value attribute of an input, falling back to
+// the placeholder attribute, or empty string.
+func getInputValue(input *rod.Element) string {
+	val, err := input.Attribute("value")
+	if err == nil && val != nil && *val != "" {
+		return *val
+	}
+	placeholder, err := input.Attribute("placeholder")
+	if err == nil && placeholder != nil && *placeholder != "" {
+		return *placeholder
+	}
+	return ""
+}

--- a/pkg/crawl/forms.go
+++ b/pkg/crawl/forms.go
@@ -101,10 +101,10 @@ func formsToObservedRequests(forms []discoveredForm, pageURL string) []ObservedR
 			URL:     f.Action,
 			Source:  "form",
 			PageURL: pageURL,
-			Headers: map[string]string{},
 		}
 
 		if f.Method == "POST" {
+			obs.Headers = map[string]string{}
 			// Encode fields as URL-encoded form body.
 			formData := url.Values{}
 			for k, v := range f.Fields {

--- a/pkg/crawl/forms_test.go
+++ b/pkg/crawl/forms_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormsToObservedRequests_PostForm(t *testing.T) {
+	forms := []discoveredForm{
+		{
+			Action:      "https://example.com/api/login",
+			Method:      "POST",
+			ContentType: "application/x-www-form-urlencoded",
+			Fields: map[string]string{
+				"username": "admin",
+				"password": "",
+			},
+		},
+	}
+
+	results := formsToObservedRequests(forms, "https://example.com/login")
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.Method != "POST" {
+		t.Errorf("Method = %q, want POST", r.Method)
+	}
+	if r.URL != "https://example.com/api/login" {
+		t.Errorf("URL = %q, want %q", r.URL, "https://example.com/api/login")
+	}
+	if r.Source != "form" {
+		t.Errorf("Source = %q, want %q", r.Source, "form")
+	}
+	if r.PageURL != "https://example.com/login" {
+		t.Errorf("PageURL = %q, want %q", r.PageURL, "https://example.com/login")
+	}
+	if r.Headers["content-type"] != "application/x-www-form-urlencoded" {
+		t.Errorf("content-type header = %q, want %q", r.Headers["content-type"], "application/x-www-form-urlencoded")
+	}
+
+	body := string(r.Body)
+	if !strings.Contains(body, "username=admin") {
+		t.Errorf("body = %q, expected username=admin", body)
+	}
+	if !strings.Contains(body, "password=") {
+		t.Errorf("body = %q, expected password=", body)
+	}
+}
+
+func TestFormsToObservedRequests_GetForm(t *testing.T) {
+	forms := []discoveredForm{
+		{
+			Action: "https://example.com/search",
+			Method: "GET",
+			Fields: map[string]string{
+				"q":    "test",
+				"page": "1",
+			},
+		},
+	}
+
+	results := formsToObservedRequests(forms, "https://example.com/")
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.Method != "GET" {
+		t.Errorf("Method = %q, want GET", r.Method)
+	}
+	// GET forms should merge fields into query params.
+	if r.QueryParams["q"] != "test" {
+		t.Errorf("QueryParams[q] = %q, want %q", r.QueryParams["q"], "test")
+	}
+	if r.QueryParams["page"] != "1" {
+		t.Errorf("QueryParams[page] = %q, want %q", r.QueryParams["page"], "1")
+	}
+	// Body should be empty for GET.
+	if len(r.Body) > 0 {
+		t.Errorf("GET form should have empty body, got %q", string(r.Body))
+	}
+}
+
+func TestFormsToObservedRequests_NoFields(t *testing.T) {
+	forms := []discoveredForm{
+		{
+			Action: "https://example.com/submit",
+			Method: "POST",
+			Fields: map[string]string{},
+		},
+	}
+
+	results := formsToObservedRequests(forms, "https://example.com/")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Method != "POST" {
+		t.Errorf("Method = %q, want POST", results[0].Method)
+	}
+}
+
+func TestFormsToObservedRequests_MultipartEnctype(t *testing.T) {
+	forms := []discoveredForm{
+		{
+			Action:      "https://example.com/upload",
+			Method:      "POST",
+			ContentType: "multipart/form-data",
+			Fields: map[string]string{
+				"name": "test",
+			},
+		},
+	}
+
+	results := formsToObservedRequests(forms, "https://example.com/")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Headers["content-type"] != "multipart/form-data" {
+		t.Errorf("content-type = %q, want multipart/form-data", results[0].Headers["content-type"])
+	}
+}
+
+func TestFormsToObservedRequests_Empty(t *testing.T) {
+	results := formsToObservedRequests(nil, "https://example.com/")
+	if results != nil {
+		t.Errorf("expected nil for empty forms, got %v", results)
+	}
+}
+
+func TestDiscoveredForm_DefaultValues(t *testing.T) {
+	// Verify default struct behavior for method and content type.
+	df := discoveredForm{
+		Action: "https://example.com/test",
+		Fields: map[string]string{"x": "1"},
+	}
+
+	// Method defaults should be set by extractForms, but if empty, formsToObservedRequests
+	// should still produce valid output.
+	results := formsToObservedRequests([]discoveredForm{df}, "https://example.com/")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	// Empty method means GET form behavior (fields in query params).
+	if !strings.Contains(results[0].URL, "x=1") {
+		t.Errorf("expected query param in URL for GET form, got %q", results[0].URL)
+	}
+}

--- a/pkg/crawl/frontier.go
+++ b/pkg/crawl/frontier.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import "sync"
+
+// urlEntry represents a URL in the frontier with its crawl depth.
+type urlEntry struct {
+	URL   string
+	Depth int
+}
+
+// urlFrontier is a thread-safe FIFO queue of URLs to visit, with deduplication,
+// scope filtering, and depth tracking. Workers call Pop to get the next URL and
+// Push to enqueue discovered links. The frontier detects completion when the
+// queue is empty and no workers are actively processing a page.
+type urlFrontier struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	queue    []urlEntry
+	seen     map[string]bool
+	maxDepth int
+	scopeFn  func(string) bool
+	active   int  // workers currently navigating a page
+	closed   bool // set by Close(); prevents new pushes
+}
+
+// newURLFrontier creates a frontier with the given max depth and scope filter.
+// The scopeFn is called for every URL before enqueuing; returning false rejects
+// the URL. A nil scopeFn accepts all URLs.
+func newURLFrontier(maxDepth int, scopeFn func(string) bool) *urlFrontier {
+	f := &urlFrontier{
+		queue:    make([]urlEntry, 0, 64),
+		seen:     make(map[string]bool),
+		maxDepth: maxDepth,
+		scopeFn:  scopeFn,
+	}
+	f.cond = sync.NewCond(&f.mu)
+	return f
+}
+
+// Push adds URLs to the frontier if they pass scope, depth, and dedup checks.
+// Returns the number of URLs actually enqueued.
+func (f *urlFrontier) Push(entries []urlEntry) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.closed {
+		return 0
+	}
+
+	added := 0
+	for _, e := range entries {
+		// Depth check: entries at depth > maxDepth are links we would visit
+		// at maxDepth+1, which exceeds the configured limit.
+		if f.maxDepth >= 0 && e.Depth > f.maxDepth {
+			continue
+		}
+
+		normalized := normalizeURL(e.URL)
+		if normalized == "" {
+			continue
+		}
+
+		if f.seen[normalized] {
+			continue
+		}
+
+		if f.scopeFn != nil && !f.scopeFn(e.URL) {
+			continue
+		}
+
+		f.seen[normalized] = true
+		f.queue = append(f.queue, e)
+		added++
+	}
+
+	if added > 0 {
+		f.cond.Broadcast()
+	}
+	return added
+}
+
+// Pop returns the next URL to visit. It blocks until a URL is available or
+// the frontier is done (empty queue, no active workers, or closed). Returns
+// (entry, true) on success or (urlEntry{}, false) when the frontier is exhausted.
+func (f *urlFrontier) Pop() (urlEntry, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for {
+		if len(f.queue) > 0 {
+			entry := f.queue[0]
+			f.queue = f.queue[1:]
+			return entry, true
+		}
+
+		// Queue is empty. If no workers are active (and thus no new URLs can
+		// arrive), or the frontier is closed, we're done.
+		if f.active == 0 || f.closed {
+			return urlEntry{}, false
+		}
+
+		// Wait for Push or MarkIdle to signal.
+		f.cond.Wait()
+	}
+}
+
+// MarkActive increments the active-worker counter. Call this when a worker
+// receives a URL from Pop and begins processing it.
+func (f *urlFrontier) MarkActive() {
+	f.mu.Lock()
+	f.active++
+	f.mu.Unlock()
+}
+
+// MarkIdle decrements the active-worker counter. Call this when a worker
+// finishes processing a URL (after pushing discovered links). If the queue
+// is empty and no workers are active, waiting Pop calls are unblocked.
+func (f *urlFrontier) MarkIdle() {
+	f.mu.Lock()
+	f.active--
+	if f.active == 0 && len(f.queue) == 0 {
+		f.cond.Broadcast()
+	}
+	f.mu.Unlock()
+}
+
+// Close signals that no more URLs will be added externally. Any blocked Pop
+// calls will return false once the queue drains.
+func (f *urlFrontier) Close() {
+	f.mu.Lock()
+	f.closed = true
+	f.cond.Broadcast()
+	f.mu.Unlock()
+}
+
+// Len returns the number of URLs currently in the queue (not including
+// URLs being actively processed by workers).
+func (f *urlFrontier) Len() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.queue)
+}
+
+// Seen returns the total number of unique URLs that have been enqueued
+// (including those already processed).
+func (f *urlFrontier) Seen() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.seen)
+}

--- a/pkg/crawl/frontier.go
+++ b/pkg/crawl/frontier.go
@@ -104,6 +104,14 @@ func (f *urlFrontier) Pop() (urlEntry, bool) {
 		if len(f.queue) > 0 {
 			entry := f.queue[0]
 			f.queue = f.queue[1:]
+			// Compact the backing array when it's 4x larger than needed.
+			// Without this, consumed slots hold stale entries that can't
+			// be GC'd — a memory concern on large crawls.
+			if cap(f.queue) > 4*len(f.queue) && len(f.queue) > 0 {
+				compact := make([]urlEntry, len(f.queue))
+				copy(compact, f.queue)
+				f.queue = compact
+			}
 			return entry, true
 		}
 

--- a/pkg/crawl/frontier_test.go
+++ b/pkg/crawl/frontier_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFrontier_BasicPushPop(t *testing.T) {
+	f := newURLFrontier(10, nil)
+
+	urls := []urlEntry{
+		{URL: "https://example.com/a", Depth: 0},
+		{URL: "https://example.com/b", Depth: 0},
+		{URL: "https://example.com/c", Depth: 0},
+	}
+	added := f.Push(urls)
+	if added != 3 {
+		t.Fatalf("Push returned %d, want 3", added)
+	}
+
+	// FIFO order
+	for _, want := range urls {
+		got, ok := f.Pop()
+		if !ok {
+			t.Fatal("Pop returned false, expected URL")
+		}
+		if got.URL != want.URL {
+			t.Errorf("Pop URL = %q, want %q", got.URL, want.URL)
+		}
+	}
+
+	// Queue empty, no active workers → Pop returns false
+	got, ok := f.Pop()
+	if ok {
+		t.Errorf("Pop returned true with URL %q, expected false (empty frontier)", got.URL)
+	}
+}
+
+func TestFrontier_Dedup(t *testing.T) {
+	f := newURLFrontier(10, nil)
+
+	f.Push([]urlEntry{{URL: "https://example.com/page", Depth: 0}})
+	f.Push([]urlEntry{{URL: "https://example.com/page", Depth: 0}})
+
+	if f.Len() != 1 {
+		t.Errorf("Len = %d, want 1 (dedup should prevent second push)", f.Len())
+	}
+	if f.Seen() != 1 {
+		t.Errorf("Seen = %d, want 1", f.Seen())
+	}
+}
+
+func TestFrontier_DedupFragment(t *testing.T) {
+	f := newURLFrontier(10, nil)
+
+	f.Push([]urlEntry{{URL: "https://example.com/page#top", Depth: 0}})
+	added := f.Push([]urlEntry{{URL: "https://example.com/page#bottom", Depth: 0}})
+
+	if added != 0 {
+		t.Errorf("Push returned %d, want 0 (fragments should normalize to same URL)", added)
+	}
+	if f.Len() != 1 {
+		t.Errorf("Len = %d, want 1", f.Len())
+	}
+}
+
+func TestFrontier_ScopeFiltering(t *testing.T) {
+	scopeFn := func(u string) bool {
+		return u == "https://example.com/in-scope"
+	}
+	f := newURLFrontier(10, scopeFn)
+
+	added := f.Push([]urlEntry{
+		{URL: "https://example.com/in-scope", Depth: 0},
+		{URL: "https://other.com/out-of-scope", Depth: 0},
+	})
+
+	if added != 1 {
+		t.Errorf("Push returned %d, want 1 (one URL out of scope)", added)
+	}
+}
+
+func TestFrontier_DepthLimit(t *testing.T) {
+	f := newURLFrontier(2, nil)
+
+	added := f.Push([]urlEntry{
+		{URL: "https://example.com/depth0", Depth: 0},
+		{URL: "https://example.com/depth1", Depth: 1},
+		{URL: "https://example.com/depth2", Depth: 2},
+		{URL: "https://example.com/depth3", Depth: 3}, // exceeds maxDepth
+	})
+
+	if added != 3 {
+		t.Errorf("Push returned %d, want 3 (depth 3 should be rejected)", added)
+	}
+}
+
+func TestFrontier_Close(t *testing.T) {
+	f := newURLFrontier(10, nil)
+	f.Close()
+
+	// Push after close should reject
+	added := f.Push([]urlEntry{{URL: "https://example.com/late", Depth: 0}})
+	if added != 0 {
+		t.Errorf("Push after Close returned %d, want 0", added)
+	}
+
+	// Pop on closed empty frontier returns false
+	_, ok := f.Pop()
+	if ok {
+		t.Error("Pop on closed frontier returned true, want false")
+	}
+}
+
+func TestFrontier_PopBlocksUntilPush(t *testing.T) {
+	f := newURLFrontier(10, nil)
+
+	// Simulate an active worker so Pop blocks instead of returning false immediately
+	f.MarkActive()
+
+	var got urlEntry
+	var ok bool
+	done := make(chan struct{})
+
+	go func() {
+		got, ok = f.Pop()
+		close(done)
+	}()
+
+	// Give the goroutine time to block
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-done:
+		t.Fatal("Pop returned before Push")
+	default:
+	}
+
+	// Push a URL to unblock
+	f.Push([]urlEntry{{URL: "https://example.com/unblock", Depth: 0}})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pop did not return after Push")
+	}
+
+	if !ok {
+		t.Error("Pop returned false after Push, want true")
+	}
+	if got.URL != "https://example.com/unblock" {
+		t.Errorf("Pop URL = %q, want %q", got.URL, "https://example.com/unblock")
+	}
+
+	f.MarkIdle()
+}
+
+func TestFrontier_PopUnblocksOnMarkIdle(t *testing.T) {
+	f := newURLFrontier(10, nil)
+
+	// One active worker, empty queue → Pop should block
+	f.MarkActive()
+
+	done := make(chan bool, 1)
+	go func() {
+		_, ok := f.Pop()
+		done <- ok
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Mark idle with empty queue → frontier is exhausted → Pop returns false
+	f.MarkIdle()
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Error("Pop returned true, want false (frontier exhausted)")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pop did not return after MarkIdle")
+	}
+}
+
+func TestFrontier_ConcurrentAccess(t *testing.T) {
+	f := newURLFrontier(100, nil)
+
+	// Seed with initial URLs
+	var initial []urlEntry
+	for i := range 100 {
+		initial = append(initial, urlEntry{
+			URL:   "https://example.com/" + string(rune('a'+i%26)) + string(rune('0'+i/26)),
+			Depth: 0,
+		})
+	}
+	f.Push(initial)
+
+	// Concurrent consumers
+	var wg sync.WaitGroup
+	consumed := make(chan string, 200)
+
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				entry, ok := f.Pop()
+				if !ok {
+					return
+				}
+				consumed <- entry.URL
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(consumed)
+
+	count := 0
+	for range consumed {
+		count++
+	}
+	if count != 100 {
+		t.Errorf("consumed %d URLs, want 100", count)
+	}
+}
+
+func TestFrontier_ActiveWorkerPreventsEarlyDone(t *testing.T) {
+	f := newURLFrontier(10, nil)
+
+	// Push one URL, pop it, mark active
+	f.Push([]urlEntry{{URL: "https://example.com/start", Depth: 0}})
+	_, ok := f.Pop()
+	if !ok {
+		t.Fatal("Pop returned false, expected URL")
+	}
+	f.MarkActive()
+
+	// Another goroutine tries to Pop — should block because a worker is active
+	done := make(chan bool, 1)
+	go func() {
+		_, popOk := f.Pop()
+		done <- popOk
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Active worker discovers a new URL
+	f.Push([]urlEntry{{URL: "https://example.com/discovered", Depth: 1}})
+	f.MarkIdle()
+
+	select {
+	case popOk := <-done:
+		if !popOk {
+			t.Error("Pop returned false, want true (new URL was pushed)")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pop did not return after worker pushed URL and marked idle")
+	}
+}

--- a/pkg/crawl/jsextract.go
+++ b/pkg/crawl/jsextract.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"strings"
+
+	"github.com/BishopFox/jsluice"
+	"github.com/go-rod/rod"
+)
+
+// jsExtractedURL represents an endpoint discovered by jsluice from JavaScript
+// source code. It carries richer metadata than a plain URL string.
+type jsExtractedURL struct {
+	URL         string
+	Method      string
+	ContentType string
+}
+
+// extractURLsFromJS runs jsluice on JavaScript source code and returns
+// discovered URLs. It filters out obviously non-API URLs (data: URIs,
+// fragment-only refs, etc.).
+func extractURLsFromJS(source []byte) []jsExtractedURL {
+	if len(source) == 0 {
+		return nil
+	}
+
+	analyzer := jsluice.NewAnalyzer(source)
+	urls := analyzer.GetURLs()
+
+	var results []jsExtractedURL
+	for _, u := range urls {
+		raw := strings.TrimSpace(u.URL)
+		if raw == "" {
+			continue
+		}
+
+		// Skip non-navigable URLs.
+		lower := strings.ToLower(raw)
+		if strings.HasPrefix(lower, "javascript:") ||
+			strings.HasPrefix(lower, "data:") ||
+			strings.HasPrefix(lower, "blob:") ||
+			strings.HasPrefix(lower, "mailto:") ||
+			strings.HasPrefix(lower, "tel:") {
+			continue
+		}
+
+		// Skip placeholder/template URLs that jsluice couldn't fully resolve.
+		if strings.Contains(raw, jsluice.ExpressionPlaceholder) {
+			continue
+		}
+
+		method := strings.ToUpper(u.Method)
+		if method == "" {
+			method = "GET"
+		}
+
+		results = append(results, jsExtractedURL{
+			URL:         raw,
+			Method:      method,
+			ContentType: u.ContentType,
+		})
+	}
+	return results
+}
+
+// extractURLsFromInlineScripts collects all inline <script> tag contents from
+// the current page DOM and runs jsluice on each. This captures endpoints
+// defined in inline JavaScript that aren't in external .js files.
+func extractURLsFromInlineScripts(page *rod.Page) []jsExtractedURL {
+	elements, err := page.Elements("script:not([src])")
+	if err != nil {
+		return nil
+	}
+
+	var results []jsExtractedURL
+	for _, el := range elements {
+		text, err := el.Text()
+		if err != nil || len(strings.TrimSpace(text)) == 0 {
+			continue
+		}
+		results = append(results, extractURLsFromJS([]byte(text))...)
+	}
+	return results
+}
+
+// extractURLsFromResponses runs jsluice on captured JavaScript response bodies
+// from network interception. This discovers endpoints embedded in external JS
+// files that the browser downloaded but whose code paths weren't triggered
+// during the page visit.
+func extractURLsFromResponses(captured []ObservedRequest) []jsExtractedURL {
+	var results []jsExtractedURL
+	for _, req := range captured {
+		ct := strings.ToLower(req.Response.ContentType)
+		if !isJavaScriptContentType(ct) {
+			continue
+		}
+		if len(req.Response.Body) == 0 {
+			continue
+		}
+		results = append(results, extractURLsFromJS(req.Response.Body)...)
+	}
+	return results
+}
+
+// isJavaScriptContentType returns true if the content type indicates JavaScript.
+func isJavaScriptContentType(ct string) bool {
+	return strings.Contains(ct, "javascript") ||
+		strings.Contains(ct, "ecmascript") ||
+		ct == "text/js" ||
+		ct == "application/x-js"
+}
+
+// jsExtractedToLinks resolves jsluice-discovered URLs against a base URL and
+// returns them as plain URL strings suitable for pushing to the frontier.
+func jsExtractedToLinks(extracted []jsExtractedURL, baseURL string) []string {
+	seen := make(map[string]bool)
+	var links []string
+
+	for _, e := range extracted {
+		resolved, err := resolveURL(baseURL, e.URL)
+		if err != nil {
+			continue
+		}
+		if seen[resolved] {
+			continue
+		}
+		seen[resolved] = true
+		links = append(links, resolved)
+	}
+	return links
+}

--- a/pkg/crawl/jsextract_test.go
+++ b/pkg/crawl/jsextract_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"testing"
+)
+
+func TestExtractURLsFromJS_FetchCall(t *testing.T) {
+	source := []byte(`
+		fetch("/api/v1/users")
+		fetch("/api/v1/orders", {method: "POST"})
+	`)
+
+	results := extractURLsFromJS(source)
+	if len(results) == 0 {
+		t.Fatal("expected at least one URL from fetch calls")
+	}
+
+	found := false
+	for _, r := range results {
+		if r.URL == "/api/v1/users" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected /api/v1/users in results, got %+v", results)
+	}
+}
+
+func TestExtractURLsFromJS_AxiosGet(t *testing.T) {
+	source := []byte(`
+		axios.get("/api/data/items")
+		axios.post("/api/data/submit", data)
+	`)
+
+	results := extractURLsFromJS(source)
+	if len(results) == 0 {
+		t.Fatal("expected at least one URL from axios calls")
+	}
+
+	urls := make(map[string]bool)
+	for _, r := range results {
+		urls[r.URL] = true
+	}
+	if !urls["/api/data/items"] {
+		t.Errorf("expected /api/data/items in results")
+	}
+}
+
+func TestExtractURLsFromJS_StringLiterals(t *testing.T) {
+	source := []byte(`
+		var endpoint = "/api/v2/search";
+		var base = "https://api.example.com/v1";
+	`)
+
+	results := extractURLsFromJS(source)
+	urls := make(map[string]bool)
+	for _, r := range results {
+		urls[r.URL] = true
+	}
+	// jsluice may or may not extract simple string literals depending on context.
+	// We just verify no crash and results are filtered.
+	for _, r := range results {
+		if r.URL == "" {
+			t.Error("got empty URL in results")
+		}
+	}
+}
+
+func TestExtractURLsFromJS_FiltersNonNavigable(t *testing.T) {
+	source := []byte(`
+		var a = "javascript:void(0)";
+		var b = "data:text/html,hello";
+		var c = "mailto:test@example.com";
+		fetch("/api/valid")
+	`)
+
+	results := extractURLsFromJS(source)
+	for _, r := range results {
+		lower := r.URL
+		if lower == "javascript:void(0)" || lower == "data:text/html,hello" || lower == "mailto:test@example.com" {
+			t.Errorf("non-navigable URL should be filtered: %q", r.URL)
+		}
+	}
+}
+
+func TestExtractURLsFromJS_EmptySource(t *testing.T) {
+	results := extractURLsFromJS(nil)
+	if results != nil {
+		t.Errorf("expected nil for empty source, got %v", results)
+	}
+
+	results = extractURLsFromJS([]byte(""))
+	if results != nil {
+		t.Errorf("expected nil for empty string source, got %v", results)
+	}
+}
+
+func TestExtractURLsFromResponses(t *testing.T) {
+	captured := []ObservedRequest{
+		{
+			URL:    "https://example.com/app.js",
+			Method: "GET",
+			Response: ObservedResponse{
+				StatusCode:  200,
+				ContentType: "application/javascript",
+				Body:        []byte(`fetch("/api/from-external-js")`),
+			},
+		},
+		{
+			URL:    "https://example.com/page.html",
+			Method: "GET",
+			Response: ObservedResponse{
+				StatusCode:  200,
+				ContentType: "text/html",
+				Body:        []byte(`<html><body>not js</body></html>`),
+			},
+		},
+		{
+			URL:    "https://example.com/empty.js",
+			Method: "GET",
+			Response: ObservedResponse{
+				StatusCode:  200,
+				ContentType: "application/javascript",
+				Body:        nil,
+			},
+		},
+	}
+
+	results := extractURLsFromResponses(captured)
+
+	found := false
+	for _, r := range results {
+		if r.URL == "/api/from-external-js" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected /api/from-external-js from JS response body, got %+v", results)
+	}
+}
+
+func TestIsJavaScriptContentType(t *testing.T) {
+	tests := []struct {
+		ct   string
+		want bool
+	}{
+		{"application/javascript", true},
+		{"application/x-javascript", true},
+		{"text/javascript", true},
+		{"application/ecmascript", true},
+		{"text/js", true},
+		{"application/x-js", true},
+		{"text/html", false},
+		{"application/json", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ct, func(t *testing.T) {
+			got := isJavaScriptContentType(tt.ct)
+			if got != tt.want {
+				t.Errorf("isJavaScriptContentType(%q) = %v, want %v", tt.ct, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJsExtractedToLinks(t *testing.T) {
+	extracted := []jsExtractedURL{
+		{URL: "/api/users", Method: "GET"},
+		{URL: "/api/orders", Method: "POST"},
+		{URL: "/api/users", Method: "GET"},              // duplicate
+		{URL: "javascript:void(0)", Method: "GET"},      // will fail resolveURL
+		{URL: "https://example.com/abs", Method: "GET"}, // absolute
+	}
+
+	links := jsExtractedToLinks(extracted, "https://example.com/app")
+
+	if len(links) == 0 {
+		t.Fatal("expected at least one resolved link")
+	}
+
+	// Check dedup: /api/users should appear only once
+	count := 0
+	for _, l := range links {
+		if l == "https://example.com/api/users" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected /api/users once, got %d times", count)
+	}
+}

--- a/pkg/crawl/links.go
+++ b/pkg/crawl/links.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/go-rod/rod"
+)
+
+// linkSelectors defines the CSS selectors and their attributes to extract URLs
+// from the DOM. Each selector is paired with the attribute that holds the URL.
+var linkSelectors = []struct {
+	selector  string
+	attribute string
+}{
+	{"a[href]", "href"},
+	{"form[action]", "action"},
+	{"iframe[src]", "src"},
+	{"area[href]", "href"},
+	{"[data-href]", "data-href"},
+	{"[data-url]", "data-url"},
+}
+
+// extractLinks extracts all navigable URLs from the current page DOM.
+// It queries for links, forms, iframes, and common SPA data attributes,
+// resolving all URLs to absolute form against the page's current URL.
+// Returned URLs are deduplicated.
+func extractLinks(page *rod.Page) ([]string, error) {
+	pageInfo, err := page.Info()
+	if err != nil {
+		return nil, err
+	}
+	baseURL := pageInfo.URL
+
+	seen := make(map[string]bool)
+	var links []string
+
+	for _, sel := range linkSelectors {
+		elements, err := page.Elements(sel.selector)
+		if err != nil {
+			continue // non-fatal: some selectors may not match
+		}
+		for _, el := range elements {
+			raw, err := el.Attribute(sel.attribute)
+			if err != nil || raw == nil || *raw == "" {
+				continue
+			}
+
+			resolved, err := resolveURL(baseURL, *raw)
+			if err != nil {
+				continue
+			}
+
+			if seen[resolved] {
+				continue
+			}
+			seen[resolved] = true
+			links = append(links, resolved)
+		}
+	}
+
+	return links, nil
+}
+
+// resolveURL resolves a potentially relative URL against the base URL.
+// It returns an error for unparseable URLs and skips non-HTTP schemes
+// (javascript:, mailto:, data:, etc.).
+func resolveURL(base, ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", url.EscapeError("empty reference")
+	}
+
+	// Skip non-navigable schemes early.
+	lower := strings.ToLower(ref)
+	if strings.HasPrefix(lower, "javascript:") ||
+		strings.HasPrefix(lower, "mailto:") ||
+		strings.HasPrefix(lower, "data:") ||
+		strings.HasPrefix(lower, "tel:") ||
+		strings.HasPrefix(lower, "blob:") {
+		return "", url.EscapeError("non-navigable scheme")
+	}
+
+	baseU, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	refU, err := url.Parse(ref)
+	if err != nil {
+		return "", err
+	}
+
+	resolved := baseU.ResolveReference(refU)
+
+	// Only keep HTTP(S) URLs.
+	if resolved.Scheme != "http" && resolved.Scheme != "https" {
+		return "", url.EscapeError("non-http scheme")
+	}
+
+	// Strip fragment for cleaner URLs.
+	resolved.Fragment = ""
+	return resolved.String(), nil
+}

--- a/pkg/crawl/links_test.go
+++ b/pkg/crawl/links_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import "testing"
+
+func TestResolveURL_Absolute(t *testing.T) {
+	got, err := resolveURL("https://example.com/page", "https://example.com/other")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/other" {
+		t.Errorf("got %q, want %q", got, "https://example.com/other")
+	}
+}
+
+func TestResolveURL_Relative(t *testing.T) {
+	got, err := resolveURL("https://example.com/dir/page", "other")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/dir/other" {
+		t.Errorf("got %q, want %q", got, "https://example.com/dir/other")
+	}
+}
+
+func TestResolveURL_RootRelative(t *testing.T) {
+	got, err := resolveURL("https://example.com/dir/page", "/api/users")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/api/users" {
+		t.Errorf("got %q, want %q", got, "https://example.com/api/users")
+	}
+}
+
+func TestResolveURL_ProtocolRelative(t *testing.T) {
+	got, err := resolveURL("https://example.com/page", "//cdn.example.com/asset.js")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://cdn.example.com/asset.js" {
+		t.Errorf("got %q, want %q", got, "https://cdn.example.com/asset.js")
+	}
+}
+
+func TestResolveURL_StripsFragment(t *testing.T) {
+	got, err := resolveURL("https://example.com/page", "/other#section")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/other" {
+		t.Errorf("got %q, want %q", got, "https://example.com/other")
+	}
+}
+
+func TestResolveURL_JavascriptScheme(t *testing.T) {
+	_, err := resolveURL("https://example.com/page", "javascript:void(0)")
+	if err == nil {
+		t.Error("expected error for javascript: URL")
+	}
+}
+
+func TestResolveURL_MailtoScheme(t *testing.T) {
+	_, err := resolveURL("https://example.com/page", "mailto:test@example.com")
+	if err == nil {
+		t.Error("expected error for mailto: URL")
+	}
+}
+
+func TestResolveURL_DataScheme(t *testing.T) {
+	_, err := resolveURL("https://example.com/page", "data:text/html,<h1>hi</h1>")
+	if err == nil {
+		t.Error("expected error for data: URL")
+	}
+}
+
+func TestResolveURL_Empty(t *testing.T) {
+	_, err := resolveURL("https://example.com/page", "")
+	if err == nil {
+		t.Error("expected error for empty reference")
+	}
+}
+
+func TestResolveURL_WhitespaceRef(t *testing.T) {
+	_, err := resolveURL("https://example.com/page", "   ")
+	if err == nil {
+		t.Error("expected error for whitespace-only reference")
+	}
+}
+
+func TestResolveURL_FTPScheme(t *testing.T) {
+	_, err := resolveURL("https://example.com/page", "ftp://files.example.com/data")
+	if err == nil {
+		t.Error("expected error for ftp: URL")
+	}
+}
+
+func TestResolveURL_PreservesQuery(t *testing.T) {
+	got, err := resolveURL("https://example.com/page", "/search?q=test&page=1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://example.com/search?q=test&page=1" {
+		t.Errorf("got %q, want %q", got, "https://example.com/search?q=test&page=1")
+	}
+}
+
+func TestResolveURL_TelScheme(t *testing.T) {
+	_, err := resolveURL("https://example.com/page", "tel:+1234567890")
+	if err == nil {
+		t.Error("expected error for tel: URL")
+	}
+}

--- a/pkg/crawl/network.go
+++ b/pkg/crawl/network.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"encoding/base64"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+)
+
+// pendingRequest tracks a network request that has been sent but whose
+// response has not yet been fully received.
+type pendingRequest struct {
+	method  string
+	url     string
+	headers map[string]string
+	body    string
+
+	// Filled by responseReceived:
+	statusCode  int
+	respHeaders map[string]string
+	contentType string
+
+	// Filled by loadingFinished → getResponseBody:
+	respBody []byte
+	complete bool
+}
+
+// pageNetworkCapture passively captures all network requests and responses on
+// a single page via CDP Network domain events. It correlates request/response
+// pairs by request ID and produces ObservedRequest values.
+type pageNetworkCapture struct {
+	mu      sync.Mutex
+	pending map[proto.NetworkRequestID]*pendingRequest
+	pageURL string
+	page    *rod.Page
+}
+
+// newPageNetworkCapture creates a capture session and wires up CDP event
+// listeners on the given page. The caller must call wait() (returned by
+// setupListeners) after page navigation completes to ensure all events are
+// processed.
+func newPageNetworkCapture(page *rod.Page, pageURL string) (*pageNetworkCapture, func()) {
+	c := &pageNetworkCapture{
+		pending: make(map[proto.NetworkRequestID]*pendingRequest),
+		pageURL: pageURL,
+		page:    page,
+	}
+	wait := c.setupListeners(page)
+	return c, wait
+}
+
+// setupListeners registers CDP event handlers and returns a wait function.
+// The wait function blocks until all registered events resolve. Callers
+// should invoke it in a goroutine; it runs for the lifetime of the page.
+func (c *pageNetworkCapture) setupListeners(page *rod.Page) func() {
+	return page.EachEvent(
+		func(e *proto.NetworkRequestWillBeSent) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			c.pending[e.RequestID] = &pendingRequest{
+				method:  e.Request.Method,
+				url:     e.Request.URL,
+				headers: flattenNetworkHeaders(e.Request.Headers),
+				body:    e.Request.PostData,
+			}
+		},
+		func(e *proto.NetworkResponseReceived) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			req, ok := c.pending[e.RequestID]
+			if !ok {
+				return
+			}
+			req.statusCode = e.Response.Status
+			req.respHeaders = flattenNetworkHeaders(e.Response.Headers)
+			req.contentType = e.Response.MIMEType
+		},
+		func(e *proto.NetworkLoadingFinished) {
+			c.mu.Lock()
+			req, ok := c.pending[e.RequestID]
+			if !ok {
+				c.mu.Unlock()
+				return
+			}
+			c.mu.Unlock()
+
+			// Fetch response body outside the lock — this is a CDP call that
+			// can block. The body may be unavailable (e.g., for redirects or
+			// cached responses); that's fine.
+			body, err := proto.NetworkGetResponseBody{RequestID: e.RequestID}.Call(page)
+			if err == nil && body != nil {
+				var bodyBytes []byte
+				if body.Base64Encoded {
+					decoded, decodeErr := base64.StdEncoding.DecodeString(body.Body)
+					if decodeErr == nil {
+						bodyBytes = decoded
+					}
+				} else {
+					bodyBytes = []byte(body.Body)
+				}
+				c.mu.Lock()
+				req.respBody = bodyBytes
+				req.complete = true
+				c.mu.Unlock()
+			} else {
+				c.mu.Lock()
+				req.complete = true
+				c.mu.Unlock()
+			}
+		},
+	)
+}
+
+// Results returns all captured network exchanges as ObservedRequest values.
+// Call this after navigation and DOM stability wait are complete.
+func (c *pageNetworkCapture) Results() []ObservedRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	results := make([]ObservedRequest, 0, len(c.pending))
+	for _, req := range c.pending {
+		results = append(results, mapNetworkToObservedRequest(req, c.pageURL))
+	}
+	return results
+}
+
+// mapNetworkToObservedRequest converts a captured network exchange to an
+// ObservedRequest, applying body truncation and extracting query parameters.
+func mapNetworkToObservedRequest(req *pendingRequest, pageURL string) ObservedRequest {
+	obs := ObservedRequest{
+		Method:  req.method,
+		URL:     req.url,
+		Headers: req.headers,
+		Body:    truncateBody([]byte(req.body)),
+		Source:  "browser",
+		PageURL: pageURL,
+		Response: ObservedResponse{
+			StatusCode:  req.statusCode,
+			Headers:     req.respHeaders,
+			ContentType: req.contentType,
+			Body:        truncateBody(req.respBody),
+		},
+	}
+
+	if obs.Method == "" {
+		obs.Method = "GET"
+	}
+
+	// Parse query parameters from URL.
+	if obs.URL != "" {
+		if u, err := url.Parse(obs.URL); err == nil {
+			obs.QueryParams = make(map[string]string)
+			for key, values := range u.Query() {
+				if len(values) > 0 {
+					obs.QueryParams[key] = values[0]
+				}
+			}
+		}
+	}
+
+	return obs
+}
+
+// truncateBody returns body truncated to MaxResponseBodySize.
+func truncateBody(body []byte) []byte {
+	if len(body) > MaxResponseBodySize {
+		return body[:MaxResponseBodySize]
+	}
+	return body
+}
+
+// flattenNetworkHeaders converts CDP NetworkHeaders (map[string]gson.JSON) to
+// a simple map[string]string, lowercasing header names for consistency.
+func flattenNetworkHeaders(headers proto.NetworkHeaders) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(headers))
+	for k, v := range headers {
+		result[strings.ToLower(k)] = v.String()
+	}
+	return result
+}

--- a/pkg/crawl/network.go
+++ b/pkg/crawl/network.go
@@ -95,15 +95,21 @@ func (c *pageNetworkCapture) setupListeners(page *rod.Page) func() {
 		func(e *proto.NetworkLoadingFinished) {
 			c.mu.Lock()
 			req, ok := c.pending[e.RequestID]
-			if !ok {
+			if !ok || req.complete {
+				// Not found or already finalized — skip to prevent
+				// duplicate writes from replayed CDP events (H-1 fix).
 				c.mu.Unlock()
 				return
 			}
+			// Mark complete under lock before releasing for the blocking
+			// CDP call. This ensures no other handler can finalize this
+			// request concurrently (H-1 fix).
+			req.complete = true
 			c.mu.Unlock()
 
-			// Fetch response body outside the lock — this is a CDP call that
-			// can block. The body may be unavailable (e.g., for redirects or
-			// cached responses); that's fine.
+			// Fetch response body outside the lock — this is a CDP call
+			// that can block. The body may be unavailable (e.g., for
+			// redirects or cached responses); that's fine.
 			body, err := proto.NetworkGetResponseBody{RequestID: e.RequestID}.Call(page)
 			if err == nil && body != nil {
 				var bodyBytes []byte
@@ -115,13 +121,13 @@ func (c *pageNetworkCapture) setupListeners(page *rod.Page) func() {
 				} else {
 					bodyBytes = []byte(body.Body)
 				}
+				// Truncate at collection time to bound memory usage.
+				// Without this, a hostile page generating many large XHR
+				// responses could exhaust memory (H-3 fix).
+				bodyBytes = truncateBody(bodyBytes)
+
 				c.mu.Lock()
 				req.respBody = bodyBytes
-				req.complete = true
-				c.mu.Unlock()
-			} else {
-				c.mu.Lock()
-				req.complete = true
 				c.mu.Unlock()
 			}
 		},

--- a/pkg/crawl/network.go
+++ b/pkg/crawl/network.go
@@ -78,7 +78,7 @@ func (c *pageNetworkCapture) setupListeners(page *rod.Page) func() {
 				method:  e.Request.Method,
 				url:     e.Request.URL,
 				headers: flattenNetworkHeaders(e.Request.Headers),
-				body:    e.Request.PostData,
+				body:    string(truncateBody([]byte(e.Request.PostData))),
 			}
 		},
 		func(e *proto.NetworkResponseReceived) {
@@ -148,20 +148,22 @@ func (c *pageNetworkCapture) Results() []ObservedRequest {
 }
 
 // mapNetworkToObservedRequest converts a captured network exchange to an
-// ObservedRequest, applying body truncation and extracting query parameters.
+// ObservedRequest and extracts query parameters. Body truncation is applied
+// at collection time (NetworkRequestWillBeSent for request bodies,
+// NetworkLoadingFinished for response bodies), not here.
 func mapNetworkToObservedRequest(req *pendingRequest, pageURL string) ObservedRequest {
 	obs := ObservedRequest{
 		Method:  req.method,
 		URL:     req.url,
 		Headers: req.headers,
-		Body:    truncateBody([]byte(req.body)),
+		Body:    []byte(req.body),
 		Source:  "browser",
 		PageURL: pageURL,
 		Response: ObservedResponse{
 			StatusCode:  req.statusCode,
 			Headers:     req.respHeaders,
 			ContentType: req.contentType,
-			Body:        truncateBody(req.respBody),
+			Body:        req.respBody,
 		},
 	}
 

--- a/pkg/crawl/network_test.go
+++ b/pkg/crawl/network_test.go
@@ -80,24 +80,40 @@ func TestMapNetworkToObservedRequest_EmptyMethod(t *testing.T) {
 	}
 }
 
-func TestMapNetworkToObservedRequest_BodyTruncation(t *testing.T) {
-	largeBody := strings.Repeat("x", MaxResponseBodySize+100)
+func TestMapNetworkToObservedRequest_BodyPassthrough(t *testing.T) {
+	// Bodies are truncated at collection time (in the CDP event handlers),
+	// not in mapNetworkToObservedRequest. Verify the mapping passes
+	// pre-truncated bodies through unchanged.
+	truncatedBody := strings.Repeat("x", MaxResponseBodySize)
 
 	req := &pendingRequest{
 		method:   "GET",
 		url:      "https://example.com/large",
-		respBody: []byte(largeBody),
-		body:     largeBody,
+		respBody: []byte(truncatedBody),
+		body:     truncatedBody,
 		complete: true,
 	}
 
 	obs := mapNetworkToObservedRequest(req, "https://example.com/")
 
 	if len(obs.Response.Body) != MaxResponseBodySize {
-		t.Errorf("Response.Body len = %d, want %d (truncated)", len(obs.Response.Body), MaxResponseBodySize)
+		t.Errorf("Response.Body len = %d, want %d", len(obs.Response.Body), MaxResponseBodySize)
 	}
 	if len(obs.Body) != MaxResponseBodySize {
-		t.Errorf("Body len = %d, want %d (truncated)", len(obs.Body), MaxResponseBodySize)
+		t.Errorf("Body len = %d, want %d", len(obs.Body), MaxResponseBodySize)
+	}
+}
+
+func TestTruncateBody_AtCollectionTime(t *testing.T) {
+	// Verify truncateBody works correctly — this is called in the CDP
+	// event handlers to bound memory at collection time.
+	large := make([]byte, MaxResponseBodySize+500)
+	for i := range large {
+		large[i] = 'x'
+	}
+	got := truncateBody(large)
+	if len(got) != MaxResponseBodySize {
+		t.Errorf("truncateBody(large) len = %d, want %d", len(got), MaxResponseBodySize)
 	}
 }
 

--- a/pkg/crawl/network_test.go
+++ b/pkg/crawl/network_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/ysmood/gson"
+)
+
+func TestMapNetworkToObservedRequest_Normal(t *testing.T) {
+	req := &pendingRequest{
+		method:      "POST",
+		url:         "https://example.com/api/users?page=1&limit=10",
+		headers:     map[string]string{"content-type": "application/json"},
+		body:        `{"name":"Alice"}`,
+		statusCode:  201,
+		respHeaders: map[string]string{"content-type": "application/json"},
+		contentType: "application/json",
+		respBody:    []byte(`{"id":1,"name":"Alice"}`),
+		complete:    true,
+	}
+
+	obs := mapNetworkToObservedRequest(req, "https://example.com/app")
+
+	if obs.Method != "POST" {
+		t.Errorf("Method = %q, want %q", obs.Method, "POST")
+	}
+	if obs.URL != "https://example.com/api/users?page=1&limit=10" {
+		t.Errorf("URL = %q, want original", obs.URL)
+	}
+	if obs.Source != "browser" {
+		t.Errorf("Source = %q, want %q", obs.Source, "browser")
+	}
+	if obs.PageURL != "https://example.com/app" {
+		t.Errorf("PageURL = %q, want %q", obs.PageURL, "https://example.com/app")
+	}
+	if obs.QueryParams["page"] != "1" {
+		t.Errorf("QueryParams[page] = %q, want %q", obs.QueryParams["page"], "1")
+	}
+	if obs.QueryParams["limit"] != "10" {
+		t.Errorf("QueryParams[limit] = %q, want %q", obs.QueryParams["limit"], "10")
+	}
+	if string(obs.Body) != `{"name":"Alice"}` {
+		t.Errorf("Body = %q, want request body", string(obs.Body))
+	}
+	if obs.Response.StatusCode != 201 {
+		t.Errorf("Response.StatusCode = %d, want 201", obs.Response.StatusCode)
+	}
+	if obs.Response.ContentType != "application/json" {
+		t.Errorf("Response.ContentType = %q, want %q", obs.Response.ContentType, "application/json")
+	}
+	if string(obs.Response.Body) != `{"id":1,"name":"Alice"}` {
+		t.Errorf("Response.Body = %q, want response body", string(obs.Response.Body))
+	}
+}
+
+func TestMapNetworkToObservedRequest_EmptyMethod(t *testing.T) {
+	req := &pendingRequest{
+		url: "https://example.com/page",
+	}
+
+	obs := mapNetworkToObservedRequest(req, "https://example.com/")
+	if obs.Method != "GET" {
+		t.Errorf("Method = %q, want %q (default)", obs.Method, "GET")
+	}
+}
+
+func TestMapNetworkToObservedRequest_BodyTruncation(t *testing.T) {
+	largeBody := strings.Repeat("x", MaxResponseBodySize+100)
+
+	req := &pendingRequest{
+		method:   "GET",
+		url:      "https://example.com/large",
+		respBody: []byte(largeBody),
+		body:     largeBody,
+		complete: true,
+	}
+
+	obs := mapNetworkToObservedRequest(req, "https://example.com/")
+
+	if len(obs.Response.Body) != MaxResponseBodySize {
+		t.Errorf("Response.Body len = %d, want %d (truncated)", len(obs.Response.Body), MaxResponseBodySize)
+	}
+	if len(obs.Body) != MaxResponseBodySize {
+		t.Errorf("Body len = %d, want %d (truncated)", len(obs.Body), MaxResponseBodySize)
+	}
+}
+
+func TestMapNetworkToObservedRequest_SmallBody(t *testing.T) {
+	req := &pendingRequest{
+		method:   "GET",
+		url:      "https://example.com/small",
+		respBody: []byte("small response"),
+		complete: true,
+	}
+
+	obs := mapNetworkToObservedRequest(req, "https://example.com/")
+	if string(obs.Response.Body) != "small response" {
+		t.Errorf("Response.Body = %q, want %q", string(obs.Response.Body), "small response")
+	}
+}
+
+func TestMapNetworkToObservedRequest_NoQueryParams(t *testing.T) {
+	req := &pendingRequest{
+		method: "GET",
+		url:    "https://example.com/page",
+	}
+
+	obs := mapNetworkToObservedRequest(req, "https://example.com/")
+	if len(obs.QueryParams) != 0 {
+		t.Errorf("QueryParams = %v, want empty", obs.QueryParams)
+	}
+}
+
+func TestMapNetworkToObservedRequest_NilHeaders(t *testing.T) {
+	req := &pendingRequest{
+		method: "GET",
+		url:    "https://example.com/page",
+	}
+
+	obs := mapNetworkToObservedRequest(req, "https://example.com/")
+	if obs.Headers != nil {
+		t.Errorf("Headers = %v, want nil", obs.Headers)
+	}
+	if obs.Response.Headers != nil {
+		t.Errorf("Response.Headers = %v, want nil", obs.Response.Headers)
+	}
+}
+
+func TestTruncateBody(t *testing.T) {
+	small := []byte("hello")
+	if got := truncateBody(small); string(got) != "hello" {
+		t.Errorf("truncateBody(small) = %q, want %q", string(got), "hello")
+	}
+
+	large := make([]byte, MaxResponseBodySize+500)
+	for i := range large {
+		large[i] = 'x'
+	}
+	if got := truncateBody(large); len(got) != MaxResponseBodySize {
+		t.Errorf("truncateBody(large) len = %d, want %d", len(got), MaxResponseBodySize)
+	}
+
+	if got := truncateBody(nil); got != nil {
+		t.Errorf("truncateBody(nil) = %v, want nil", got)
+	}
+}
+
+func TestFlattenNetworkHeaders(t *testing.T) {
+	headers := proto.NetworkHeaders{
+		"Content-Type":    gson.New("application/json"),
+		"X-Custom-Header": gson.New("value"),
+	}
+
+	flat := flattenNetworkHeaders(headers)
+	if flat["content-type"] != "application/json" {
+		t.Errorf("content-type = %q, want %q", flat["content-type"], "application/json")
+	}
+	if flat["x-custom-header"] != "value" {
+		t.Errorf("x-custom-header = %q, want %q", flat["x-custom-header"], "value")
+	}
+}
+
+func TestFlattenNetworkHeaders_Empty(t *testing.T) {
+	flat := flattenNetworkHeaders(nil)
+	if flat != nil {
+		t.Errorf("flattenNetworkHeaders(nil) = %v, want nil", flat)
+	}
+
+	flat = flattenNetworkHeaders(proto.NetworkHeaders{})
+	if flat != nil {
+		t.Errorf("flattenNetworkHeaders({}) = %v, want nil", flat)
+	}
+}

--- a/pkg/crawl/scope.go
+++ b/pkg/crawl/scope.go
@@ -83,7 +83,8 @@ func registeredDomain(host string) (string, error) {
 	return domain, nil
 }
 
-// normalizeURL strips the fragment and normalizes a URL for deduplication.
+// normalizeURL normalizes a URL for deduplication by lowercasing the scheme
+// and host, stripping fragments, and removing default ports.
 // It returns the empty string for unparseable URLs.
 func normalizeURL(rawURL string) string {
 	u, err := url.Parse(rawURL)
@@ -91,5 +92,15 @@ func normalizeURL(rawURL string) string {
 		return ""
 	}
 	u.Fragment = ""
+	u.Host = strings.ToLower(u.Host)
+	u.Scheme = strings.ToLower(u.Scheme)
+
+	// Remove default ports to avoid treating example.com and example.com:443 as different.
+	hostname := u.Hostname()
+	port := u.Port()
+	if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
+		u.Host = hostname
+	}
+
 	return u.String()
 }

--- a/pkg/crawl/scope.go
+++ b/pkg/crawl/scope.go
@@ -16,25 +16,98 @@ package crawl
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 
 	"golang.org/x/net/publicsuffix"
 )
 
+// privateNetworks defines CIDR ranges considered private or internal.
+// This mirrors the list in pkg/probe/validate.go to provide consistent
+// SSRF protection across both the crawl and probe stages.
+var privateNetworks []*net.IPNet
+
+func init() {
+	cidrs := []string{
+		"127.0.0.0/8",    // IPv4 loopback
+		"10.0.0.0/8",     // RFC 1918
+		"172.16.0.0/12",  // RFC 1918
+		"192.168.0.0/16", // RFC 1918
+		"169.254.0.0/16", // link-local (includes cloud metadata 169.254.169.254)
+		"::1/128",        // IPv6 loopback
+		"fe80::/10",      // IPv6 link-local
+		"fc00::/7",       // IPv6 ULA
+	}
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic("invalid CIDR in privateNetworks: " + cidr)
+		}
+		privateNetworks = append(privateNetworks, network)
+	}
+}
+
+// isPrivateIP reports whether ip falls within a private or internal network.
+func isPrivateIP(ip net.IP) bool {
+	if ip.IsUnspecified() {
+		return true
+	}
+	for _, network := range privateNetworks {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPrivateHost resolves a hostname via DNS and returns true if any of the
+// resolved IPs are private/internal. Also returns true for raw IP addresses
+// in private ranges. This prevents the browser from navigating to internal
+// network endpoints (SSRF protection).
+func isPrivateHost(hostname string) bool {
+	// Check if it's already a raw IP address.
+	if ip := net.ParseIP(hostname); ip != nil {
+		return isPrivateIP(ip)
+	}
+
+	// Resolve and check all addresses.
+	addrs, err := net.LookupHost(hostname)
+	if err != nil {
+		// DNS failure — reject to be safe.
+		return true
+	}
+	for _, addr := range addrs {
+		if ip := net.ParseIP(addr); ip != nil && isPrivateIP(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 // scopeChecker returns a function that checks whether a URL is in scope
-// relative to the seed URL, based on the scope policy.
+// relative to the seed URL, based on the scope policy. Unless allowPrivate
+// is true, URLs that resolve to private/internal IP addresses are rejected
+// to prevent SSRF attacks when the crawl engine runs as a service component.
 //
 // Scope policies:
 //   - "same-origin": exact scheme + host + port match (equivalent to Katana's fqdn)
 //   - "same-domain": registered domain match, allowing subdomains (equivalent to Katana's rdn)
-func scopeChecker(seedURL string, scope string) (func(string) bool, error) {
+func scopeChecker(seedURL string, scope string, allowPrivate bool) (func(string) bool, error) {
 	seed, err := url.Parse(seedURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse seed URL: %w", err)
 	}
 	if seed.Host == "" {
 		return nil, fmt.Errorf("seed URL has no host: %q", seedURL)
+	}
+
+	// ssrfCheck returns false (reject) if the URL resolves to a private IP.
+	ssrfCheck := func(u *url.URL) bool {
+		if allowPrivate {
+			return true
+		}
+		return !isPrivateHost(u.Hostname())
 	}
 
 	switch scope {
@@ -44,33 +117,39 @@ func scopeChecker(seedURL string, scope string) (func(string) bool, error) {
 			return nil, fmt.Errorf("extract registered domain: %w", err)
 		}
 		return func(rawURL string) bool {
-			u, err := url.Parse(rawURL)
-			if err != nil || u.Host == "" {
-				return false
-			}
-			if u.Scheme != "http" && u.Scheme != "https" {
+			u := parseHTTPURL(rawURL)
+			if u == nil {
 				return false
 			}
 			d, err := registeredDomain(u.Hostname())
 			if err != nil {
 				return false
 			}
-			return strings.EqualFold(d, seedDomain)
+			return strings.EqualFold(d, seedDomain) && ssrfCheck(u)
 		}, nil
 
 	default: // "same-origin" and any unknown value
 		seedOrigin := seed.Scheme + "://" + seed.Host
 		return func(rawURL string) bool {
-			u, err := url.Parse(rawURL)
-			if err != nil || u.Host == "" {
+			u := parseHTTPURL(rawURL)
+			if u == nil {
 				return false
 			}
-			if u.Scheme != "http" && u.Scheme != "https" {
-				return false
-			}
-			return (u.Scheme + "://" + u.Host) == seedOrigin
+			return (u.Scheme+"://"+u.Host) == seedOrigin && ssrfCheck(u)
 		}, nil
 	}
+}
+
+// parseHTTPURL parses a URL and returns nil if it is invalid or not HTTP(S).
+func parseHTTPURL(rawURL string) *url.URL {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return nil
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil
+	}
+	return u
 }
 
 // registeredDomain extracts the eTLD+1 (registered domain) from a hostname.

--- a/pkg/crawl/scope.go
+++ b/pkg/crawl/scope.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// scopeChecker returns a function that checks whether a URL is in scope
+// relative to the seed URL, based on the scope policy.
+//
+// Scope policies:
+//   - "same-origin": exact scheme + host + port match (equivalent to Katana's fqdn)
+//   - "same-domain": registered domain match, allowing subdomains (equivalent to Katana's rdn)
+func scopeChecker(seedURL string, scope string) (func(string) bool, error) {
+	seed, err := url.Parse(seedURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse seed URL: %w", err)
+	}
+	if seed.Host == "" {
+		return nil, fmt.Errorf("seed URL has no host: %q", seedURL)
+	}
+
+	switch scope {
+	case "same-domain":
+		seedDomain, err := registeredDomain(seed.Hostname())
+		if err != nil {
+			return nil, fmt.Errorf("extract registered domain: %w", err)
+		}
+		return func(rawURL string) bool {
+			u, err := url.Parse(rawURL)
+			if err != nil || u.Host == "" {
+				return false
+			}
+			if u.Scheme != "http" && u.Scheme != "https" {
+				return false
+			}
+			d, err := registeredDomain(u.Hostname())
+			if err != nil {
+				return false
+			}
+			return strings.EqualFold(d, seedDomain)
+		}, nil
+
+	default: // "same-origin" and any unknown value
+		seedOrigin := seed.Scheme + "://" + seed.Host
+		return func(rawURL string) bool {
+			u, err := url.Parse(rawURL)
+			if err != nil || u.Host == "" {
+				return false
+			}
+			if u.Scheme != "http" && u.Scheme != "https" {
+				return false
+			}
+			return (u.Scheme + "://" + u.Host) == seedOrigin
+		}, nil
+	}
+}
+
+// registeredDomain extracts the eTLD+1 (registered domain) from a hostname.
+// For example, "api.example.com" returns "example.com".
+func registeredDomain(host string) (string, error) {
+	domain, err := publicsuffix.EffectiveTLDPlusOne(host)
+	if err != nil {
+		return "", err
+	}
+	return domain, nil
+}
+
+// normalizeURL strips the fragment and normalizes a URL for deduplication.
+// It returns the empty string for unparseable URLs.
+func normalizeURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	u.Fragment = ""
+	return u.String()
+}

--- a/pkg/crawl/scope_test.go
+++ b/pkg/crawl/scope_test.go
@@ -147,6 +147,11 @@ func TestNormalizeURL(t *testing.T) {
 		{"preserves query", "https://example.com/page?q=1#frag", "https://example.com/page?q=1"},
 		{"empty string", "", ""},
 		{"root path", "https://example.com/", "https://example.com/"},
+		{"lowercases host", "https://Example.COM/Page", "https://example.com/Page"},
+		{"lowercases scheme", "HTTP://example.com/page", "http://example.com/page"},
+		{"removes default https port", "https://example.com:443/page", "https://example.com/page"},
+		{"removes default http port", "http://example.com:80/page", "http://example.com/page"},
+		{"preserves non-default port", "https://example.com:8443/page", "https://example.com:8443/page"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/crawl/scope_test.go
+++ b/pkg/crawl/scope_test.go
@@ -14,10 +14,13 @@
 
 package crawl
 
-import "testing"
+import (
+	"net"
+	"testing"
+)
 
 func TestScopeChecker_SameOrigin(t *testing.T) {
-	check, err := scopeChecker("https://example.com", "same-origin")
+	check, err := scopeChecker("https://example.com", "same-origin", true)
 	if err != nil {
 		t.Fatalf("scopeChecker error: %v", err)
 	}
@@ -51,7 +54,7 @@ func TestScopeChecker_SameOrigin(t *testing.T) {
 }
 
 func TestScopeChecker_SameOriginWithPort(t *testing.T) {
-	check, err := scopeChecker("https://example.com:8443", "same-origin")
+	check, err := scopeChecker("https://example.com:8443", "same-origin", true)
 	if err != nil {
 		t.Fatalf("scopeChecker error: %v", err)
 	}
@@ -77,7 +80,7 @@ func TestScopeChecker_SameOriginWithPort(t *testing.T) {
 }
 
 func TestScopeChecker_SameDomain(t *testing.T) {
-	check, err := scopeChecker("https://www.example.com", "same-domain")
+	check, err := scopeChecker("https://www.example.com", "same-domain", true)
 	if err != nil {
 		t.Fatalf("scopeChecker error: %v", err)
 	}
@@ -108,21 +111,21 @@ func TestScopeChecker_SameDomain(t *testing.T) {
 }
 
 func TestScopeChecker_InvalidSeedURL(t *testing.T) {
-	_, err := scopeChecker("://bad", "same-origin")
+	_, err := scopeChecker("://bad", "same-origin", true)
 	if err == nil {
 		t.Error("expected error for invalid seed URL")
 	}
 }
 
 func TestScopeChecker_EmptySeedHost(t *testing.T) {
-	_, err := scopeChecker("not-a-url", "same-origin")
+	_, err := scopeChecker("not-a-url", "same-origin", true)
 	if err == nil {
 		t.Error("expected error for seed URL without host")
 	}
 }
 
 func TestScopeChecker_UnknownScopeDefaultsToSameOrigin(t *testing.T) {
-	check, err := scopeChecker("https://example.com", "unknown-scope")
+	check, err := scopeChecker("https://example.com", "unknown-scope", true)
 	if err != nil {
 		t.Fatalf("scopeChecker error: %v", err)
 	}
@@ -194,5 +197,92 @@ func TestRegisteredDomain(t *testing.T) {
 				t.Errorf("registeredDomain(%q) = %q, want %q", tt.host, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{"loopback v4", "127.0.0.1", true},
+		{"loopback v4 other", "127.0.0.2", true},
+		{"RFC1918 10.x", "10.0.0.1", true},
+		{"RFC1918 172.16.x", "172.16.0.1", true},
+		{"RFC1918 192.168.x", "192.168.1.1", true},
+		{"link-local", "169.254.169.254", true},
+		{"loopback v6", "::1", true},
+		{"public IP", "93.184.215.14", false},
+		{"public IP 2", "8.8.8.8", false},
+		{"unspecified v4", "0.0.0.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse IP %q", tt.ip)
+			}
+			got := isPrivateIP(ip)
+			if got != tt.want {
+				t.Errorf("isPrivateIP(%q) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPrivateHost_RawIPs(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{"loopback", "127.0.0.1", true},
+		{"cloud metadata", "169.254.169.254", true},
+		{"RFC1918", "10.0.0.1", true},
+		{"public", "93.184.215.14", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPrivateHost(tt.host)
+			if got != tt.want {
+				t.Errorf("isPrivateHost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopeChecker_SSRFProtection_RejectsPrivateIPs(t *testing.T) {
+	check, err := scopeChecker("http://127.0.0.1:8080", "same-origin", false)
+	if err != nil {
+		t.Fatalf("scopeChecker error: %v", err)
+	}
+
+	if check("http://127.0.0.1:8080/api/users") {
+		t.Error("expected SSRF protection to reject loopback URL")
+	}
+}
+
+func TestScopeChecker_SSRFProtection_AllowPrivateBypass(t *testing.T) {
+	check, err := scopeChecker("http://127.0.0.1:8080", "same-origin", true)
+	if err != nil {
+		t.Fatalf("scopeChecker error: %v", err)
+	}
+
+	if !check("http://127.0.0.1:8080/api/users") {
+		t.Error("expected allowPrivate=true to permit loopback URL")
+	}
+}
+
+func TestScopeChecker_SSRFProtection_RejectsMetadataIP(t *testing.T) {
+	check, err := scopeChecker("http://169.254.169.254", "same-origin", false)
+	if err != nil {
+		t.Fatalf("scopeChecker error: %v", err)
+	}
+
+	if check("http://169.254.169.254/latest/meta-data/") {
+		t.Error("expected SSRF protection to reject cloud metadata IP")
 	}
 }

--- a/pkg/crawl/scope_test.go
+++ b/pkg/crawl/scope_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import "testing"
+
+func TestScopeChecker_SameOrigin(t *testing.T) {
+	check, err := scopeChecker("https://example.com", "same-origin")
+	if err != nil {
+		t.Fatalf("scopeChecker error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"exact match", "https://example.com/api/users", true},
+		{"with path and query", "https://example.com/page?q=1", true},
+		{"root", "https://example.com/", true},
+		{"different scheme", "http://example.com/api", false},
+		{"different host", "https://other.com/api", false},
+		{"subdomain", "https://api.example.com/data", false},
+		{"with port vs no port", "https://example.com:8443/api", false},
+		{"empty string", "", false},
+		{"javascript url", "javascript:void(0)", false},
+		{"mailto", "mailto:test@example.com", false},
+		{"data url", "data:text/html,<h1>hi</h1>", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := check(tt.url)
+			if got != tt.want {
+				t.Errorf("scopeCheck(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopeChecker_SameOriginWithPort(t *testing.T) {
+	check, err := scopeChecker("https://example.com:8443", "same-origin")
+	if err != nil {
+		t.Fatalf("scopeChecker error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"same port", "https://example.com:8443/api", true},
+		{"different port", "https://example.com:9443/api", false},
+		{"no port", "https://example.com/api", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := check(tt.url)
+			if got != tt.want {
+				t.Errorf("scopeCheck(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopeChecker_SameDomain(t *testing.T) {
+	check, err := scopeChecker("https://www.example.com", "same-domain")
+	if err != nil {
+		t.Fatalf("scopeChecker error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"exact match", "https://www.example.com/api", true},
+		{"subdomain", "https://api.example.com/data", true},
+		{"different subdomain", "https://cdn.example.com/asset.js", true},
+		{"bare domain", "https://example.com/", true},
+		{"http scheme allowed", "http://example.com/api", true},
+		{"different domain", "https://other.com/api", false},
+		{"similar suffix", "https://notexample.com/api", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := check(tt.url)
+			if got != tt.want {
+				t.Errorf("scopeCheck(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopeChecker_InvalidSeedURL(t *testing.T) {
+	_, err := scopeChecker("://bad", "same-origin")
+	if err == nil {
+		t.Error("expected error for invalid seed URL")
+	}
+}
+
+func TestScopeChecker_EmptySeedHost(t *testing.T) {
+	_, err := scopeChecker("not-a-url", "same-origin")
+	if err == nil {
+		t.Error("expected error for seed URL without host")
+	}
+}
+
+func TestScopeChecker_UnknownScopeDefaultsToSameOrigin(t *testing.T) {
+	check, err := scopeChecker("https://example.com", "unknown-scope")
+	if err != nil {
+		t.Fatalf("scopeChecker error: %v", err)
+	}
+
+	// Same-origin behavior: subdomain should be rejected
+	if check("https://api.example.com/data") {
+		t.Error("unknown scope should default to same-origin (reject subdomains)")
+	}
+	if !check("https://example.com/api") {
+		t.Error("unknown scope should default to same-origin (accept same host)")
+	}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"strips fragment", "https://example.com/page#section", "https://example.com/page"},
+		{"no fragment unchanged", "https://example.com/page", "https://example.com/page"},
+		{"preserves query", "https://example.com/page?q=1#frag", "https://example.com/page?q=1"},
+		{"empty string", "", ""},
+		{"root path", "https://example.com/", "https://example.com/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeURL(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegisteredDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		want    string
+		wantErr bool
+	}{
+		{"simple domain", "example.com", "example.com", false},
+		{"subdomain", "api.example.com", "example.com", false},
+		{"deep subdomain", "a.b.c.example.com", "example.com", false},
+		{"co.uk domain", "www.example.co.uk", "example.co.uk", false},
+		{"bare TLD", "com", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := registeredDomain(tt.host)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("registeredDomain(%q) expected error, got %q", tt.host, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("registeredDomain(%q) unexpected error: %v", tt.host, err)
+			}
+			if got != tt.want {
+				t.Errorf("registeredDomain(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Replaces Katana's serial headless crawl loop with a concurrent go-rod engine that runs 10 browser tabs in parallel (configurable via `--concurrency`). Katana processed URLs one at a time with a ~3s DOM stability wait per page — the new engine overlaps these waits, achieving a **7.5x speedup** on benchmarks (67s → 9s on the REST test target).

Katana's `standard.Engine` is retained for `--headless=false` — full Katana removal is a separate ticket.

## Changes

- **Concurrent crawl engine** (`pkg/crawl/engine.go`): go-rod worker pool with CDP network interception
- **URL frontier** (`pkg/crawl/frontier.go`): thread-safe queue with dedup, scope filtering, depth tracking
- **jsluice integration** (`pkg/crawl/jsextract.go`): JS AST parsing of external and inline scripts for endpoint discovery
- **Form discovery** (`pkg/crawl/forms.go`): extracts forms and emits synthetic POST requests
- **SSRF protection** (`pkg/crawl/scope.go`): DNS-resolution-based private IP blocking, critical for Guard platform deployments
- **New CLI flag**: `--concurrency` (default 10, max 50)

## Security

Passed backend security review. All HIGH findings addressed:
- H-1: Race condition in CDP event handler — fixed with atomic complete flag
- H-2: SSRF on crawled URLs — added private IP blocklist with DNS resolution
- H-3: Unbounded response body — truncation at collection time

## Test plan

- [ ] `make check` passes (fmt, vet, lint, test with `-race`)
- [ ] 8/8 expected REST API paths discovered against built-in test target
- [ ] 7.5x speedup verified: 67s (Katana) → 9s (go-rod) on same target
- [ ] E2E scan against snyk.io produces valid OpenAPI spec
- [ ] SSRF tests verify private IP rejection and `--dangerous-allow-private` bypass