### PR TITLE
ci: migrate external-contribution.yml to centralized reusable workflow

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -6,23 +6,7 @@ on:
   pull_request_target:
     types: [opened, assigned, closed]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   notify:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: praetorian-inc/external-contrib-action@v2
-        with:
-          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
-          linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
-          linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
-          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          dry-run: "false"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@4900fbd3aaf1992181e2ebfb108c71fee8250c67  # v2.0.1
+    secrets: inherit


### PR DESCRIPTION
Migrates `.github/workflows/external-contribution.yml` from the old standalone `praetorian-inc/external-contrib-action@v2` (which requires a repo-level `ORG_MEMBER_CHECK_PAT` secret) to the centralized `praetorian-inc/public-workflows/external-contrib-notify.yml@v2.0.1` reusable workflow.

## Why

The old action errored with `ORG_MEMBER_CHECK_PAT environment variable is required` because that repo-level PAT secret isn't set. The centralized reusable workflow replaces the PAT with an org-level GitHub App (`EXTERNAL_CONTRIB_APP_ID` / `EXTERNAL_CONTRIB_APP_PRIVATE_KEY`) that's already provisioned at the org level. `secrets: inherit` forwards everything the reusable workflow needs; no per-repo secret plumbing.

## Test plan

- [ ] On this PR (external contribution from outside org or internal PR), the notify job runs without the PAT error
- [ ] Linear issue + Slack notification appear if this PR qualifies as external

Part of ENG-3079 supply-chain hardening rollout.