### PR TITLE
fix(ci): bump go-security.yml pin to v2.0.2

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@a2b8d84dbc6aa0136dabf4ce5dda0fe28b6bf407  # v1.1.2
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
One-line pin bump to pick up the latest public-workflows main ([SHA `faa2e42`](https://github.com/praetorian-inc/public-workflows/commit/faa2e42989736cf9b3f47e5377dd5f2e0327517f), tag `v2.0.2`).

**What's included since the last bump on this repo:**
- v1.1.1 — pinned `go install` for gosec/govulncheck (avoids org action allowlist)
- v2.0.1 — govulncheck SARIF robustness (empty-output fallback, exit-3 tolerance)
- v2.0.2 — codeql-action/upload-sarif v4 (Node 24) + SHA-pin all actions ([ENG-3093](https://github.com/praetorian-inc/public-workflows/pull/16))

Note: `v1.1.2` was deleted; it came chronologically after `v2.0.0`/`v2.0.1` and broke monotonic semver. `v2.0.2` supersedes it at a newer commit.