### PR TITLE
fix(crawl): error loudly when seed URL is rejected by frontier (LAB-2438)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Vespasian takes a different approach: it observes actual network traffic at the 
 | **Traffic Import** | Import existing captures from Burp Suite XML, HAR 1.2 files, and mitmproxy dumps |
 | **Active Probing** | OPTIONS discovery, JSON schema inference, WSDL document fetching, and GraphQL introspection |
 | **Path Normalization** | `/users/42` and `/users/87` become `/users/{id}` with known literal preservation (`/me`, `/self`) |
-| **SSRF Protection** | Blocks probing of private and loopback addresses by default. Use `--dangerous-allow-private` to test internal targets. |
+| **SSRF Protection** | Blocks crawling and probing of private and loopback addresses by default. Pass `--dangerous-allow-private` to test internal targets (localhost, 127.0.0.1, RFC1918, link-local); the flag is required when the seed URL is itself a private host. |
 | **Proxy Support** | Route headless browser traffic through Burp Suite or other intercepting proxies |
 | **Two-Stage Pipeline** | Capture once, generate many: separate capture and generation steps for maximum flexibility |
 
@@ -222,7 +222,9 @@ vespasian scan <url> [flags]
   --confidence       Min classification confidence (default: 0.5)
   --probe            Enable active probing (default: true)
   --deduplicate      Deduplicate endpoints before probing (default: true)
-  --dangerous-allow-private  Disable SSRF protection for private targets
+  --dangerous-allow-private  Disable SSRF protection for private/localhost targets.
+                     Required when the seed URL is a private host (localhost,
+                     127.0.0.1, RFC1918, link-local).
   --no-request-id    Disable auto X-Vespasian-Request-Id header
   -v, --verbose      Show requests in real-time
 ```
@@ -241,6 +243,9 @@ vespasian crawl <url> [flags]
   --scope            same-origin or same-domain (default: same-origin)
   --headless         Browser mode (default: true)
   --proxy            Proxy URL for headless browser (e.g., http://127.0.0.1:8080)
+  --dangerous-allow-private  Disable SSRF protection for private/localhost targets.
+                     Required when the seed URL is a private host (localhost,
+                     127.0.0.1, RFC1918, link-local).
   --no-request-id    Disable auto X-Vespasian-Request-Id header
   -v, --verbose      Show requests in real-time
 ```
@@ -267,7 +272,9 @@ vespasian generate <api-type> <capture-file> [flags]
   --confidence       Min classification confidence (default: 0.5)
   --probe            Enable active probing (default: true)
   --deduplicate      Deduplicate endpoints before probing (default: true)
-  --dangerous-allow-private  Disable SSRF protection for private targets
+  --dangerous-allow-private  Disable SSRF protection on the probe path
+                     (OPTIONS/schema/WSDL-fetch/GraphQL-introspection requests
+                     to private hosts).
   -v, --verbose      Show discovered endpoints
 ```
 

--- a/README.md
+++ b/README.md
@@ -223,9 +223,11 @@ vespasian scan <url> [flags]
   --probe            Enable active probing (default: true)
   --deduplicate      Deduplicate endpoints before probing (default: true)
   --dangerous-allow-private  Disable SSRF protection for crawling and probes,
-                     allowing private/localhost targets. Required when the seed
-                     URL is a private host (localhost, 127.0.0.1, RFC1918,
-                     link-local).
+                     allowing private/localhost targets (localhost, 127.0.0.1,
+                     RFC1918, link-local). Required when the seed URL is a
+                     private host, otherwise the crawl exits with an error and
+                     captures nothing. WARNING: Do not use on production
+                     systems.
   --no-request-id    Disable auto X-Vespasian-Request-Id header
   -v, --verbose      Show requests in real-time
 ```
@@ -244,9 +246,12 @@ vespasian crawl <url> [flags]
   --scope            same-origin or same-domain (default: same-origin)
   --headless         Browser mode (default: true)
   --proxy            Proxy URL for headless browser (e.g., http://127.0.0.1:8080)
-  --dangerous-allow-private  Disable SSRF protection for private/localhost targets.
-                     Required when the seed URL is a private host (localhost,
-                     127.0.0.1, RFC1918, link-local).
+  --dangerous-allow-private  Disable SSRF protection for crawling, allowing
+                     private/localhost targets (localhost, 127.0.0.1, RFC1918,
+                     link-local). Required when the seed URL is a private
+                     host, otherwise the crawl exits with an error and
+                     captures nothing. WARNING: Do not use on production
+                     systems.
   --no-request-id    Disable auto X-Vespasian-Request-Id header
   -v, --verbose      Show requests in real-time
 ```
@@ -274,8 +279,9 @@ vespasian generate <api-type> <capture-file> [flags]
   --probe            Enable active probing (default: true)
   --deduplicate      Deduplicate endpoints before probing (default: true)
   --dangerous-allow-private  Disable SSRF protection on the probe path
-                     (OPTIONS/schema/WSDL-fetch/GraphQL introspection requests
-                     to private hosts).
+                     (OPTIONS/schema/WSDL-fetch/GraphQL introspection) for
+                     private/localhost targets. WARNING: Do not use on
+                     production systems.
   -v, --verbose      Show discovered endpoints
 ```
 

--- a/README.md
+++ b/README.md
@@ -222,9 +222,10 @@ vespasian scan <url> [flags]
   --confidence       Min classification confidence (default: 0.5)
   --probe            Enable active probing (default: true)
   --deduplicate      Deduplicate endpoints before probing (default: true)
-  --dangerous-allow-private  Disable SSRF protection for private/localhost targets.
-                     Required when the seed URL is a private host (localhost,
-                     127.0.0.1, RFC1918, link-local).
+  --dangerous-allow-private  Disable SSRF protection for crawling and probes,
+                     allowing private/localhost targets. Required when the seed
+                     URL is a private host (localhost, 127.0.0.1, RFC1918,
+                     link-local).
   --no-request-id    Disable auto X-Vespasian-Request-Id header
   -v, --verbose      Show requests in real-time
 ```
@@ -273,7 +274,7 @@ vespasian generate <api-type> <capture-file> [flags]
   --probe            Enable active probing (default: true)
   --deduplicate      Deduplicate endpoints before probing (default: true)
   --dangerous-allow-private  Disable SSRF protection on the probe path
-                     (OPTIONS/schema/WSDL-fetch/GraphQL-introspection requests
+                     (OPTIONS/schema/WSDL-fetch/GraphQL introspection requests
                      to private hosts).
   -v, --verbose      Show discovered endpoints
 ```

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -480,7 +480,7 @@ type GenerateCmd struct {
 	Confidence            float64 `default:"0.5" help:"Minimum confidence threshold"`
 	Probe                 bool    `default:"true" help:"Enable endpoint probing"`
 	Deduplicate           bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
-	DangerousAllowPrivate bool    `help:"Disable SSRF protection for probes, allowing private/localhost targets. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
+	DangerousAllowPrivate bool    `help:"Disable SSRF protection on the probe path (OPTIONS/schema/WSDL-fetch/GraphQL introspection) for private/localhost targets. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
 	Verbose               bool    `short:"v" help:"Enable verbose logging"`
 }
 

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -386,7 +386,7 @@ func setupBrowserAndSignals(rawHeaders []string, crawlOpts CrawlOptions, extraOp
 // CrawlCmd crawls a web application to capture HTTP traffic.
 type CrawlCmd struct {
 	URL                   string `arg:"" help:"Target URL to crawl"`
-	DangerousAllowPrivate bool   `help:"Disable SSRF protection for crawling, allowing private/localhost targets. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
+	DangerousAllowPrivate bool   `help:"Disable SSRF protection for crawling, allowing private/localhost targets (localhost, 127.0.0.1, RFC1918, link-local). Required when the seed URL is a private host, otherwise the crawl exits with an error and captures nothing. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
 	CrawlOptions
 }
 
@@ -553,7 +553,7 @@ type ScanCmd struct {
 	Confidence            float64 `default:"0.5" help:"Minimum confidence threshold"`
 	Probe                 bool    `default:"true" help:"Enable endpoint probing"`
 	Deduplicate           bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
-	DangerousAllowPrivate bool    `help:"Disable SSRF protection for probes, allowing private/localhost targets. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
+	DangerousAllowPrivate bool    `help:"Disable SSRF protection for crawling and probes, allowing private/localhost targets (localhost, 127.0.0.1, RFC1918, link-local). Required when the seed URL is a private host, otherwise the crawl exits with an error and captures nothing. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
 
 	CrawlOptions
 }

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -123,6 +123,7 @@ func (b *BrowserManager) cleanup() {
 // for use with defer in the normal (non-signal) path.
 func (b *BrowserManager) Close() {
 	if b.browser != nil {
+		// #nosec G104 -- best-effort close on a process that may already be dead; any error is unactionable and the subsequent Kill() + cleanup() still execute.
 		b.browser.Close() //nolint:errcheck,gosec // best-effort; process may already be dead
 	}
 	b.Kill()

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -123,7 +123,7 @@ func (b *BrowserManager) cleanup() {
 // for use with defer in the normal (non-signal) path.
 func (b *BrowserManager) Close() {
 	if b.browser != nil {
-		_ = b.browser.Close() // best-effort; process may already be dead
+		b.browser.Close() //nolint:errcheck,gosec // best-effort; process may already be dead
 	}
 	b.Kill()
 	b.cleanup()

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -47,19 +47,27 @@ const DefaultStableWait = 3 * time.Second
 // in cmd/vespasian/main.go.
 const flagDangerousAllowPrivate = "--dangerous-allow-private"
 
-// unparseableURLPlaceholder is substituted for a URL that failed url.Parse AND
-// contains an "@" (meaning we cannot safely strip userinfo without parsing).
-// Emitting the raw string in that case would leak credentials the whole point
-// of redactSeedURL is to hide.
+// unparseableURLPlaceholder is substituted for a URL that cannot be safely
+// stripped of userinfo (either url.Parse failed and "@" is present, or
+// url.Parse succeeded into an opaque form where u.User is not populated).
+// Emitting the raw string in either case would leak credentials — the whole
+// point of redactSeedURL is to hide them.
 const unparseableURLPlaceholder = "<unparseable URL with userinfo redacted>"
 
 // redactSeedURL returns raw with any userinfo (user[:password]) removed so the
 // URL can be echoed to stderr / logs without leaking credentials. Behavior:
-//   - url.Parse succeeds: userinfo is stripped and the URL is re-serialized.
-//   - url.Parse fails AND raw contains "@": fail closed — emit a generic
-//     placeholder instead of the raw string, since a parse failure on a URL
-//     with "@" (e.g. "http://admin:se%zz@host/path" — invalid percent escape
-//     in userinfo) would otherwise echo the credentials verbatim.
+//   - url.Parse succeeds AND the re-serialized URL has no "@": userinfo is
+//     stripped via u.User = nil and the URL is re-serialized.
+//   - url.Parse succeeds AND the re-serialized URL still contains "@":
+//     the URL is in opaque form (e.g. "http:user:pass@host/path" parses into
+//     u.Opaque rather than u.User, so u.User = nil is a no-op). Fail closed —
+//     emit the placeholder rather than round-trip credentials through u.String().
+//   - url.Parse fails AND raw contains "@": fail closed — emit the placeholder,
+//     since a parse failure on a URL with "@" (e.g. "http://admin:se%zz@host/path"
+//     — invalid percent escape in userinfo) would otherwise echo the credentials
+//     verbatim. Note: "@" may also appear in the path or query of a malformed
+//     URL (with no real userinfo); we accept that false positive (operator loses
+//     host/path context) to avoid any risk of echoing credentials.
 //   - url.Parse fails AND raw contains no "@": return raw unchanged; nothing
 //     to redact and the operator still gets an actionable error.
 func redactSeedURL(raw string) string {
@@ -71,7 +79,15 @@ func redactSeedURL(raw string) string {
 		return raw
 	}
 	u.User = nil
-	return u.String()
+	// Defensive: opaque URLs (e.g. "http:user:pass@host/path") parse with
+	// userinfo in u.Opaque, so u.User = nil above is a no-op and the
+	// credentials survive u.String(). Any residual "@" after clearing User
+	// means we cannot safely emit the URL; fall back to the placeholder.
+	out := u.String()
+	if strings.Contains(out, "@") {
+		return unparseableURLPlaceholder
+	}
+	return out
 }
 
 // engineOptions configures the concurrent headless crawl engine.

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -47,12 +47,12 @@ const DefaultStableWait = 3 * time.Second
 // in cmd/vespasian/main.go.
 const flagDangerousAllowPrivate = "--dangerous-allow-private"
 
-// unparseableURLPlaceholder is substituted for a URL that cannot be safely
+// redactedURLPlaceholder is substituted for a URL that cannot be safely
 // stripped of userinfo (either url.Parse failed and "@" is present, or
 // url.Parse succeeded into an opaque form where u.User is not populated).
 // Emitting the raw string in either case would leak credentials — the whole
 // point of redactSeedURL is to hide them.
-const unparseableURLPlaceholder = "<unparseable URL with userinfo redacted>"
+const redactedURLPlaceholder = "<URL with userinfo redacted>"
 
 // redactSeedURL returns raw with any userinfo (user[:password]) removed so the
 // URL can be echoed to stderr / logs without leaking credentials. Behavior:
@@ -74,7 +74,7 @@ func redactSeedURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
 		if strings.Contains(raw, "@") {
-			return unparseableURLPlaceholder
+			return redactedURLPlaceholder
 		}
 		return raw
 	}
@@ -85,7 +85,7 @@ func redactSeedURL(raw string) string {
 	// means we cannot safely emit the URL; fall back to the placeholder.
 	out := u.String()
 	if strings.Contains(out, "@") {
-		return unparseableURLPlaceholder
+		return redactedURLPlaceholder
 	}
 	return out
 }

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -94,8 +94,17 @@ func newRodEngine(wsURL string, opts engineOptions) (*rodEngine, error) {
 // completes (frontier exhausted, maxPages reached, or ctx canceled). Each
 // captured network request is passed to onResult as it is observed.
 func (e *rodEngine) Crawl(ctx context.Context, seedURL string, onResult func(ObservedRequest)) error {
-	// Seed the frontier.
-	e.frontier.Push([]urlEntry{{URL: seedURL, Depth: 0}})
+	// Seed the frontier. If Push adds zero entries the seed was rejected
+	// (malformed URL, scope mismatch, or — the common case — the seed is a
+	// private host such as localhost / 127.0.0.1 / RFC1918 / 169.254.*, which
+	// the scope predicate's SSRF check rejects unless --dangerous-allow-private
+	// is set). Without this guard the crawl silently returned zero captures
+	// with no error to help the operator diagnose (LAB-2438).
+	if e.frontier.Push([]urlEntry{{URL: seedURL, Depth: 0}}) == 0 {
+		return fmt.Errorf("seed URL rejected by frontier (scope, SSRF, or parse): %s; "+
+			"if crawling a private host (localhost, 127.0.0.1, RFC1918, link-local), "+
+			"pass --dangerous-allow-private", seedURL)
+	}
 
 	// Track page count for MaxPages enforcement. The onResult callback in
 	// Crawler.crawlHeadless also tracks this, but we need our own counter

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -59,15 +59,19 @@ const redactedURLPlaceholder = "<URL with userinfo redacted>"
 //   - url.Parse succeeds AND the re-serialized URL has no "@": userinfo is
 //     stripped via u.User = nil and the URL is re-serialized.
 //   - url.Parse succeeds AND the re-serialized URL still contains "@":
-//     the URL is in opaque form (e.g. "http:user:pass@host/path" parses into
-//     u.Opaque rather than u.User, so u.User = nil is a no-op). Fail closed —
-//     emit the placeholder rather than round-trip credentials through u.String().
+//     either the URL is in opaque form (e.g. "http:user:pass@host/path" parses
+//     into u.Opaque rather than u.User, so u.User = nil is a no-op), or "@"
+//     appears unencoded in the path/query (Go preserves it there — e.g.
+//     "http://example.com/@user" or "http://example.com/?q=a@b"). Fail closed
+//     in both cases: emit the placeholder rather than round-trip credentials
+//     through u.String(). For the path/query case this is a deliberate false
+//     positive — operators lose host/path context, but we accept that to avoid
+//     any risk of echoing credentials. Keep the check in place.
 //   - url.Parse fails AND raw contains "@": fail closed — emit the placeholder,
 //     since a parse failure on a URL with "@" (e.g. "http://admin:se%zz@host/path"
 //     — invalid percent escape in userinfo) would otherwise echo the credentials
 //     verbatim. Note: "@" may also appear in the path or query of a malformed
-//     URL (with no real userinfo); we accept that false positive (operator loses
-//     host/path context) to avoid any risk of echoing credentials.
+//     URL (with no real userinfo); same deliberate false positive as above.
 //   - url.Parse fails AND raw contains no "@": return raw unchanged; nothing
 //     to redact and the operator still gets an actionable error.
 func redactSeedURL(raw string) string {
@@ -79,10 +83,14 @@ func redactSeedURL(raw string) string {
 		return raw
 	}
 	u.User = nil
-	// Defensive: opaque URLs (e.g. "http:user:pass@host/path") parse with
-	// userinfo in u.Opaque, so u.User = nil above is a no-op and the
-	// credentials survive u.String(). Any residual "@" after clearing User
-	// means we cannot safely emit the URL; fall back to the placeholder.
+	// Defensive: the residual-"@" check catches two distinct cases:
+	//   1. Opaque URLs (e.g. "http:user:pass@host/path") parse with userinfo
+	//      in u.Opaque, so u.User = nil above is a no-op and credentials
+	//      would survive u.String() verbatim.
+	//   2. "@" unencoded in the path or query (e.g. "http://example.com/@user")
+	//      — no credentials, but we cannot cheaply distinguish this case from
+	//      (1), so we fall back to the placeholder. Deliberate false positive;
+	//      see the function-level doc comment.
 	out := u.String()
 	if strings.Contains(out, "@") {
 		return redactedURLPlaceholder

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -28,6 +28,13 @@ import (
 // DefaultConcurrency is the default number of concurrent browser tabs.
 const DefaultConcurrency = 10
 
+// flagDangerousAllowPrivate is the CLI flag name that disables SSRF protection
+// for private/localhost targets. It is referenced in operator-facing error
+// messages so operators can copy-paste it verbatim; keep this in sync with the
+// `name:"..."` tag on CrawlCmd.DangerousAllowPrivate / ScanCmd.DangerousAllowPrivate
+// in cmd/vespasian/main.go.
+const flagDangerousAllowPrivate = "--dangerous-allow-private"
+
 // MaxConcurrency is the upper bound on concurrent browser tabs. Each tab
 // consumes significant Chrome process memory (~50 MB), so unbounded values
 // could exhaust system resources.
@@ -97,13 +104,13 @@ func (e *rodEngine) Crawl(ctx context.Context, seedURL string, onResult func(Obs
 	// Seed the frontier. If Push adds zero entries the seed was rejected
 	// (malformed URL, scope mismatch, or — the common case — the seed is a
 	// private host such as localhost / 127.0.0.1 / RFC1918 / 169.254.*, which
-	// the scope predicate's SSRF check rejects unless --dangerous-allow-private
+	// the scope predicate's SSRF check rejects unless flagDangerousAllowPrivate
 	// is set). Without this guard the crawl silently returned zero captures
 	// with no error to help the operator diagnose (LAB-2438).
 	if e.frontier.Push([]urlEntry{{URL: seedURL, Depth: 0}}) == 0 {
 		return fmt.Errorf("seed URL rejected by frontier (scope, SSRF, or parse): %s; "+
 			"if crawling a private host (localhost, 127.0.0.1, RFC1918, link-local), "+
-			"pass --dangerous-allow-private", seedURL)
+			"pass %s", seedURL, flagDangerousAllowPrivate)
 	}
 
 	// Track page count for MaxPages enforcement. The onResult callback in

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"sync"
 	"time"
 
@@ -34,6 +35,19 @@ const DefaultConcurrency = 10
 // `name:"..."` tag on CrawlCmd.DangerousAllowPrivate / ScanCmd.DangerousAllowPrivate
 // in cmd/vespasian/main.go.
 const flagDangerousAllowPrivate = "--dangerous-allow-private"
+
+// redactSeedURL returns raw with any userinfo (user[:password]) removed so the
+// URL can be echoed to stderr / logs without leaking credentials. If raw does
+// not parse as a URL, it is returned unchanged — the operator-facing error is
+// still useful without redaction and we never want to swallow the seed string.
+func redactSeedURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
+}
 
 // MaxConcurrency is the upper bound on concurrent browser tabs. Each tab
 // consumes significant Chrome process memory (~50 MB), so unbounded values
@@ -108,9 +122,15 @@ func (e *rodEngine) Crawl(ctx context.Context, seedURL string, onResult func(Obs
 	// is set). Without this guard the crawl silently returned zero captures
 	// with no error to help the operator diagnose (LAB-2438).
 	if e.frontier.Push([]urlEntry{{URL: seedURL, Depth: 0}}) == 0 {
+		// redactSeedURL strips userinfo (user[:password]) before echoing the
+		// seed URL to stderr. If an operator pastes a credentialed URL and
+		// forgets flagDangerousAllowPrivate, the error message still lands in
+		// shell history / CI logs / scrollback — without this we would emit
+		// the cleartext credentials. url.Parse errors return the raw string
+		// unchanged so the operator still sees an actionable message.
 		return fmt.Errorf("seed URL rejected by frontier (scope, SSRF, or parse): %s; "+
 			"if crawling a private host (localhost, 127.0.0.1, RFC1918, link-local), "+
-			"pass %s", seedURL, flagDangerousAllowPrivate)
+			"pass %s", redactSeedURL(seedURL), flagDangerousAllowPrivate)
 	}
 
 	// Track page count for MaxPages enforcement. The onResult callback in

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -29,26 +30,6 @@ import (
 // DefaultConcurrency is the default number of concurrent browser tabs.
 const DefaultConcurrency = 10
 
-// flagDangerousAllowPrivate is the CLI flag name that disables SSRF protection
-// for private/localhost targets. It is referenced in operator-facing error
-// messages so operators can copy-paste it verbatim; keep this in sync with the
-// `name:"..."` tag on CrawlCmd.DangerousAllowPrivate / ScanCmd.DangerousAllowPrivate
-// in cmd/vespasian/main.go.
-const flagDangerousAllowPrivate = "--dangerous-allow-private"
-
-// redactSeedURL returns raw with any userinfo (user[:password]) removed so the
-// URL can be echoed to stderr / logs without leaking credentials. If raw does
-// not parse as a URL, it is returned unchanged — the operator-facing error is
-// still useful without redaction and we never want to swallow the seed string.
-func redactSeedURL(raw string) string {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return raw
-	}
-	u.User = nil
-	return u.String()
-}
-
 // MaxConcurrency is the upper bound on concurrent browser tabs. Each tab
 // consumes significant Chrome process memory (~50 MB), so unbounded values
 // could exhaust system resources.
@@ -56,6 +37,42 @@ const MaxConcurrency = 50
 
 // DefaultStableWait is the default DOM stability wait duration.
 const DefaultStableWait = 3 * time.Second
+
+// ---- operator-message helpers ----
+
+// flagDangerousAllowPrivate is the CLI flag name that disables SSRF protection
+// for private/localhost targets. It is referenced in operator-facing error
+// messages so operators can copy-paste it verbatim; keep this in sync with the
+// `name:"..."` tag on CrawlCmd.DangerousAllowPrivate / ScanCmd.DangerousAllowPrivate
+// in cmd/vespasian/main.go.
+const flagDangerousAllowPrivate = "--dangerous-allow-private"
+
+// unparseableURLPlaceholder is substituted for a URL that failed url.Parse AND
+// contains an "@" (meaning we cannot safely strip userinfo without parsing).
+// Emitting the raw string in that case would leak credentials the whole point
+// of redactSeedURL is to hide.
+const unparseableURLPlaceholder = "<unparseable URL with userinfo redacted>"
+
+// redactSeedURL returns raw with any userinfo (user[:password]) removed so the
+// URL can be echoed to stderr / logs without leaking credentials. Behavior:
+//   - url.Parse succeeds: userinfo is stripped and the URL is re-serialized.
+//   - url.Parse fails AND raw contains "@": fail closed — emit a generic
+//     placeholder instead of the raw string, since a parse failure on a URL
+//     with "@" (e.g. "http://admin:se%zz@host/path" — invalid percent escape
+//     in userinfo) would otherwise echo the credentials verbatim.
+//   - url.Parse fails AND raw contains no "@": return raw unchanged; nothing
+//     to redact and the operator still gets an actionable error.
+func redactSeedURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		if strings.Contains(raw, "@") {
+			return unparseableURLPlaceholder
+		}
+		return raw
+	}
+	u.User = nil
+	return u.String()
+}
 
 // engineOptions configures the concurrent headless crawl engine.
 type engineOptions struct {

--- a/pkg/crawl/engine_test.go
+++ b/pkg/crawl/engine_test.go
@@ -69,3 +69,68 @@ func TestRodEngine_Crawl_SeedRejectedByFrontierReturnsError(t *testing.T) {
 		t.Errorf("Crawl error %q should name the remediation flag (%s) so operators know what to do", err, flagDangerousAllowPrivate)
 	}
 }
+
+// TestRodEngine_Crawl_SeedRejectionRedactsUserinfo covers the follow-up to
+// LAB-2438: an operator may paste a credentialed seed URL (e.g.
+// http://user:pass@internal.corp) and forget flagDangerousAllowPrivate. The
+// rejection error is written to stderr by kong's FatalIfErrorf and can land in
+// shell history, terminal scrollback, or CI logs. The error message therefore
+// must not echo the password (or username) back to the operator.
+func TestRodEngine_Crawl_SeedRejectionRedactsUserinfo(t *testing.T) {
+	rejectAll := func(string) bool { return false }
+
+	e := &rodEngine{
+		browser: nil,
+		opts: engineOptions{
+			Concurrency: 1, MaxPages: 10, MaxDepth: 2, ScopeCheck: rejectAll,
+		},
+		frontier: newURLFrontier(2, rejectAll),
+	}
+
+	seed := "http://admin:s3cret@10.0.0.5:8080/path"
+	err := e.Crawl(context.Background(), seed, func(ObservedRequest) {
+		t.Fatal("onResult must not be called when the seed is rejected")
+	})
+	if err == nil {
+		t.Fatal("Crawl returned nil error on rejected credentialed seed; expected a descriptive error")
+	}
+	if strings.Contains(err.Error(), "s3cret") {
+		t.Errorf("Crawl error %q MUST NOT echo the seed password; it could land in shell history or CI logs", err)
+	}
+	if strings.Contains(err.Error(), "admin") {
+		t.Errorf("Crawl error %q MUST NOT echo the seed username; redactSeedURL is expected to strip the full userinfo block", err)
+	}
+	// The rest of the URL (host, port, path) is operator-supplied context and
+	// must still be present so the operator can identify which seed failed.
+	if !strings.Contains(err.Error(), "10.0.0.5:8080") {
+		t.Errorf("Crawl error %q should still echo the host:port after redaction", err)
+	}
+	if !strings.Contains(err.Error(), "/path") {
+		t.Errorf("Crawl error %q should still echo the path after redaction", err)
+	}
+}
+
+// TestRedactSeedURL table-drives the redaction helper directly so regressions
+// in url.Parse handling (empty URLs, malformed, no userinfo) are caught
+// independently of the Crawl integration above.
+func TestRedactSeedURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no userinfo", "http://example.com/x", "http://example.com/x"},
+		{"user+password", "http://u:p@example.com:443/x?q=1", "http://example.com:443/x?q=1"},
+		{"user only", "http://u@example.com/x", "http://example.com/x"},
+		{"empty password", "http://u:@example.com/x", "http://example.com/x"},
+		{"malformed returned as-is", "://not a url", "://not a url"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactSeedURL(tc.in)
+			if got != tc.want {
+				t.Errorf("redactSeedURL(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/crawl/engine_test.go
+++ b/pkg/crawl/engine_test.go
@@ -184,6 +184,13 @@ func TestRedactSeedURL(t *testing.T) {
 		// string contains "@", so we fail closed: the placeholder is emitted
 		// instead of echoing "admin:se%zz@host/path" with credentials.
 		{"malformed with userinfo redacts to placeholder", "http://admin:se%zz@host/path", unparseableURLPlaceholder}, //nolint:gosec // G101: intentional malformed test credential used to verify fail-closed redaction
+		// Opaque form: "http:user:pass@host/path" parses as Opaque="user:pass@host/path"
+		// with u.User nil. Clearing u.User is a no-op and u.String() would
+		// round-trip the credentials — the residual "@" check forces the
+		// placeholder. Not reachable via the CLI (main.go:validateURL blocks
+		// empty-Host URLs) but pinned here because redactSeedURL lives at a
+		// package boundary.
+		{"opaque with userinfo redacts to placeholder", "http:admin:pw@host/path", unparseableURLPlaceholder}, //nolint:gosec // G101: intentional opaque-form test credential used to verify fail-closed redaction
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/crawl/engine_test.go
+++ b/pkg/crawl/engine_test.go
@@ -87,7 +87,7 @@ func TestRodEngine_Crawl_SeedRejectionRedactsUserinfo(t *testing.T) {
 		frontier: newURLFrontier(2, rejectAll),
 	}
 
-	seed := "http://admin:s3cret@10.0.0.5:8080/path"
+	seed := "http://admin:s3cret@10.0.0.5:8080/path" //nolint:gosec // G101: intentional test credential used to verify redactSeedURL strips userinfo from error messages
 	err := e.Crawl(context.Background(), seed, func(ObservedRequest) {
 		t.Fatal("onResult must not be called when the seed is rejected")
 	})

--- a/pkg/crawl/engine_test.go
+++ b/pkg/crawl/engine_test.go
@@ -39,10 +39,11 @@ func TestRodEngine_Crawl_SeedRejectedByFrontierReturnsError(t *testing.T) {
 	rejectAll := func(string) bool { return false }
 
 	e := &rodEngine{
-		// browser intentionally nil — the error path must return before any
-		// CDP call happens. If a future refactor accidentally advances past
-		// Push before the guard, this test will panic on nil-browser deref
-		// rather than silently passing.
+		// AC #3: nil browser is deliberate — see LAB-2438. The error path must
+		// return before any CDP call happens. If a future refactor accidentally
+		// advances past Push before the guard, this test will panic on a
+		// nil-browser deref (at e.browser.Page() in visitPage, engine.go) rather
+		// than silently passing.
 		browser: nil,
 		opts: engineOptions{
 			Concurrency: 1,
@@ -67,6 +68,54 @@ func TestRodEngine_Crawl_SeedRejectedByFrontierReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), flagDangerousAllowPrivate) {
 		t.Errorf("Crawl error %q should name the remediation flag (%s) so operators know what to do", err, flagDangerousAllowPrivate)
+	}
+	// Pin the load-bearing operator-facing clauses so a refactor that drops
+	// either the diagnostic breakdown or the private-host enumeration fails
+	// the test instead of silently degrading the error message.
+	if !strings.Contains(err.Error(), "scope, SSRF, or parse") {
+		t.Errorf("Crawl error %q should include the '(scope, SSRF, or parse)' diagnostic breakdown so operators know why the seed was rejected", err)
+	}
+	if !strings.Contains(err.Error(), "private host") {
+		t.Errorf("Crawl error %q should include the 'private host' enumeration so operators recognize the common-case cause", err)
+	}
+}
+
+// TestRodEngine_Crawl_SeedAcceptedDoesNotReturnRejectionError covers LAB-2438
+// AC #2: with --dangerous-allow-private (modeled here as an accept-all scope
+// predicate) the Crawl entry-point must NOT emit the
+// "seed URL rejected by frontier" error. Without this test the happy path is
+// only pinned by the live-test harness / integration-tagged tests; the default
+// suite had no tripwire for a regression that starts rejecting valid seeds.
+//
+// We cannot run the full crawl in a unit test (there is no browser), so we
+// invoke Crawl with Concurrency=0 — newRodEngine normally bumps that to
+// DefaultConcurrency, but we bypass newRodEngine here and construct rodEngine
+// directly. With Concurrency=0 no worker goroutines launch, wg.Wait() returns
+// immediately, and Crawl returns ctx.Err() (nil for context.Background()).
+// The only way to hit the rejection error is for Push to return 0; with an
+// accept-all predicate Push returns 1, so the rejection error is not emitted.
+func TestRodEngine_Crawl_SeedAcceptedDoesNotReturnRejectionError(t *testing.T) {
+	acceptAll := func(string) bool { return true }
+
+	e := &rodEngine{
+		// Same nil-browser rationale as the rejection test above, and it is
+		// load-bearing here: Concurrency=0 means no workers launch, so we
+		// never reach visitPage's e.browser.Page() call. If someone changes
+		// Crawl to launch a worker regardless of Concurrency, this test will
+		// panic on nil-browser deref instead of silently hanging.
+		browser: nil,
+		opts: engineOptions{
+			Concurrency: 0,
+			MaxPages:    10,
+			MaxDepth:    2,
+			ScopeCheck:  acceptAll,
+		},
+		frontier: newURLFrontier(2, acceptAll),
+	}
+
+	err := e.Crawl(context.Background(), "http://example.com", func(ObservedRequest) {})
+	if err != nil && strings.Contains(err.Error(), "seed URL rejected by frontier") {
+		t.Fatalf("Crawl returned rejection error %q on accept-all predicate; AC #2 requires the happy path to not trigger the rejection path", err)
 	}
 }
 
@@ -123,7 +172,18 @@ func TestRedactSeedURL(t *testing.T) {
 		{"user+password", "http://u:p@example.com:443/x?q=1", "http://example.com:443/x?q=1"},
 		{"user only", "http://u@example.com/x", "http://example.com/x"},
 		{"empty password", "http://u:@example.com/x", "http://example.com/x"},
-		{"malformed returned as-is", "://not a url", "://not a url"},
+		// IPv6 literal uses bracket notation in the authority; url.Parse
+		// round-trips the brackets so the host:port form is preserved.
+		{"ipv6 with userinfo", "http://u:p@[::1]:8080/x", "http://[::1]:8080/x"}, //nolint:gosec // G101: intentional test credential used to verify IPv6 userinfo redaction
+		{"empty string", "", ""},
+		// url.Parse fails on unknown scheme syntax, but the string has no
+		// "@" so we fall through to the raw-return path. Operators still
+		// get an actionable message without risking credential leak.
+		{"malformed no userinfo returned as-is", "://not a url", "://not a url"},
+		// url.Parse fails (invalid percent-escape in userinfo) AND the raw
+		// string contains "@", so we fail closed: the placeholder is emitted
+		// instead of echoing "admin:se%zz@host/path" with credentials.
+		{"malformed with userinfo redacts to placeholder", "http://admin:se%zz@host/path", unparseableURLPlaceholder}, //nolint:gosec // G101: intentional malformed test credential used to verify fail-closed redaction
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/crawl/engine_test.go
+++ b/pkg/crawl/engine_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestRodEngine_Crawl_SeedRejectedByFrontierReturnsError covers LAB-2438.
+//
+// Before this fix, when the frontier rejected the seed (e.g., the seed host
+// was private and allowPrivate=false), engine.Crawl pushed zero entries and
+// then blocked in wg.Wait() until all workers saw an empty frontier, returning
+// nil with no captures — the operator got `captured 0 requests` with no error
+// and no way to diagnose. The fix makes this condition a hard error that
+// names the seed and points at `--dangerous-allow-private`.
+//
+// This test constructs a frontier with a scope predicate that rejects every
+// URL, calls Crawl, and asserts a non-nil error is returned without the
+// engine ever touching the (nil) browser.
+func TestRodEngine_Crawl_SeedRejectedByFrontierReturnsError(t *testing.T) {
+	// rejectAll mirrors the private-seed + SSRF rejection case without
+	// requiring the real scopeChecker wiring — Push just asks for a
+	// func(string) bool, and we control its answer.
+	rejectAll := func(string) bool { return false }
+
+	e := &rodEngine{
+		// browser intentionally nil — the error path must return before any
+		// CDP call happens. If a future refactor accidentally advances past
+		// Push before the guard, this test will panic on nil-browser deref
+		// rather than silently passing.
+		browser: nil,
+		opts: engineOptions{
+			Concurrency: 1,
+			MaxPages:    10,
+			MaxDepth:    2,
+			ScopeCheck:  rejectAll,
+		},
+		frontier: newURLFrontier(2, rejectAll),
+	}
+
+	err := e.Crawl(context.Background(), "http://localhost:9000", func(ObservedRequest) {
+		t.Fatal("onResult must not be called when the seed is rejected")
+	})
+	if err == nil {
+		t.Fatal("Crawl returned nil error on rejected seed; expected a descriptive error")
+	}
+	if !strings.Contains(err.Error(), "rejected") {
+		t.Errorf("Crawl error %q should mention 'rejected'; prior bug was a silent empty-frontier exit", err)
+	}
+	if !strings.Contains(err.Error(), "http://localhost:9000") {
+		t.Errorf("Crawl error %q should echo the seed URL for operator diagnosis", err)
+	}
+	if !strings.Contains(err.Error(), "--dangerous-allow-private") {
+		t.Errorf("Crawl error %q should name the remediation flag (--dangerous-allow-private) so operators know what to do", err)
+	}
+}

--- a/pkg/crawl/engine_test.go
+++ b/pkg/crawl/engine_test.go
@@ -197,6 +197,15 @@ func TestRedactSeedURL(t *testing.T) {
 		// empty-Host URLs) but pinned here because redactSeedURL lives at a
 		// package boundary.
 		{"opaque with userinfo redacts to placeholder", "http:admin:pw@host/path", redactedURLPlaceholder}, //nolint:gosec // G101: intentional opaque-form test credential used to verify fail-closed redaction
+		// Deliberate false positive: "@" is legal in path/query components
+		// (Go preserves it unencoded). The residual-"@" check cannot cheaply
+		// distinguish this from opaque-form credential smuggling, so we fail
+		// closed. Operators lose host/path context; accepted as the safer
+		// default. Pin the behavior so a future refactor that "fixes" the
+		// false positive by removing the check does not silently expose the
+		// opaque-form credential-leak path.
+		{"@ in path falls back to placeholder", "http://example.com/@user", redactedURLPlaceholder},
+		{"@ in query falls back to placeholder", "http://example.com/?q=a@b", redactedURLPlaceholder},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/crawl/engine_test.go
+++ b/pkg/crawl/engine_test.go
@@ -65,7 +65,7 @@ func TestRodEngine_Crawl_SeedRejectedByFrontierReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "http://localhost:9000") {
 		t.Errorf("Crawl error %q should echo the seed URL for operator diagnosis", err)
 	}
-	if !strings.Contains(err.Error(), "--dangerous-allow-private") {
-		t.Errorf("Crawl error %q should name the remediation flag (--dangerous-allow-private) so operators know what to do", err)
+	if !strings.Contains(err.Error(), flagDangerousAllowPrivate) {
+		t.Errorf("Crawl error %q should name the remediation flag (%s) so operators know what to do", err, flagDangerousAllowPrivate)
 	}
 }

--- a/pkg/crawl/engine_test.go
+++ b/pkg/crawl/engine_test.go
@@ -113,9 +113,15 @@ func TestRodEngine_Crawl_SeedAcceptedDoesNotReturnRejectionError(t *testing.T) {
 		frontier: newURLFrontier(2, acceptAll),
 	}
 
+	// With Concurrency=0 and context.Background(), Crawl's control flow is
+	// deterministically: Push succeeds → range over 0 launches no workers →
+	// wg.Wait returns immediately → return ctx.Err() == nil. Any non-nil error
+	// at all is a regression of AC #2 (happy path must not fail). Asserting
+	// err == nil (rather than only inspecting for the rejection substring)
+	// keeps the tripwire broad so an unrelated regression does not slip past.
 	err := e.Crawl(context.Background(), "http://example.com", func(ObservedRequest) {})
-	if err != nil && strings.Contains(err.Error(), "seed URL rejected by frontier") {
-		t.Fatalf("Crawl returned rejection error %q on accept-all predicate; AC #2 requires the happy path to not trigger the rejection path", err)
+	if err != nil {
+		t.Fatalf("Crawl returned unexpected error %q on accept-all predicate; AC #2 happy path must return nil", err)
 	}
 }
 
@@ -183,14 +189,14 @@ func TestRedactSeedURL(t *testing.T) {
 		// url.Parse fails (invalid percent-escape in userinfo) AND the raw
 		// string contains "@", so we fail closed: the placeholder is emitted
 		// instead of echoing "admin:se%zz@host/path" with credentials.
-		{"malformed with userinfo redacts to placeholder", "http://admin:se%zz@host/path", unparseableURLPlaceholder}, //nolint:gosec // G101: intentional malformed test credential used to verify fail-closed redaction
+		{"malformed with userinfo redacts to placeholder", "http://admin:se%zz@host/path", redactedURLPlaceholder}, //nolint:gosec // G101: intentional malformed test credential used to verify fail-closed redaction
 		// Opaque form: "http:user:pass@host/path" parses as Opaque="user:pass@host/path"
 		// with u.User nil. Clearing u.User is a no-op and u.String() would
 		// round-trip the credentials — the residual "@" check forces the
 		// placeholder. Not reachable via the CLI (main.go:validateURL blocks
 		// empty-Host URLs) but pinned here because redactSeedURL lives at a
 		// package boundary.
-		{"opaque with userinfo redacts to placeholder", "http:admin:pw@host/path", unparseableURLPlaceholder}, //nolint:gosec // G101: intentional opaque-form test credential used to verify fail-closed redaction
+		{"opaque with userinfo redacts to placeholder", "http:admin:pw@host/path", redactedURLPlaceholder}, //nolint:gosec // G101: intentional opaque-form test credential used to verify fail-closed redaction
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/README.md
+++ b/test/README.md
@@ -42,7 +42,7 @@ For each target:
 6. **Validate spec** — Path/operation coverage, schema structure, no static assets
 7. **Print summary** — Pass/fail status with endpoint counts and durations
 
-> **Why `--dangerous-allow-private`?** All live targets run on `localhost`, which the crawler's SSRF gate treats as a private host. The flag is required on every `vespasian crawl` invocation in this suite; running without it will exit non-zero with `seed URL rejected by frontier ...`. The flag name reflects production danger — never pass it on non-test crawls.
+> **Why `--dangerous-allow-private`?** All live targets run on `localhost`, which the crawler's SSRF gate treats as a private host. The flag is required on every `vespasian crawl` invocation in this suite; running without it will exit non-zero with `seed URL rejected by frontier ...`. The flag name reflects production-risk semantics — pass it only when you intend to crawl a known-private host (e.g., this suite, or an internal-network assessment).
 
 For the GraphQL live test (`graphql-server`):
 

--- a/test/README.md
+++ b/test/README.md
@@ -36,11 +36,13 @@ For each target:
 
 1. **Build** vespasian and target binaries
 2. **Start** target services (with auto-resolved ports)
-3. **Crawl** — `vespasian crawl <url> -o capture.json`
+3. **Crawl** — `vespasian crawl <url> --dangerous-allow-private -o capture.json`
 4. **Validate capture** — Check request count and expected URLs
 5. **Generate** — `vespasian generate <type> capture.json -o spec.<ext>`
 6. **Validate spec** — Path/operation coverage, schema structure, no static assets
 7. **Print summary** — Pass/fail status with endpoint counts and durations
+
+> **Why `--dangerous-allow-private`?** All live targets run on `localhost`, which the crawler's SSRF gate treats as a private host. The flag is required on every `vespasian crawl` invocation in this suite; running without it will exit non-zero with `seed URL rejected by frontier ...`. The flag name reflects production danger — never pass it on non-test crawls.
 
 For the GraphQL live test (`graphql-server`):
 
@@ -307,6 +309,15 @@ curl http://localhost:8990/api/health
 ```
 
 If you're running the harness inside a devcontainer and the targets are on the host, set `TEST_HOST` (see Configuration above) and verify connectivity from inside the container with `curl http://${TEST_HOST}:8990/api/health`. Without `TEST_HOST`, `localhost` resolves to the container's own loopback (not the Docker host), the crawler connects to nothing, and the capture is empty.
+
+### Crawl exits with `seed URL rejected by frontier (scope, SSRF, or parse): ...`
+
+The seed URL is a private host (`localhost`, `127.0.0.1`, RFC1918, or link-local) and `--dangerous-allow-private` was not passed. All live tests in this suite crawl localhost targets, so every `vespasian crawl` invocation in `run-live-tests.sh` already includes the flag. If you are reproducing a single test by hand, add the flag to your command line:
+
+```bash
+./bin/vespasian crawl http://localhost:8990 --dangerous-allow-private \
+    -o /tmp/cap.json --depth 2 --max-pages 50
+```
 
 ### Build failures
 


### PR DESCRIPTION
## Summary

Fixes [LAB-2438](https://linear.app/praetorianlabs/issue/LAB-2438/headless-crawl-silently-drops-private-host-seed-rest-apisoap-service).

Running `vespasian crawl http://localhost:<port>` without `--dangerous-allow-private` previously **silently** captured zero requests and exited 0 — the operator got `captured 0 requests` with no hint the seed was never visited. Root cause: `scopeChecker.ssrfCheck` rejects private hosts, `frontier.Push` applies the predicate to the seed, seed is dropped, all workers see an empty frontier in `Pop`, `engine.Crawl` returns `nil`.

This PR surfaces that condition as a loud, actionable error. `--dangerous-allow-private` remains required when the seed is a private host — the flag's existing contract is preserved.

## Scope decision

An earlier draft of this PR also exempted the seed host from the SSRF gate so localhost crawls worked without the flag. That was reverted after review: the flag's name already says "I am crawling a private host, let me through." An invisible seed exemption would make the flag harder to reason about, and future maintainers would need to remember a special case that isn't surfaced in the CLI. See the Linear ticket's Scope decision section for the full rationale.

The alternative semantic change (seed exemption, or renaming the flag) is tracked as possible future work.

## Changes

| File | Change |
|------|--------|
| `pkg/crawl/engine.go` | `Crawl` returns a descriptive error when `frontier.Push(seed)` adds zero entries. The message names the seed and points at `--dangerous-allow-private`. |
| `pkg/crawl/engine_test.go` (new) | Default-suite test that asserts the new error, with a `nil` browser in the engine struct so a future refactor that advances past the guard panics on nil-deref instead of silently passing. |
| `cmd/vespasian/main.go` | `CrawlCmd` and `ScanCmd` `--dangerous-allow-private` help text now states the flag is required when the seed URL is a private host. `GenerateCmd` help text clarifies the flag applies to the probe path only. |
| `README.md` | SSRF Protection feature row and `crawl` / `scan` / `generate` command help blocks updated to match. |
| `test/README.md` | Explains why the harness passes `--dangerous-allow-private` on every live crawl; adds a troubleshooting section for the new error message. |

## Explicitly not changed

- `pkg/crawl/scope.go` — unchanged. `ssrfCheck` still rejects any private host regardless of whether it matches the seed.
- `test/run-live-tests.sh` — unchanged. The harness continues to pass `--dangerous-allow-private` on all seven live-crawl invocations (added by #84 / LAB-2308). Consistent with the flag's contract; all live targets are localhost.
- Probe-side `--dangerous-allow-private` (used on `vespasian generate graphql` in the harness) — different code path in `pkg/probe`, out of scope.

## Test plan

- [x] `go test -race ./...` — green (default suite, includes new `TestRodEngine_Crawl_SeedRejectedByFrontierReturnsError`).
- [x] `gofmt -l .` — clean. `go vet ./...` — clean.
- [x] End-to-end reproducer (Linux + chromium):

  ```bash
  ./test/rest-api/rest-api &  # port 9300

  # WITHOUT flag — previously: captured 0 requests, exit 0; now:
  ./bin/vespasian crawl http://localhost:9300 -o /tmp/err.json --depth 2 --max-pages 50
  # → "vespasian: error: crawl failed: seed URL rejected by frontier
  #    (scope, SSRF, or parse): http://localhost:9300; if crawling a
  #    private host (localhost, 127.0.0.1, RFC1918, link-local),
  #    pass --dangerous-allow-private"
  # → exit 1

  # WITH flag — happy path unchanged:
  ./bin/vespasian crawl http://localhost:9300 --dangerous-allow-private \
      -o /tmp/ok.json --depth 2 --max-pages 50
  jq length /tmp/ok.json
  # → 18
  ```
- [ ] Reviewer to run `./test/setup-live-targets.sh && ./test/run-live-tests.sh` on macOS and confirm the harness still passes (no harness-side changes in this PR so expected to be green).

## Regression lineage

- #66 (`f62fbe0 feat: replace Katana headless crawl with concurrent go-rod engine`) introduced the silent-drop behavior by running the seed through the same scope predicate used for discovered links.
- #84 (LAB-2308) worked around the symptom in the harness by passing `--dangerous-allow-private` on every crawl. That remains the right posture for the harness; this PR keeps the harness as-is and fixes the underlying UX bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)