### PR TITLE
fix(test): pass --dangerous-allow-private for localhost crawls (LAB-2308)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,8 @@ The `test/` directory contains live test targets:
 - **test/soap-service/**: Go HTTP server exposing SOAP/WSDL endpoints
 - **test/graphql-server/**: Node.js GraphQL server with Apollo
 
+See `test/README.md` for how to run the suite, including the `TEST_HOST` override for devcontainer setups.
+
 ## Code Conventions
 
 - Go file naming: lowercase with underscores (e.g., `rest_classifier.go`, not `restClassifier.go`)

--- a/test/README.md
+++ b/test/README.md
@@ -300,13 +300,13 @@ brew install --cask google-chrome
 
 ### Crawl produces empty capture
 
-Ensure the target service is running and healthy:
+Ensure the target service is running and healthy. Run the check from the host that started the services (`setup-live-targets.sh` binds to localhost there):
 
 ```bash
 curl http://localhost:8990/api/health
 ```
 
-If you're running the harness inside a devcontainer and the targets are on the host, set `TEST_HOST` (see Configuration above). Without it, the crawler's SSRF guard rejects the seed URL and the capture is empty.
+If you're running the harness inside a devcontainer and the targets are on the host, set `TEST_HOST` (see Configuration above) and verify connectivity from inside the container with `curl http://${TEST_HOST}:8990/api/health`. Without `TEST_HOST`, the crawler's SSRF guard rejects the seed URL and the capture is empty.
 
 ### Build failures
 

--- a/test/README.md
+++ b/test/README.md
@@ -99,6 +99,22 @@ Options:
 
 ## Configuration
 
+### `TEST_HOST` (optional)
+
+`run-live-tests.sh` reaches the target services at `http://${TEST_HOST:-localhost}:<port>`. The default (`localhost`) is correct when the harness and the targets run on the same host.
+
+Override `TEST_HOST` when the harness runs inside a devcontainer while the target services run on the Docker host. Example (Docker Desktop):
+
+```bash
+TEST_HOST=host.docker.internal ./test/run-live-tests.sh --targets rest-api
+```
+
+For Linux devcontainers without Docker Desktop, use the detected host gateway (e.g. the address of the `docker0` bridge or whatever name resolves to the host from inside the container).
+
+`setup-live-targets.sh` does not read `TEST_HOST` — run it on the host that actually runs the target binaries.
+
+### `.live-test-config`
+
 The setup script writes `.live-test-config` with resolved ports:
 
 ```
@@ -289,6 +305,8 @@ Ensure the target service is running and healthy:
 ```bash
 curl http://localhost:8990/api/health
 ```
+
+If you're running the harness inside a devcontainer and the targets are on the host, set `TEST_HOST` (see Configuration above). Without it, the crawler's SSRF guard rejects the seed URL and the capture is empty.
 
 ### Build failures
 

--- a/test/README.md
+++ b/test/README.md
@@ -306,7 +306,7 @@ Ensure the target service is running and healthy. Run the check from the host th
 curl http://localhost:8990/api/health
 ```
 
-If you're running the harness inside a devcontainer and the targets are on the host, set `TEST_HOST` (see Configuration above) and verify connectivity from inside the container with `curl http://${TEST_HOST}:8990/api/health`. Without `TEST_HOST`, the crawler's SSRF guard rejects the seed URL and the capture is empty.
+If you're running the harness inside a devcontainer and the targets are on the host, set `TEST_HOST` (see Configuration above) and verify connectivity from inside the container with `curl http://${TEST_HOST}:8990/api/health`. Without `TEST_HOST`, `localhost` resolves to the container's own loopback (not the Docker host), the crawler connects to nothing, and the capture is empty.
 
 ### Build failures
 

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -60,6 +60,25 @@ load_config() {
     log_ok "Loaded config from ${CONFIG_FILE}"
 }
 
+# Verify the harness can reach rest-api at TEST_HOST. A misconfigured TEST_HOST
+# (typical for devcontainer users who forgot to set it) otherwise surfaces as
+# mysterious empty captures downstream.
+preflight_test_host() {
+    local port="${REST_API_PORT:-}"
+    [ -z "$port" ] && return 0
+    local url="http://${TEST_HOST}:${port}/api/health"
+    if ! curl -sf -o /dev/null --max-time 5 "$url" 2>/dev/null; then
+        log_fail "rest-api is unreachable at ${url}"
+        if [ "$TEST_HOST" = "localhost" ]; then
+            log_info "Is ./test/setup-live-targets.sh running? Check 'curl ${url}' on this host."
+        else
+            log_info "TEST_HOST=${TEST_HOST} cannot reach the target. For a devcontainer on Docker Desktop try TEST_HOST=host.docker.internal."
+        fi
+        exit 1
+    fi
+    log_ok "rest-api reachable at ${url}"
+}
+
 # ──────────────────────────────────────────────────────────────
 # Result tracking
 # ──────────────────────────────────────────────────────────────
@@ -223,6 +242,8 @@ test_soap_service() {
 
     # Step 1: Crawl the SOAP service
     # First, make some SOAP requests to generate traffic for the capture.
+    # Note: xmlns:tns="http://localhost/soap" is a SOAP target-namespace
+    # identifier (not a URL), so it stays literal regardless of TEST_HOST.
     log_info "Generating SOAP traffic..."
     for action in GetUser ListUsers CreateUser; do
         curl -sf -X POST "${base_url}/soap" \
@@ -1157,7 +1178,10 @@ test_crawl_unreachable() {
 
     log_header "Testing: crawl-unreachable (target not running)"
 
-    # Crawl a port where nothing is listening
+    # Crawl a port where nothing is listening.
+    # Intentionally hardcoded to localhost:19999 regardless of TEST_HOST — this
+    # test asserts graceful behavior against an unreachable target, which is
+    # easier to guarantee on the in-container loopback than on the host gateway.
     log_info "Crawling unreachable target (http://localhost:19999)..."
     local crawl_output
     crawl_output=$("$VESPASIAN" crawl "http://localhost:19999" \
@@ -1453,7 +1477,6 @@ PYEOF
 
 test_classifier_edge_cases() {
     local port="${REST_API_PORT:-8990}"
-    local base_url="http://${TEST_HOST}:${port}"
     local target_dir="${RESULTS_DIR}/classifier-edge"
     local verbose_flag=""
 
@@ -1937,6 +1960,7 @@ main() {
 
     # Load config
     load_config
+    preflight_test_host
 
     # Default targets from config
     if [ -z "$targets" ]; then

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -297,10 +297,10 @@ test_soap_service() {
     # For SOAP testing, we create a synthetic capture with the SOAP requests.
     log_info "Creating SOAP capture with direct requests..."
     local soap_capture="${target_dir}/soap-capture.json"
-    python3 - "$port" "$soap_capture" << 'PYEOF' 2>/dev/null
+    python3 - "$base_url" "$soap_capture" << 'PYEOF' 2>/dev/null
 import json, base64, sys
 
-port = sys.argv[1]
+base_url = sys.argv[1].rstrip('/')
 outfile = sys.argv[2]
 
 def b64(s):
@@ -312,7 +312,7 @@ for action in ['GetUser', 'ListUsers', 'CreateUser']:
     resp_body = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><tns:%sResponse xmlns:tns="http://localhost/soap"><id>1</id></tns:%sResponse></soap:Body></soap:Envelope>' % (action, action)
     req = {
         'method': 'POST',
-        'url': 'http://localhost:%s/soap' % port,
+        'url': base_url + '/soap',
         'headers': {
             'Content-Type': 'text/xml; charset=utf-8',
             'SOAPAction': 'urn:%s' % action
@@ -331,7 +331,7 @@ for action in ['GetUser', 'ListUsers', 'CreateUser']:
 # Also add the WSDL fetch
 requests.append({
     'method': 'GET',
-    'url': 'http://localhost:%s/service.wsdl' % port,
+    'url': base_url + '/service.wsdl',
     'headers': {},
     'response': {
         'status_code': 200,
@@ -1211,15 +1211,17 @@ test_crawl_unreachable() {
     # test asserts graceful behavior against an unreachable target, which is
     # easier to guarantee on the in-container loopback than on the host gateway.
     log_info "Crawling unreachable target (http://localhost:19999)..."
-    local crawl_output
+    # Capture exit code explicitly: under `set -euo pipefail`, relying on $? after
+    # a multi-line command substitution assignment is fragile. Pre-init and use
+    # `|| crawl_exit=$?` so the non-zero path is always recorded.
+    local crawl_output crawl_exit=0
     crawl_output=$("$VESPASIAN" crawl "http://localhost:19999" \
         -o "$capture_file" \
         --depth 1 \
         --max-pages 5 \
         --timeout 15s \
         --dangerous-allow-private \
-        $verbose_flag 2>&1)
-    local crawl_exit=$?
+        $verbose_flag 2>&1) || crawl_exit=$?
 
     # Either the crawl fails with non-zero exit, or it succeeds with 0 results.
     # Either is acceptable — what matters is no crash/panic.

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -22,6 +22,12 @@ CONFIG_FILE="${SCRIPT_DIR}/.live-test-config"
 RESULTS_DIR="${SCRIPT_DIR}/.results"
 VESPASIAN="${PROJECT_ROOT}/bin/vespasian"
 
+# Hostname the test harness uses to reach the target services. Defaults to
+# "localhost" for host-only runs. Set TEST_HOST=host.docker.internal (or the
+# devcontainer's detected host gateway) when the harness runs inside a
+# devcontainer while the target services run on the Docker host.
+TEST_HOST="${TEST_HOST:-localhost}"
+
 # Source shared colors, logging, and validation functions
 # shellcheck source=common.sh
 source "${SCRIPT_DIR}/common.sh"
@@ -117,7 +123,7 @@ PYEOF
 
 test_rest_api() {
     local port="${REST_API_PORT:-8990}"
-    local base_url="http://localhost:${port}"
+    local base_url="http://${TEST_HOST}:${port}"
     local target_dir="${RESULTS_DIR}/rest-api"
     local capture_file="${target_dir}/capture.json"
     local spec_file="${target_dir}/spec.yaml"
@@ -141,6 +147,7 @@ test_rest_api() {
         --depth 2 \
         --max-pages 50 \
         --timeout 2m \
+        --dangerous-allow-private \
         $verbose_flag 2>&1; then
         log_fail "Crawl failed"
         set_test_result "rest-api" "FAIL" "?" "?" "$((SECONDS - start))"
@@ -197,7 +204,7 @@ test_rest_api() {
 
 test_soap_service() {
     local port="${SOAP_SERVICE_PORT:-8991}"
-    local base_url="http://localhost:${port}"
+    local base_url="http://${TEST_HOST}:${port}"
     local target_dir="${RESULTS_DIR}/soap-service"
     local capture_file="${target_dir}/capture.json"
     local spec_file="${target_dir}/spec.xml"
@@ -218,7 +225,7 @@ test_soap_service() {
     # First, make some SOAP requests to generate traffic for the capture.
     log_info "Generating SOAP traffic..."
     for action in GetUser ListUsers CreateUser; do
-        curl -sf -X POST "http://localhost:${port}/soap" \
+        curl -sf -X POST "${base_url}/soap" \
             -H "Content-Type: text/xml; charset=utf-8" \
             -H "SOAPAction: \"urn:${action}\"" \
             -d "<?xml version=\"1.0\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"><soap:Body><tns:${action}Request xmlns:tns=\"http://localhost/soap\"><id>1</id></tns:${action}Request></soap:Body></soap:Envelope>" \
@@ -232,6 +239,7 @@ test_soap_service() {
         --depth 2 \
         --max-pages 20 \
         --timeout 1m \
+        --dangerous-allow-private \
         $verbose_flag 2>&1; then
         log_warn "Crawl returned non-zero (may still have partial results)"
     fi
@@ -539,7 +547,7 @@ test_generate_wsdl() {
 
 test_graphql_server() {
     local port="${GRAPHQL_SERVER_PORT:-8992}"
-    local base_url="http://localhost:${port}"
+    local base_url="http://${TEST_HOST}:${port}"
     local target_dir="${RESULTS_DIR}/graphql-server"
     local capture_file="${target_dir}/capture.json"
     local spec_file="${target_dir}/spec.graphql"
@@ -946,7 +954,7 @@ test_import_empty() {
 
 test_edge_cases() {
     local port="${REST_API_PORT:-8990}"
-    local base_url="http://localhost:${port}"
+    local base_url="http://${TEST_HOST}:${port}"
     local target_dir="${RESULTS_DIR}/edge-cases"
     local verbose_flag=""
 
@@ -1085,6 +1093,7 @@ test_edge_cases() {
         --depth 3 \
         --max-pages 200 \
         --timeout 3m \
+        --dangerous-allow-private \
         $verbose_flag 2>&1; then
         log_ok "Crawl with edge cases: completed without crash"
 
@@ -1156,6 +1165,7 @@ test_crawl_unreachable() {
         --depth 1 \
         --max-pages 5 \
         --timeout 15s \
+        --dangerous-allow-private \
         $verbose_flag 2>&1)
     local crawl_exit=$?
 
@@ -1343,7 +1353,7 @@ test_import_duplicates() {
 
 test_crawl_depth() {
     local port="${REST_API_PORT:-8990}"
-    local base_url="http://localhost:${port}"
+    local base_url="http://${TEST_HOST}:${port}"
     local target_dir="${RESULTS_DIR}/crawl-depth"
     local verbose_flag=""
 
@@ -1365,6 +1375,7 @@ test_crawl_depth() {
         --depth 2 \
         --max-pages 50 \
         --timeout 1m \
+        --dangerous-allow-private \
         $verbose_flag 2>&1; then
 
         # Should have levels 1-2, but not 3+
@@ -1395,6 +1406,7 @@ PYEOF
         --depth 2 \
         --max-pages 10 \
         --timeout 1m \
+        --dangerous-allow-private \
         $verbose_flag 2>&1; then
 
         local page_count
@@ -1418,6 +1430,7 @@ PYEOF
         --depth 3 \
         --max-pages 20 \
         --timeout 30s \
+        --dangerous-allow-private \
         $verbose_flag 2>&1; then
         log_ok "Loop detection: crawl completed (did not hang)"
     else
@@ -1440,7 +1453,7 @@ PYEOF
 
 test_classifier_edge_cases() {
     local port="${REST_API_PORT:-8990}"
-    local base_url="http://localhost:${port}"
+    local base_url="http://${TEST_HOST}:${port}"
     local target_dir="${RESULTS_DIR}/classifier-edge"
     local verbose_flag=""
 

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -63,20 +63,28 @@ load_config() {
 # Verify the harness can reach rest-api at TEST_HOST. A misconfigured TEST_HOST
 # (typical for devcontainer users who forgot to set it) otherwise surfaces as
 # mysterious empty captures downstream.
+#
+# Only runs when the selected target list includes a target that crawls the
+# live rest-api server. Importer-only, synthetic-capture, and crawl-unreachable
+# runs do not need rest-api up and skip this check.
 preflight_test_host() {
+    local targets=$1
+    case ",${targets}," in
+        *,rest-api,*|*,edge-cases,*|*,crawl-depth,*) ;;
+        *) return 0 ;;
+    esac
     local port="${REST_API_PORT:-}"
     [ -z "$port" ] && return 0
     local url="http://${TEST_HOST}:${port}/api/health"
-    if ! curl -sf -o /dev/null --max-time 5 "$url" 2>/dev/null; then
-        log_fail "rest-api is unreachable at ${url}"
-        if [ "$TEST_HOST" = "localhost" ]; then
-            log_info "Is ./test/setup-live-targets.sh running? Check 'curl ${url}' on this host."
-        else
-            log_info "TEST_HOST=${TEST_HOST} cannot reach the target. For a devcontainer on Docker Desktop try TEST_HOST=host.docker.internal."
-        fi
-        exit 1
+    local curl_err
+    curl_err=$(curl -sS -o /dev/null --max-time 5 "$url" 2>&1) && return 0
+    log_fail "rest-api is unreachable at ${url}: ${curl_err}"
+    if [ "$TEST_HOST" = "localhost" ]; then
+        log_info "Is ./test/setup-live-targets.sh running? Check 'curl ${url}' on this host."
+    else
+        log_info "TEST_HOST=${TEST_HOST} cannot reach the target. For a devcontainer on Docker Desktop try TEST_HOST=host.docker.internal."
     fi
-    log_ok "rest-api reachable at ${url}"
+    exit 1
 }
 
 # ──────────────────────────────────────────────────────────────
@@ -1960,7 +1968,6 @@ main() {
 
     # Load config
     load_config
-    preflight_test_host
 
     # Default targets from config
     if [ -z "$targets" ]; then
@@ -1971,6 +1978,8 @@ main() {
         targets="${targets},edge-cases,crawl-depth,crawl-unreachable"
         targets="${targets},classifier-edge,spec-edge"
     fi
+
+    preflight_test_host "$targets"
 
     # Create results directory
     mkdir -p "$RESULTS_DIR"

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -60,29 +60,49 @@ load_config() {
     log_ok "Loaded config from ${CONFIG_FILE}"
 }
 
-# Verify the harness can reach rest-api at TEST_HOST. A misconfigured TEST_HOST
-# (typical for devcontainer users who forgot to set it) otherwise surfaces as
-# mysterious empty captures downstream.
-#
-# Only runs when the selected target list includes a target that crawls the
-# live rest-api server. Importer-only, synthetic-capture, and crawl-unreachable
-# runs do not need rest-api up and skip this check.
+# Probe one target's health endpoint at TEST_HOST. Returns 0 on success or
+# when the port is unset (target wasn't configured by setup-live-targets.sh).
+_probe_target_host() {
+    local port=$1 path=$2 name=$3
+    [ -z "$port" ] && return 0
+    local url="http://${TEST_HOST}:${port}${path}"
+    local curl_err
+    if curl_err=$(curl -sS -o /dev/null --max-time 5 "$url" 2>&1); then
+        log_ok "${name} reachable at ${url}"
+        return 0
+    fi
+    log_fail "${name} is unreachable at ${url}: ${curl_err}"
+    return 1
+}
+
+# Verify each selected live target is reachable at TEST_HOST before any
+# crawls run. A misconfigured TEST_HOST (typical for devcontainer users
+# who forgot to set it) otherwise surfaces as mysterious empty captures
+# downstream. Importer-only, synthetic-capture, and crawl-unreachable runs
+# don't touch a live host and are skipped.
 preflight_test_host() {
     local targets=$1
+    local failed=0
     case ",${targets}," in
-        *,rest-api,*|*,edge-cases,*|*,crawl-depth,*) ;;
-        *) return 0 ;;
+        *,rest-api,*|*,edge-cases,*|*,crawl-depth,*)
+            _probe_target_host "${REST_API_PORT:-}" "/api/health" "rest-api" || failed=1
+            ;;
     esac
-    local port="${REST_API_PORT:-}"
-    [ -z "$port" ] && return 0
-    local url="http://${TEST_HOST}:${port}/api/health"
-    local curl_err
-    curl_err=$(curl -sS -o /dev/null --max-time 5 "$url" 2>&1) && return 0
-    log_fail "rest-api is unreachable at ${url}: ${curl_err}"
+    case ",${targets}," in
+        *,soap-service,*)
+            _probe_target_host "${SOAP_SERVICE_PORT:-}" "/service.wsdl" "soap-service" || failed=1
+            ;;
+    esac
+    case ",${targets}," in
+        *,graphql-server,*)
+            _probe_target_host "${GRAPHQL_SERVER_PORT:-}" "/" "graphql-server" || failed=1
+            ;;
+    esac
+    [ $failed -eq 0 ] && return 0
     if [ "$TEST_HOST" = "localhost" ]; then
-        log_info "Is ./test/setup-live-targets.sh running? Check 'curl ${url}' on this host."
+        log_info "Is ./test/setup-live-targets.sh running? Check the failing URL on this host."
     else
-        log_info "TEST_HOST=${TEST_HOST} cannot reach the target. For a devcontainer on Docker Desktop try TEST_HOST=host.docker.internal."
+        log_info "TEST_HOST=${TEST_HOST} cannot reach one or more targets. For a devcontainer on Docker Desktop try TEST_HOST=host.docker.internal."
     fi
     exit 1
 }


### PR DESCRIPTION
## Summary

- Adds `--dangerous-allow-private` to every `vespasian crawl` invocation in `test/run-live-tests.sh` so the SSRF guard (added in #66) lets localhost seeds through. Fixes the `rest-api`, `soap-service`, `edge-cases`, `crawl-depth`, and `crawl-unreachable` targets.
- Introduces a `TEST_HOST` override (default `localhost`) so the harness can run inside a devcontainer while target services run on the Docker host, e.g. `TEST_HOST=host.docker.internal ./test/run-live-tests.sh`.
- Documents the override and adds a troubleshooting note to `test/README.md`.
- No production crawl behavior changes — `generate`/`scan` sites all use `--probe=false` (or already have the flag), and the SSRF default stays safe.

Closes [LAB-2308](https://linear.app/praetorianlabs/issue/LAB-2308/test-live-rest-api-test-fails-due-to-missing-dangerous-allow-private).

## Test plan

- [x] `./test/setup-live-targets.sh --targets rest-api && ./test/run-live-tests.sh --targets rest-api` — PASS (8 endpoints, 8 expected, 8s) ✅
- [ ] `./test/run-live-tests.sh --targets soap-service,graphql-server` — requires SOAP + GraphQL targets; recommend CI or a follow-up local verify.
- [ ] `./test/run-live-tests.sh --targets edge-cases,crawl-depth,crawl-unreachable` — recommend local verify once CI picks up the branch.
- [ ] Devcontainer path: `TEST_HOST=host.docker.internal ./test/run-live-tests.sh --targets rest-api` — needs a Docker Desktop reviewer to confirm.