### PR TITLE
chore(ci): harden claude-code workflow (pin SHA + read-only + concurrency)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -2,15 +2,19 @@ name: Claude PR Assistant
 
 on:
   pull_request:
-    types: [synchronize, opened]
+    types: [opened, synchronize, reopened]
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: claude-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@main
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@4900fbd3aaf1992181e2ebfb108c71fee8250c67  # v2.0.1
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Addresses reviewer feedback on the earlier claude-code rollout. See full context on pius or hadrian for rationale.

Changes:
- SHA-pin public-workflows/claude-code.yml to 4900fbd3 (v2.0.1) — was @main
- contents: read (review-only)
- concurrency group with cancel-in-progress
- add 'reopened' trigger

Related: ENG-3081 SHA-pin policy.