### PR TITLE
ci: migrate to centralized go-ci.yml reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,90 +5,17 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Build
-        run: go build -trimpath -ldflags "-s -w" ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Test
-        run: make coverage
-
-      - name: Check coverage threshold
-        run: |
-          set -euo pipefail
-          total=$(go tool cover -func=coverage.out | grep '^total:' | awk '{print $3}' | tr -d '%')
-          if [ -z "$total" ]; then
-            echo "ERROR: could not parse coverage from coverage.out"
-            exit 1
-          fi
-          echo "Total coverage: ${total}%"
-          threshold=80
-          awk -v cov="$total" -v thr="$threshold" 'BEGIN { if (cov+0 < thr+0) { printf "FAIL: coverage %.1f%% < %d%% threshold\n", cov, thr; exit 1 } }'
-
-      - name: Upload coverage
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage
-          path: coverage.out
-          retention-days: 7
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.10.1
-
-  fmt:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Check formatting
-        run: |
-          unformatted=$(gofmt -s -l .)
-          if [ -n "$unformatted" ]; then
-            echo "Files not formatted:"
-            echo "$unformatted"
-            exit 1
-          fi
+  ci:
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@f89bda45e8073b1b6ac20198164de2b71ebf0c69  # v1.0.2
+    permissions:
+      contents: read
+    with:
+      build-cmd-path: ./cmd/vespasian
+      build-binary-name: vespasian
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,13 @@ permissions:
 
 jobs:
   ci:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@f89bda45e8073b1b6ac20198164de2b71ebf0c69  # v1.0.2
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@1073478d5f4a99443b302f174f25e84ac4655e59  # v1.0.3
     permissions:
       contents: read
     with:
       build-cmd-path: ./cmd/vespasian
       build-binary-name: vespasian
+      build-cgo-enabled: "1"
+      build-matrix-os: '["linux"]'
+      build-matrix-arch: '["amd64"]'
     secrets: inherit


### PR DESCRIPTION
## Summary

Migrates vespasian's CI to centralized `go-ci.yml@v1.0.2` ([ENG-3092](https://linear.app/praetorianlabs/issue/ENG-3092)).

Inline ci.yml → 18-line caller. Build path `./cmd/vespasian`.

external-contribution.yml, release.yml unchanged.