### PR TITLE
fix(ci): add actions: read + bump go-security.yml to v2.0.12

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,8 +14,9 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@e7c1f39e9219a3256df321445d558e18cf3027c0  # v2.0.11
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@646324637b20a47d2fcf70623cf1dcafa4880ed3  # v2.0.12
     permissions:
       contents: read
       security-events: write
+      actions: read           # required by codeql-action/upload-sarif for run metadata
     secrets: inherit


### PR DESCRIPTION
Adds `actions: read` permission to the `security` job and bumps the `go-security.yml` pin to v2.0.12 (`646324637b20a47d2fcf70623cf1dcafa4880ed3`).

## Why

`codeql-action/upload-sarif` (used by v2.0.12's gosec + govulncheck jobs) calls `GET /repos/{owner}/{repo}/actions/runs/{run_id}` for run metadata and telemetry. Without `actions: read` at the caller's job level, the SARIF upload step fails with "Resource not accessible by integration" even though the scans themselves succeed.

Pre-existing silent failure — findings never reached the Security tab. Upstream fix: [praetorian-inc/public-workflows#29](https://github.com/praetorian-inc/public-workflows/pull/29). GitHub's permission cascade requires the caller to ALSO grant `actions: read` (a reusable workflow's job can only hold permissions its caller granted).