### PR TITLE
chore(ci): harden claude-code workflow (v2.0.2)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@4900fbd3aaf1992181e2ebfb108c71fee8250c67  # v2.0.1
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Supersedes #75. Same caller-visible changes as the prior PR (SHA pin, `contents: read`, concurrency, `reopened` trigger) but pinning to **v2.0.2** of `public-workflows/claude-code.yml` (commit `faa2e429...`).

v2.0.2 adds SHA-pinning of the reusable workflow's own internal actions — most importantly, replaces `anthropics/claude-code-action@beta` (a branch pin that runs with `ANTHROPIC_API_KEY` loaded) with an immutable SHA. Closes ENG-3093. No caller-visible behavior difference from v2.0.1.

Related: ENG-3081 SHA-pin policy, ENG-3093 (public-workflows internal hardening).