### PR TITLE
feat(rest): parse form-encoded and multipart request bodies (LAB-2106)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ The CLI (`cmd/vespasian`) uses Kong for argument parsing. Each command (crawl, i
 - **pkg/classify**: Request classification engine with confidence-based heuristics; classifiers for REST, GraphQL, and WSDL; deduplication
 - **pkg/probe**: Active endpoint probing strategies (OPTIONS discovery, JSON schema inference, WSDL document fetching, GraphQL introspection with 3-tier WAF bypass); SSRF protection with DNS rebinding mitigation
 - **pkg/generate**: Spec generation interface and registry; delegates to sub-packages by API type
-- **pkg/generate/rest**: OpenAPI 3.0 generation, path normalization (UUID detection, context-aware parameter naming), JSON schema inference
+- **pkg/generate/rest**: OpenAPI 3.0 generation, path normalization (UUID detection, context-aware parameter naming), JSON schema inference, form-encoded and multipart request-body inference
 - **pkg/generate/graphql**: GraphQL SDL generation from introspection results or traffic-based inference
 - **pkg/generate/wsdl**: WSDL generation from SOAP traffic, WSDL document parsing, type inference from SOAP envelopes
 - **pkg/importer**: Traffic importers for Burp Suite XML, HAR 1.2, and mitmproxy dumps; format registry with size limits (500MB)

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Vespasian classifies and generates specifications for three API types:
 
 | API Type | Classification Signals | Output Format | Probing |
 |----------|----------------------|---------------|---------|
-| **REST** | JSON/XML content-type, `/api/` `/v1/` path patterns, HTTP methods | OpenAPI 3.0 (YAML/JSON) | OPTIONS discovery, JSON schema inference |
+| **REST** | JSON/XML content-type, `/api/` `/v1/` path patterns, HTTP methods | OpenAPI 3.0 (YAML/JSON) | OPTIONS discovery, JSON, urlencoded, and multipart request-body inference |
 | **GraphQL** | `/graphql` path, query structure in POST body, `data`/`errors` response keys | GraphQL SDL | Tiered introspection queries (3 tiers for WAF bypass) |
 | **WSDL/SOAP** | SOAPAction header, SOAP envelope in body, `?wsdl` URL parameter | WSDL XML | Active `?wsdl` document fetching |
 

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -128,6 +128,15 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
 			if ct := getContentType(req.Headers); ct != "" {
 				key += ":" + baseMediaType(ct)
 			}
+			// Append a short fingerprint of the body so distinct payload shapes
+			// on the same endpoint+method+CT survive deduplication. This is
+			// required for downstream form/JSON merge logic in buildOperation
+			// to see all observations and union their fields. 8 bytes (64 bits)
+			// is a deliberate balance: birthday-collision probability is ~7e-13
+			// at 500 distinct bodies per endpoint, well under realistic crawl
+			// scale (capped at MaxPages, default 100). A collision would
+			// silently merge two distinct bodies into one dedup bucket; this
+			// is no worse than pre-fix behavior and worth the simpler key.
 			h := sha256.Sum256(req.Body)
 			key += ":" + hex.EncodeToString(h[:8])
 		}

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -114,6 +114,16 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
 			key += ":" + sa
 		}
 
+		// If this observation has a body, include the base content type in the
+		// key so that distinct request body shapes (JSON, urlencoded, multipart)
+		// survive deduplication on the same path. Empty bodies (e.g. GET) do
+		// not split.
+		if len(req.Body) > 0 {
+			if ct := getContentType(req.Headers); ct != "" {
+				key += ":" + baseMediaType(ct)
+			}
+		}
+
 		existing, found := seen[key]
 		if !found {
 			order = append(order, key)
@@ -155,4 +165,26 @@ func getSoapAction(headers map[string]string) string {
 		}
 	}
 	return ""
+}
+
+// getContentType returns the Content-Type header value, case-insensitively.
+func getContentType(headers map[string]string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, "content-type") {
+			return v
+		}
+	}
+	return ""
+}
+
+// baseMediaType returns the lowercased media type from a Content-Type value,
+// stripped of any parameters (e.g. "; boundary=..."). Returns "" on empty input.
+func baseMediaType(ct string) string {
+	if ct == "" {
+		return ""
+	}
+	if i := strings.Index(ct, ";"); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.ToLower(strings.TrimSpace(ct))
 }

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -15,6 +15,8 @@
 package classify
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/url"
 	"strings"
 
@@ -114,14 +116,20 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
 			key += ":" + sa
 		}
 
-		// If this observation has a body, include the base content type in the
-		// key so that distinct request body shapes (JSON, urlencoded, multipart)
-		// survive deduplication on the same path. Empty bodies (e.g. GET) do
-		// not split.
+		// If this observation has a body, include the base content type and a
+		// short hash of the body bytes in the key so that:
+		//   - Distinct body shapes on the same path+method survive as separate
+		//     entries (required for downstream form/JSON field-merge logic in
+		//     buildOperation in pkg/generate/rest/openapi.go, which unions fields
+		//     across observations).
+		//   - Identical bodies still collapse correctly (true duplicates).
+		//   - Empty-body requests (GET, DELETE, HEAD, OPTIONS) are unaffected.
 		if len(req.Body) > 0 {
 			if ct := getContentType(req.Headers); ct != "" {
 				key += ":" + baseMediaType(ct)
 			}
+			h := sha256.Sum256(req.Body)
+			key += ":" + hex.EncodeToString(h[:8])
 		}
 
 		existing, found := seen[key]

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -15,8 +15,10 @@
 package classify
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"mime"
 	"net/url"
 	"strings"
 
@@ -85,7 +87,7 @@ func RunClassifiers(classifiers []APIClassifier, requests []crawl.ObservedReques
 // In practice this is bounded by the upstream crawl layer's MaxPages setting
 // (default 100). The import path (ReadCapture) does not enforce size limits,
 // so callers importing from untrusted capture files should validate input size.
-func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
+func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest { //nolint:gocyclo // boundary normalization for multipart adds necessary branches
 	type entry struct {
 		req ClassifiedRequest
 	}
@@ -137,7 +139,18 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest {
 			// scale (capped at MaxPages, default 100). A collision would
 			// silently merge two distinct bodies into one dedup bucket; this
 			// is no worse than pre-fix behavior and worth the simpler key.
-			h := sha256.Sum256(req.Body)
+			fingerprintBody := req.Body
+			if ct := getContentType(req.Headers); ct != "" {
+				if mt, params, err := mime.ParseMediaType(ct); err == nil && mt == "multipart/form-data" {
+					if boundary := params["boundary"]; boundary != "" {
+						// Multipart bodies contain a random boundary token (per-request) that
+						// would otherwise make every observation unique. Normalize it to a
+						// sentinel so identical logical forms with different boundaries dedup.
+						fingerprintBody = bytes.ReplaceAll(req.Body, []byte(boundary), []byte("BOUNDARY"))
+					}
+				}
+			}
+			h := sha256.Sum256(fingerprintBody)
 			key += ":" + hex.EncodeToString(h[:8])
 		}
 

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -134,18 +134,23 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest { //nolint:
 			// on the same endpoint+method+CT survive deduplication. This is
 			// required for downstream form/JSON merge logic in buildOperation
 			// to see all observations and union their fields. 8 bytes (64 bits)
-			// is a deliberate balance: birthday-collision probability is ~7e-13
+			// is a deliberate balance: birthday-collision probability is ~1e-14
 			// at 500 distinct bodies per endpoint, well under realistic crawl
-			// scale (capped at MaxPages, default 100). A collision would
-			// silently merge two distinct bodies into one dedup bucket; this
-			// is no worse than pre-fix behavior and worth the simpler key.
+			// scale (capped at MaxPages, default 100). With 1M distinct bodies the
+			// probability rises to ~5e-8, still negligible in practice.
+			// A collision would silently merge two distinct bodies into one dedup
+			// bucket; this is no worse than pre-fix behavior and worth the simpler key.
 			fingerprintBody := req.Body
 			if ct := getContentType(req.Headers); ct != "" {
 				if mt, params, err := mime.ParseMediaType(ct); err == nil && mt == "multipart/form-data" {
-					if boundary := params["boundary"]; boundary != "" {
+					if boundary := params["boundary"]; len(boundary) >= 4 {
 						// Multipart bodies contain a random boundary token (per-request) that
 						// would otherwise make every observation unique. Normalize it to a
 						// sentinel so identical logical forms with different boundaries dedup.
+						// boundary < 4 chars: skip normalization, fall through to raw body hash.
+						// This is defensive — RFC 2046 allows 1-70 char boundaries but real-world
+						// browsers/libraries use 30+ chars. A pathologically short boundary would
+						// corrupt the body more than it'd help dedup.
 						fingerprintBody = bytes.ReplaceAll(req.Body, []byte(boundary), []byte("BOUNDARY"))
 					}
 				}

--- a/pkg/classify/classifier.go
+++ b/pkg/classify/classifier.go
@@ -127,7 +127,8 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest { //nolint:
 		//   - Identical bodies still collapse correctly (true duplicates).
 		//   - Empty-body requests (GET, DELETE, HEAD, OPTIONS) are unaffected.
 		if len(req.Body) > 0 {
-			if ct := getContentType(req.Headers); ct != "" {
+			ct := getContentType(req.Headers)
+			if ct != "" {
 				key += ":" + baseMediaType(ct)
 			}
 			// Append a short fingerprint of the body so distinct payload shapes
@@ -141,7 +142,7 @@ func Deduplicate(classified []ClassifiedRequest) []ClassifiedRequest { //nolint:
 			// A collision would silently merge two distinct bodies into one dedup
 			// bucket; this is no worse than pre-fix behavior and worth the simpler key.
 			fingerprintBody := req.Body
-			if ct := getContentType(req.Headers); ct != "" {
+			if ct != "" {
 				if mt, params, err := mime.ParseMediaType(ct); err == nil && mt == "multipart/form-data" {
 					if boundary := params["boundary"]; len(boundary) >= 4 {
 						// Multipart bodies contain a random boundary token (per-request) that

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -425,13 +425,15 @@ func TestDeduplicate_KeepsDistinctBodiesByContentType(t *testing.T) {
 }
 
 func TestDeduplicate_MergesSameContentType(t *testing.T) {
+	// Byte-identical bodies with the same CT must collapse — they are true duplicates.
+	body := []byte(`{"name":"alice"}`)
 	classified := []ClassifiedRequest{
 		{
 			ObservedRequest: crawl.ObservedRequest{
 				Method:  "POST",
 				URL:     "https://example.com/api/create",
 				Headers: map[string]string{"Content-Type": "application/json"},
-				Body:    []byte(`{"name":"first"}`),
+				Body:    body,
 			},
 			IsAPI: true, Confidence: 0.8, APIType: "rest",
 		},
@@ -440,14 +442,14 @@ func TestDeduplicate_MergesSameContentType(t *testing.T) {
 				Method:  "POST",
 				URL:     "https://example.com/api/create",
 				Headers: map[string]string{"Content-Type": "application/json"},
-				Body:    []byte(`{"name":"second"}`),
+				Body:    body,
 			},
 			IsAPI: true, Confidence: 0.9, APIType: "rest",
 		},
 	}
 
 	result := Deduplicate(classified)
-	require.Len(t, result, 1, "same content type on same path should collapse to one entry")
+	require.Len(t, result, 1, "byte-identical bodies on same path+CT should collapse to one entry")
 	assert.InDelta(t, 0.9, result[0].Confidence, 0.001, "highest confidence kept")
 }
 
@@ -497,4 +499,55 @@ func TestRunClassifiers_WSDLWinsOverREST(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, "wsdl", results[0].APIType, "WSDL should win for SOAP traffic")
 	assert.GreaterOrEqual(t, results[0].Confidence, 0.90)
+}
+
+// TestDeduplicate_DistinctBodiesSurvive verifies that form-encoded POST observations
+// with distinct body bytes survive deduplication as separate entries, enabling
+// downstream buildOperation to union fields across observations (LAB-2106).
+func TestDeduplicate_DistinctBodiesSurvive(t *testing.T) {
+	ct := "application/x-www-form-urlencoded"
+	classified := []ClassifiedRequest{
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/checkout", Headers: map[string]string{"Content-Type": ct}, Body: []byte("product_id=1&qty=1")}, IsAPI: true, Confidence: 0.8},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/checkout", Headers: map[string]string{"Content-Type": ct}, Body: []byte("product_id=2&coupon=SAVE10")}, IsAPI: true, Confidence: 0.8},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/checkout", Headers: map[string]string{"Content-Type": ct}, Body: []byte("product_id=3&gift_wrap=true&note=hello")}, IsAPI: true, Confidence: 0.8},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/checkout", Headers: map[string]string{"Content-Type": ct}, Body: []byte("product_id=4&address_id=99")}, IsAPI: true, Confidence: 0.8},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/checkout", Headers: map[string]string{"Content-Type": ct}, Body: []byte("product_id=5&promo=FLASH")}, IsAPI: true, Confidence: 0.8},
+	}
+
+	result := Deduplicate(classified)
+	assert.Len(t, result, 5, "5 POST observations with distinct bodies must each survive dedup")
+}
+
+// TestDeduplicate_IdenticalBodiesCollapse verifies that POST observations with
+// byte-identical bodies collapse to a single entry (true duplicates).
+func TestDeduplicate_IdenticalBodiesCollapse(t *testing.T) {
+	body := []byte(`{"user":"alice","role":"admin"}`)
+	ct := "application/json"
+	classified := []ClassifiedRequest{
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/users", Headers: map[string]string{"Content-Type": ct}, Body: body}, IsAPI: true, Confidence: 0.8},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/users", Headers: map[string]string{"Content-Type": ct}, Body: body}, IsAPI: true, Confidence: 0.85},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/users", Headers: map[string]string{"Content-Type": ct}, Body: body}, IsAPI: true, Confidence: 0.9},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/users", Headers: map[string]string{"Content-Type": ct}, Body: body}, IsAPI: true, Confidence: 0.7},
+		{ObservedRequest: crawl.ObservedRequest{Method: "POST", URL: "https://example.com/api/users", Headers: map[string]string{"Content-Type": ct}, Body: body}, IsAPI: true, Confidence: 0.75},
+	}
+
+	result := Deduplicate(classified)
+	require.Len(t, result, 1, "5 POST observations with byte-identical bodies must collapse to 1 entry")
+	assert.InDelta(t, 0.9, result[0].Confidence, 0.001, "highest confidence kept")
+}
+
+// TestDeduplicate_GETsStillCollapseByPath verifies that bodyless GETs continue
+// to deduplicate by path regardless of any header differences (unchanged behavior).
+func TestDeduplicate_GETsStillCollapseByPath(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: "https://example.com/api/products?page=1", QueryParams: map[string]string{"page": "1"}}, IsAPI: true, Confidence: 0.8},
+		{ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: "https://example.com/api/products?page=2", QueryParams: map[string]string{"page": "2"}}, IsAPI: true, Confidence: 0.85},
+		{ObservedRequest: crawl.ObservedRequest{Method: "GET", URL: "https://example.com/api/products?page=3", QueryParams: map[string]string{"page": "3"}}, IsAPI: true, Confidence: 0.75},
+	}
+
+	result := Deduplicate(classified)
+	require.Len(t, result, 1, "bodyless GETs must still collapse by path")
+	assert.InDelta(t, 0.85, result[0].Confidence, 0.001, "highest confidence kept")
+	// Query params from all 3 observations should be merged.
+	assert.Equal(t, "1", result[0].QueryParams["page"])
 }

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -389,6 +389,94 @@ func TestDeduplicate_NonSOAPEndpointsStillDedupByPath(t *testing.T) {
 	assert.Len(t, result, 2, "REST deduplicates by path, WSDL separate")
 }
 
+func TestDeduplicate_KeepsDistinctBodiesByContentType(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/api/submit",
+				Headers: map[string]string{"Content-Type": "application/json"},
+				Body:    []byte(`{"key":"value"}`),
+			},
+			IsAPI: true, Confidence: 0.9, APIType: "rest",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/api/submit",
+				Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+				Body:    []byte(`key=value`),
+			},
+			IsAPI: true, Confidence: 0.8, APIType: "rest",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/api/submit",
+				Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=abc123"},
+				Body:    []byte(`--abc123\r\nContent-Disposition: form-data; name="key"\r\n\r\nvalue\r\n--abc123--`),
+			},
+			IsAPI: true, Confidence: 0.85, APIType: "rest",
+		},
+	}
+
+	result := Deduplicate(classified)
+	assert.Len(t, result, 3, "distinct content types on same path must not be merged")
+}
+
+func TestDeduplicate_MergesSameContentType(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/api/create",
+				Headers: map[string]string{"Content-Type": "application/json"},
+				Body:    []byte(`{"name":"first"}`),
+			},
+			IsAPI: true, Confidence: 0.8, APIType: "rest",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://example.com/api/create",
+				Headers: map[string]string{"Content-Type": "application/json"},
+				Body:    []byte(`{"name":"second"}`),
+			},
+			IsAPI: true, Confidence: 0.9, APIType: "rest",
+		},
+	}
+
+	result := Deduplicate(classified)
+	require.Len(t, result, 1, "same content type on same path should collapse to one entry")
+	assert.InDelta(t, 0.9, result[0].Confidence, 0.001, "highest confidence kept")
+}
+
+func TestDeduplicate_GETsCollapseIgnoringContentType(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "GET",
+				URL:     "https://example.com/api/items",
+				Headers: map[string]string{"Content-Type": "application/json"},
+				// No body
+			},
+			IsAPI: true, Confidence: 0.8, APIType: "rest",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "GET",
+				URL:     "https://example.com/api/items?page=2",
+				Headers: map[string]string{"Content-Type": "application/xml"},
+				// No body
+			},
+			IsAPI: true, Confidence: 0.85, APIType: "rest",
+		},
+	}
+
+	result := Deduplicate(classified)
+	require.Len(t, result, 1, "empty-body GETs should collapse by path regardless of Content-Type header")
+}
+
 func TestRunClassifiers_WSDLWinsOverREST(t *testing.T) {
 	classifiers := []APIClassifier{
 		&RESTClassifier{},

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -15,6 +15,7 @@
 package classify
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -341,6 +342,45 @@ func TestDeduplicate_MergesSameSOAPAction(t *testing.T) {
 	assert.InDelta(t, 0.95, result[0].Confidence, 0.001, "highest confidence kept")
 }
 
+// TestDeduplicate_SOAPDistinctBodiesSurvive verifies that two SOAP requests
+// to the same endpoint and SOAPAction with DIFFERENT envelope bytes are
+// preserved as separate entries — the new body-fingerprint behavior. This
+// makes the contrast with TestDeduplicate_MergesSameSOAPAction (which uses
+// empty bodies) explicit, so future readers don't think the bodyless test
+// implies bodies are also collapsed.
+func TestDeduplicate_SOAPDistinctBodiesSurvive(t *testing.T) {
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/service",
+				Headers: map[string]string{
+					"SOAPAction":   `"urn:GetUser"`,
+					"Content-Type": "text/xml; charset=utf-8",
+				},
+				Body: []byte(`<env:Envelope xmlns:env="..."><env:Body><GetUser><id>1</id></GetUser></env:Body></env:Envelope>`),
+			},
+			IsAPI: true, Confidence: 0.85, APIType: "wsdl",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://example.com/service",
+				Headers: map[string]string{
+					"SOAPAction":   `"urn:GetUser"`,
+					"Content-Type": "text/xml; charset=utf-8",
+				},
+				Body: []byte(`<env:Envelope xmlns:env="..."><env:Body><GetUser><id>2</id></GetUser></env:Body></env:Envelope>`),
+			},
+			IsAPI: true, Confidence: 0.90, APIType: "wsdl",
+		},
+	}
+
+	result := Deduplicate(classified)
+	require.Len(t, result, 2,
+		"distinct SOAP envelope bodies on same path+SOAPAction should survive (allows downstream merge to see all observations)")
+}
+
 func TestDeduplicate_SOAPActionCaseInsensitive(t *testing.T) {
 	classified := []ClassifiedRequest{
 		{
@@ -550,4 +590,31 @@ func TestDeduplicate_GETsStillCollapseByPath(t *testing.T) {
 	assert.InDelta(t, 0.85, result[0].Confidence, 0.001, "highest confidence kept")
 	// Query params from all 3 observations should be merged.
 	assert.Equal(t, "1", result[0].QueryParams["page"])
+}
+
+// BenchmarkDeduplicate exercises the dedup hot path (key construction +
+// body fingerprint when applicable) at varying scales. Establishes a
+// baseline before stretch-goal performance work.
+func BenchmarkDeduplicate(b *testing.B) {
+	for _, n := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			// Build a fixture: n distinct POST observations, urlencoded bodies
+			input := make([]ClassifiedRequest, n)
+			for i := 0; i < n; i++ {
+				input[i] = ClassifiedRequest{
+					ObservedRequest: crawl.ObservedRequest{
+						Method:  "POST",
+						URL:     fmt.Sprintf("https://example.com/api/endpoint%d", i%50),
+						Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+						Body:    []byte(fmt.Sprintf("name=u%d&value=%d", i, i)),
+					},
+					IsAPI: true, Confidence: 0.9, APIType: "rest",
+				}
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = Deduplicate(input)
+			}
+		})
+	}
 }

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -592,6 +592,42 @@ func TestDeduplicate_GETsStillCollapseByPath(t *testing.T) {
 	assert.Equal(t, "1", result[0].QueryParams["page"])
 }
 
+// TestDeduplicate_MultipartBoundaryNormalized verifies that two logically
+// identical multipart bodies with DIFFERENT boundary tokens dedup correctly.
+// Boundaries are random per-request from clients, so without normalization
+// every observation would be unique.
+func TestDeduplicate_MultipartBoundaryNormalized(t *testing.T) {
+	body1 := []byte("--BoundaryAAA\r\n" +
+		"Content-Disposition: form-data; name=\"x\"\r\n\r\n" +
+		"value\r\n" +
+		"--BoundaryAAA--\r\n")
+	body2 := []byte("--BoundaryZZZ\r\n" +
+		"Content-Disposition: form-data; name=\"x\"\r\n\r\n" +
+		"value\r\n" +
+		"--BoundaryZZZ--\r\n")
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST", URL: "https://example.com/api/upload",
+				Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=BoundaryAAA"},
+				Body:    body1,
+			},
+			IsAPI: true, Confidence: 0.85, APIType: "rest",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST", URL: "https://example.com/api/upload",
+				Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=BoundaryZZZ"},
+				Body:    body2,
+			},
+			IsAPI: true, Confidence: 0.95, APIType: "rest",
+		},
+	}
+	result := Deduplicate(classified)
+	require.Len(t, result, 1, "identical multipart content with different boundaries should dedup to one entry")
+	assert.InDelta(t, 0.95, result[0].Confidence, 0.001, "highest confidence kept")
+}
+
 // BenchmarkDeduplicate exercises the dedup hot path (key construction +
 // body fingerprint when applicable) at varying scales. Establishes a
 // baseline before stretch-goal performance work.
@@ -600,13 +636,13 @@ func BenchmarkDeduplicate(b *testing.B) {
 		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
 			// Build a fixture: n distinct POST observations, urlencoded bodies
 			input := make([]ClassifiedRequest, n)
-			for i := 0; i < n; i++ {
+			for i := range n {
 				input[i] = ClassifiedRequest{
 					ObservedRequest: crawl.ObservedRequest{
 						Method:  "POST",
 						URL:     fmt.Sprintf("https://example.com/api/endpoint%d", i%50),
 						Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-						Body:    []byte(fmt.Sprintf("name=u%d&value=%d", i, i)),
+						Body:    fmt.Appendf(nil, "name=u%d&value=%d", i, i),
 					},
 					IsAPI: true, Confidence: 0.9, APIType: "rest",
 				}

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -379,6 +379,20 @@ func TestDeduplicate_SOAPDistinctBodiesSurvive(t *testing.T) {
 	result := Deduplicate(classified)
 	require.Len(t, result, 2,
 		"distinct SOAP envelope bodies on same path+SOAPAction should survive (allows downstream merge to see all observations)")
+
+	// Also assert the actual envelope bytes survive.
+	gotBodies := make([]string, 0, len(result))
+	for _, r := range result {
+		gotBodies = append(gotBodies, string(r.Body))
+	}
+	assert.ElementsMatch(t,
+		[]string{
+			`<env:Envelope xmlns:env="..."><env:Body><GetUser><id>1</id></GetUser></env:Body></env:Envelope>`,
+			`<env:Envelope xmlns:env="..."><env:Body><GetUser><id>2</id></GetUser></env:Body></env:Envelope>`,
+		},
+		gotBodies,
+		"both SOAP envelope bodies (<id>1</id> and <id>2</id>) must survive dedup",
+	)
 }
 
 func TestDeduplicate_SOAPActionCaseInsensitive(t *testing.T) {
@@ -556,6 +570,23 @@ func TestDeduplicate_DistinctBodiesSurvive(t *testing.T) {
 
 	result := Deduplicate(classified)
 	assert.Len(t, result, 5, "5 POST observations with distinct bodies must each survive dedup")
+
+	// Also assert that the SET of body bytes in the result equals the input set.
+	gotBodies := make([]string, 0, len(result))
+	for _, r := range result {
+		gotBodies = append(gotBodies, string(r.Body))
+	}
+	assert.ElementsMatch(t,
+		[]string{
+			"product_id=1&qty=1",
+			"product_id=2&coupon=SAVE10",
+			"product_id=3&gift_wrap=true&note=hello",
+			"product_id=4&address_id=99",
+			"product_id=5&promo=FLASH",
+		},
+		gotBodies,
+		"result bodies should match input bodies exactly",
+	)
 }
 
 // TestDeduplicate_IdenticalBodiesCollapse verifies that POST observations with

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -659,6 +659,40 @@ func TestDeduplicate_MultipartBoundaryNormalized(t *testing.T) {
 	assert.InDelta(t, 0.95, result[0].Confidence, 0.001, "highest confidence kept")
 }
 
+// TestDeduplicate_MultipartShortBoundarySkipsNormalize verifies that when the
+// multipart boundary is shorter than 4 characters, boundary normalization is
+// skipped and the raw body bytes are used for fingerprinting instead.
+// Two observations with boundary=ab (2 chars) and different boundary values
+// but otherwise identical content must NOT dedup because the normalization
+// path is not taken — they hash to different raw bytes.
+func TestDeduplicate_MultipartShortBoundarySkipsNormalize(t *testing.T) {
+	// Both observations have the same logical content but different raw bytes
+	// because the boundary tokens differ and are NOT normalized (len < 4).
+	body1 := []byte("--ab\r\nContent-Disposition: form-data; name=\"x\"\r\n\r\nvalue\r\n--ab--\r\n")
+	body2 := []byte("--cd\r\nContent-Disposition: form-data; name=\"x\"\r\n\r\nvalue\r\n--cd--\r\n")
+	classified := []ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST", URL: "https://example.com/api/upload",
+				Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=ab"},
+				Body:    body1,
+			},
+			IsAPI: true, Confidence: 0.85, APIType: "rest",
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST", URL: "https://example.com/api/upload",
+				Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=cd"},
+				Body:    body2,
+			},
+			IsAPI: true, Confidence: 0.90, APIType: "rest",
+		},
+	}
+	result := Deduplicate(classified)
+	assert.Len(t, result, 2,
+		"short boundaries (<4 chars) skip normalization, so raw body hashes differ and observations must NOT dedup")
+}
+
 // BenchmarkDeduplicate exercises the dedup hot path (key construction +
 // body fingerprint when applicable) at varying scales. Establishes a
 // baseline before stretch-goal performance work.
@@ -679,7 +713,7 @@ func BenchmarkDeduplicate(b *testing.B) {
 				}
 			}
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_ = Deduplicate(input)
 			}
 		})

--- a/pkg/classify/classifier_test.go
+++ b/pkg/classify/classifier_test.go
@@ -468,7 +468,7 @@ func TestDeduplicate_KeepsDistinctBodiesByContentType(t *testing.T) {
 				Method:  "POST",
 				URL:     "https://example.com/api/submit",
 				Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=abc123"},
-				Body:    []byte(`--abc123\r\nContent-Disposition: form-data; name="key"\r\n\r\nvalue\r\n--abc123--`),
+				Body:    []byte("--abc123\r\nContent-Disposition: form-data; name=\"key\"\r\n\r\nvalue\r\n--abc123--\r\n"),
 			},
 			IsAPI: true, Confidence: 0.85, APIType: "rest",
 		},
@@ -691,6 +691,148 @@ func TestDeduplicate_MultipartShortBoundarySkipsNormalize(t *testing.T) {
 	result := Deduplicate(classified)
 	assert.Len(t, result, 2,
 		"short boundaries (<4 chars) skip normalization, so raw body hashes differ and observations must NOT dedup")
+}
+
+// TestDeduplicate_BodyWithoutContentType verifies body-fingerprint logic when
+// no Content-Type header is present. Two distinct body bytes should survive as
+// two separate entries; two identical bodies should collapse to one.
+func TestDeduplicate_BodyWithoutContentType(t *testing.T) {
+	t.Run("two distinct bodies survive", func(t *testing.T) {
+		classified := []ClassifiedRequest{
+			{
+				ObservedRequest: crawl.ObservedRequest{
+					Method: "POST",
+					URL:    "https://example.com/api/data",
+					// No Content-Type header
+					Body: []byte("foo=1&bar=2"),
+				},
+				IsAPI: true, Confidence: 0.8, APIType: "rest",
+			},
+			{
+				ObservedRequest: crawl.ObservedRequest{
+					Method: "POST",
+					URL:    "https://example.com/api/data",
+					// No Content-Type header
+					Body: []byte("baz=3&qux=4"),
+				},
+				IsAPI: true, Confidence: 0.8, APIType: "rest",
+			},
+		}
+		result := Deduplicate(classified)
+		assert.Len(t, result, 2, "two distinct bodies without Content-Type must not be merged")
+	})
+
+	t.Run("two identical bodies collapse to one", func(t *testing.T) {
+		body := []byte("same=body&data=here")
+		classified := []ClassifiedRequest{
+			{
+				ObservedRequest: crawl.ObservedRequest{
+					Method: "POST",
+					URL:    "https://example.com/api/data",
+					Body:   body,
+				},
+				IsAPI: true, Confidence: 0.8, APIType: "rest",
+			},
+			{
+				ObservedRequest: crawl.ObservedRequest{
+					Method: "POST",
+					URL:    "https://example.com/api/data",
+					Body:   body,
+				},
+				IsAPI: true, Confidence: 0.9, APIType: "rest",
+			},
+		}
+		result := Deduplicate(classified)
+		require.Len(t, result, 1, "byte-identical bodies without Content-Type must collapse to one entry")
+		assert.InDelta(t, 0.9, result[0].Confidence, 0.001, "highest confidence kept")
+	})
+}
+
+// TestGetContentType verifies case-insensitive header lookup for Content-Type.
+func TestGetContentType(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{
+			name:    "empty headers",
+			headers: map[string]string{},
+			want:    "",
+		},
+		{
+			name:    "exact case Content-Type",
+			headers: map[string]string{"Content-Type": "application/json"},
+			want:    "application/json",
+		},
+		{
+			name:    "lowercase content-type",
+			headers: map[string]string{"content-type": "application/json"},
+			want:    "application/json",
+		},
+		{
+			name:    "title-case Content-type",
+			headers: map[string]string{"Content-type": "application/json"},
+			want:    "application/json",
+		},
+		{
+			name:    "uppercase CONTENT-TYPE",
+			headers: map[string]string{"CONTENT-TYPE": "application/json"},
+			want:    "application/json",
+		},
+		{
+			name:    "absent header returns empty",
+			headers: map[string]string{"Accept": "text/html"},
+			want:    "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getContentType(tc.headers)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestBaseMediaType verifies that baseMediaType strips parameters and lowercases.
+func TestBaseMediaType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "plain application/json",
+			input: "application/json",
+			want:  "application/json",
+		},
+		{
+			name:  "with parameters application/json; charset=utf-8",
+			input: "application/json; charset=utf-8",
+			want:  "application/json",
+		},
+		{
+			name:  "lowercase normalization Application/JSON",
+			input: "Application/JSON",
+			want:  "application/json",
+		},
+		{
+			name:  "whitespace handling",
+			input: "  text/html  ; q=1",
+			want:  "text/html",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := baseMediaType(tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // BenchmarkDeduplicate exercises the dedup hot path (key construction +

--- a/pkg/classify/doc.go
+++ b/pkg/classify/doc.go
@@ -26,5 +26,9 @@
 //
 // [RunClassifiers] applies one or more classifiers to a slice of observed
 // requests, returning only those that exceed the confidence threshold.
-// [Deduplicate] removes duplicate endpoints based on method and normalized URL.
+// [Deduplicate] removes duplicate endpoints based on method, normalized URL,
+// and (for non-empty bodies) Content-Type plus an 8-byte body fingerprint.
+// Bodyless requests still collapse by method and path. Distinct request body
+// shapes on the same endpoint+content-type survive as separate entries so
+// downstream merge logic can union their fields.
 package classify

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -123,7 +123,8 @@ func (b *BrowserManager) cleanup() {
 // for use with defer in the normal (non-signal) path.
 func (b *BrowserManager) Close() {
 	if b.browser != nil {
-		_ = b.browser.Close() // best-effort; process may already be dead
+		// #nosec G104 -- best-effort close on a process that may already be dead; any error is unactionable and the subsequent Kill() + cleanup() still execute.
+		b.browser.Close() //nolint:errcheck,gosec // best-effort; process may already be dead
 	}
 	b.Kill()
 	b.cleanup()

--- a/pkg/generate/rest/doc.go
+++ b/pkg/generate/rest/doc.go
@@ -23,4 +23,11 @@
 //     parameterized templates while preserving known literals (/me, /self).
 //   - Schema inference examines response JSON to generate OpenAPI schema
 //     objects with depth and property guards.
+//   - [ParseURLEncodedForm] and [ParseMultipartForm] parse request bodies for
+//     application/x-www-form-urlencoded and multipart/form-data content types
+//     respectively. File upload fields are represented as type: string,
+//     format: binary. Text fields undergo type inference (integer, number,
+//     boolean, string). Multiple observations for the same endpoint and
+//     content-type are merged in buildOperation via per-content-type grouping,
+//     unioning properties and promoting conflicting types to string.
 package rest

--- a/pkg/generate/rest/form.go
+++ b/pkg/generate/rest/form.go
@@ -25,6 +25,11 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
+// maxMultipartParts bounds memory under adversarial input where a hostile
+// multipart body might contain millions of trivial parts. Realistic forms
+// have well below this limit.
+const maxMultipartParts = 1000
+
 // getHeader retrieves a header value case-insensitively. The exact-match
 // shortcut at the top is a performance optimization for the common path
 // (browser-lowercased "content-type"); the loop handles other casings such
@@ -72,9 +77,16 @@ func ParseMultipartForm(body []byte, boundary string) *openapi3.SchemaRef {
 	}
 	reader := multipart.NewReader(bytes.NewReader(body), boundary)
 	schema := openapi3.NewObjectSchema()
+	partCount := 0
 	for {
 		part, err := reader.NextPart()
 		if err != nil {
+			break
+		}
+		partCount++
+		if partCount > maxMultipartParts {
+			// Defensive: bound memory under adversarial input where a hostile
+			// multipart body might contain millions of trivial parts.
 			break
 		}
 		name := part.FormName()

--- a/pkg/generate/rest/form.go
+++ b/pkg/generate/rest/form.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/url"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// getHeader retrieves a header value case-insensitively. It checks for an exact
+// match first, then falls back to a case-insensitive scan. This handles browsers
+// (lowercase "content-type") and Burp/HAR importers (title-case "Content-Type").
+func getHeader(headers map[string]string, name string) string {
+	if v, ok := headers[name]; ok {
+		return v
+	}
+	lower := strings.ToLower(name)
+	for k, v := range headers {
+		if strings.ToLower(k) == lower {
+			return v
+		}
+	}
+	return ""
+}
+
+// ParseURLEncodedForm parses an application/x-www-form-urlencoded body into an
+// OpenAPI SchemaRef (object with one property per field).
+func ParseURLEncodedForm(body []byte) *openapi3.SchemaRef {
+	if len(body) == 0 {
+		return nil
+	}
+	values, err := url.ParseQuery(string(body))
+	if err != nil || len(values) == 0 {
+		return nil
+	}
+	schema := openapi3.NewObjectSchema()
+	for key, vals := range values {
+		t := inferQueryParamType(vals[0])
+		schema.Properties[key] = openapi3.NewSchemaRef("", &openapi3.Schema{
+			Type: &openapi3.Types{t},
+		})
+	}
+	return openapi3.NewSchemaRef("", schema)
+}
+
+// ParseMultipartForm parses a multipart/form-data body into an OpenAPI SchemaRef.
+// File upload fields get type: string, format: binary.
+// boundary must be extracted from the Content-Type header of the observation.
+func ParseMultipartForm(body []byte, boundary string) *openapi3.SchemaRef {
+	if boundary == "" {
+		return nil
+	}
+	reader := multipart.NewReader(strings.NewReader(string(body)), boundary)
+	schema := openapi3.NewObjectSchema()
+	for {
+		part, err := reader.NextPart()
+		if err != nil {
+			break
+		}
+		name := part.FormName()
+		if name == "" {
+			continue
+		}
+		if part.FileName() != "" {
+			fileSchema := openapi3.NewStringSchema()
+			fileSchema.Format = "binary"
+			schema.Properties[name] = openapi3.NewSchemaRef("", fileSchema)
+		} else {
+			var buf strings.Builder
+			_, _ = io.Copy(&buf, part) //nolint:errcheck // read from in-memory multipart part; errors are not actionable
+			t := inferQueryParamType(buf.String())
+			schema.Properties[name] = openapi3.NewSchemaRef("", &openapi3.Schema{
+				Type: &openapi3.Types{t},
+			})
+		}
+	}
+	if len(schema.Properties) == 0 {
+		return nil
+	}
+	return openapi3.NewSchemaRef("", schema)
+}
+
+// extractBoundary returns the multipart boundary from a Content-Type header value.
+func extractBoundary(contentType string) string {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return ""
+	}
+	return params["boundary"]
+}
+
+// mergeURLEncodedBodies merges URL-encoded form bodies across multiple observations
+// into a single OpenAPI SchemaRef by taking the union of all observed properties.
+func mergeURLEncodedBodies(bodies [][]byte) *openapi3.SchemaRef {
+	var merged *openapi3.SchemaRef
+	for _, body := range bodies {
+		schema := ParseURLEncodedForm(body)
+		merged = mergeObjectSchemas(merged, schema)
+	}
+	return merged
+}
+
+// mergeMultipartBodies merges multipart form bodies across multiple observations.
+// contentTypes must correspond 1:1 with bodies; each entry is the full Content-Type
+// header value for that observation (used to extract the per-observation boundary).
+func mergeMultipartBodies(bodies [][]byte, contentTypes []string) *openapi3.SchemaRef {
+	var merged *openapi3.SchemaRef
+	for i, body := range bodies {
+		ct := ""
+		if i < len(contentTypes) {
+			ct = contentTypes[i]
+		}
+		boundary := extractBoundary(ct)
+		schema := ParseMultipartForm(body, boundary)
+		merged = mergeObjectSchemas(merged, schema)
+	}
+	return merged
+}
+
+// mergeObjectSchemas merges overlay's properties into base and returns base.
+// If both schemas define the same property with conflicting types, the property
+// is promoted to string (matching the strategy used for JSON schema merging).
+func mergeObjectSchemas(base, overlay *openapi3.SchemaRef) *openapi3.SchemaRef {
+	if base == nil {
+		return overlay
+	}
+	if overlay == nil {
+		return base
+	}
+	if base.Value == nil || base.Value.Properties == nil ||
+		overlay.Value == nil || overlay.Value.Properties == nil {
+		return base
+	}
+	for k, v := range overlay.Value.Properties {
+		if existing, ok := base.Value.Properties[k]; ok {
+			if schemaTypesConflict(existing, v) {
+				base.Value.Properties[k] = openapi3.NewSchemaRef("", openapi3.NewStringSchema())
+			}
+		} else {
+			base.Value.Properties[k] = v
+		}
+	}
+	return base
+}
+
+// schemaTypesConflict returns true if two SchemaRefs carry different non-empty type names.
+func schemaTypesConflict(a, b *openapi3.SchemaRef) bool {
+	if a == nil || b == nil || a.Value == nil || b.Value == nil {
+		return false
+	}
+	if a.Value.Type == nil || b.Value.Type == nil {
+		return false
+	}
+	aTypes := a.Value.Type.Slice()
+	bTypes := b.Value.Type.Slice()
+	if len(aTypes) == 0 || len(bTypes) == 0 {
+		return false
+	}
+	return aTypes[0] != bTypes[0]
+}

--- a/pkg/generate/rest/form.go
+++ b/pkg/generate/rest/form.go
@@ -15,6 +15,7 @@
 package rest
 
 import (
+	"bytes"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -24,9 +25,11 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// getHeader retrieves a header value case-insensitively. It checks for an exact
-// match first, then falls back to a case-insensitive scan. This handles browsers
-// (lowercase "content-type") and Burp/HAR importers (title-case "Content-Type").
+// getHeader retrieves a header value case-insensitively. The exact-match
+// shortcut at the top is a performance optimization for the common path
+// (browser-lowercased "content-type"); the loop handles other casings such
+// as Burp/HAR's title-case "Content-Type". Both branches return semantically
+// identical results — the shortcut is not a behavioral distinction.
 func getHeader(headers map[string]string, name string) string {
 	if v, ok := headers[name]; ok {
 		return v
@@ -67,7 +70,7 @@ func ParseMultipartForm(body []byte, boundary string) *openapi3.SchemaRef {
 	if boundary == "" {
 		return nil
 	}
-	reader := multipart.NewReader(strings.NewReader(string(body)), boundary)
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
 	schema := openapi3.NewObjectSchema()
 	for {
 		part, err := reader.NextPart()
@@ -83,8 +86,11 @@ func ParseMultipartForm(body []byte, boundary string) *openapi3.SchemaRef {
 			fileSchema.Format = "binary"
 			schema.Properties[name] = openapi3.NewSchemaRef("", fileSchema)
 		} else {
+			// Type inference only needs a small prefix of the value (we only check
+			// for integer/number/boolean format); reading the entire part into memory
+			// is wasteful for large text fields.
 			var buf strings.Builder
-			_, _ = io.Copy(&buf, part) //nolint:errcheck // read from in-memory multipart part; errors are not actionable
+			_, _ = io.Copy(&buf, io.LimitReader(part, 4096)) //nolint:errcheck // read from in-memory multipart part; errors are not actionable
 			t := inferQueryParamType(buf.String())
 			schema.Properties[name] = openapi3.NewSchemaRef("", &openapi3.Schema{
 				Type: &openapi3.Types{t},

--- a/pkg/generate/rest/form.go
+++ b/pkg/generate/rest/form.go
@@ -30,6 +30,11 @@ import (
 // have well below this limit.
 const maxMultipartParts = 1000
 
+const (
+	maxURLEncodedBodySize = 10 * 1024 * 1024 // 10MB; matches JSON InferSchema cap
+	maxFormFields         = 1000             // matches maxMultipartParts
+)
+
 // getHeader retrieves a header value case-insensitively. The exact-match
 // shortcut at the top is a performance optimization for the common path
 // (browser-lowercased "content-type"); the loop handles other casings such
@@ -54,8 +59,20 @@ func ParseURLEncodedForm(body []byte) *openapi3.SchemaRef {
 	if len(body) == 0 {
 		return nil
 	}
+	// Bound resident memory under adversarial input. The JSON path has the
+	// same cap (schema.go:maxBodySize); aligning here so all three body parsers
+	// (JSON / urlencoded / multipart) reject obviously hostile sizes uniformly.
+	if len(body) > maxURLEncodedBodySize {
+		return nil
+	}
 	values, err := url.ParseQuery(string(body))
 	if err != nil || len(values) == 0 {
+		return nil
+	}
+	if len(values) > maxFormFields {
+		// Defensive: don't allocate one schema property per field on adversarial
+		// bodies (millions of `k=v&` pairs). Drop on the floor to mirror
+		// multipart's maxMultipartParts behavior.
 		return nil
 	}
 	schema := openapi3.NewObjectSchema()

--- a/pkg/generate/rest/form.go
+++ b/pkg/generate/rest/form.go
@@ -17,6 +17,7 @@ package rest
 import (
 	"bytes"
 	"io"
+	"log/slog"
 	"mime"
 	"mime/multipart"
 	"net/url"
@@ -25,14 +26,14 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// maxMultipartParts bounds memory under adversarial input where a hostile
-// multipart body might contain millions of trivial parts. Realistic forms
-// have well below this limit.
-const maxMultipartParts = 1000
-
 const (
 	maxURLEncodedBodySize = 10 * 1024 * 1024 // 10MB; matches JSON InferSchema cap
 	maxFormFields         = 1000             // matches maxMultipartParts
+	maxMultipartBodySize  = 10 * 1024 * 1024 // 10MB; parity with urlencoded + JSON
+	// maxMultipartParts bounds memory under adversarial input where a hostile
+	// multipart body might contain millions of trivial parts. Realistic forms
+	// have well below this limit.
+	maxMultipartParts = 1000
 )
 
 // getHeader retrieves a header value case-insensitively. The exact-match
@@ -63,6 +64,7 @@ func ParseURLEncodedForm(body []byte) *openapi3.SchemaRef {
 	// same cap (schema.go:maxBodySize); aligning here so all three body parsers
 	// (JSON / urlencoded / multipart) reject obviously hostile sizes uniformly.
 	if len(body) > maxURLEncodedBodySize {
+		slog.Warn("form parser dropped urlencoded body", "reason", "body_size_exceeded", "size", len(body), "cap", maxURLEncodedBodySize)
 		return nil
 	}
 	values, err := url.ParseQuery(string(body))
@@ -73,6 +75,7 @@ func ParseURLEncodedForm(body []byte) *openapi3.SchemaRef {
 		// Defensive: don't allocate one schema property per field on adversarial
 		// bodies (millions of `k=v&` pairs). Drop on the floor to mirror
 		// multipart's maxMultipartParts behavior.
+		slog.Warn("form parser dropped urlencoded body", "reason", "field_count_exceeded", "fields", len(values), "cap", maxFormFields)
 		return nil
 	}
 	schema := openapi3.NewObjectSchema()
@@ -92,6 +95,10 @@ func ParseMultipartForm(body []byte, boundary string) *openapi3.SchemaRef {
 	if boundary == "" {
 		return nil
 	}
+	if len(body) > maxMultipartBodySize {
+		slog.Warn("form parser dropped multipart body", "reason", "body_size_exceeded", "size", len(body), "cap", maxMultipartBodySize)
+		return nil
+	}
 	reader := multipart.NewReader(bytes.NewReader(body), boundary)
 	schema := openapi3.NewObjectSchema()
 	partCount := 0
@@ -104,6 +111,7 @@ func ParseMultipartForm(body []byte, boundary string) *openapi3.SchemaRef {
 		if partCount > maxMultipartParts {
 			// Defensive: bound memory under adversarial input where a hostile
 			// multipart body might contain millions of trivial parts.
+			slog.Warn("form parser truncated multipart body", "reason", "parts_cap_exceeded", "cap", maxMultipartParts)
 			break
 		}
 		name := part.FormName()

--- a/pkg/generate/rest/form_test.go
+++ b/pkg/generate/rest/form_test.go
@@ -29,35 +29,25 @@ func TestParseURLEncodedForm(t *testing.T) {
 	t.Run("basic fields with type inference", func(t *testing.T) {
 		body := []byte("name=Alice&age=30")
 		schema := ParseURLEncodedForm(body)
-		if schema == nil {
-			t.Fatal("expected schema, got nil")
-		}
-		if schema.Value == nil || schema.Value.Properties == nil {
-			t.Fatal("expected object schema with properties")
-		}
-		if _, ok := schema.Value.Properties["name"]; !ok {
-			t.Error("expected property 'name'")
-		}
-		if _, ok := schema.Value.Properties["age"]; !ok {
-			t.Error("expected property 'age'")
-		}
+		require.NotNil(t, schema, "expected schema, got nil")
+		require.NotNil(t, schema.Value, "expected object schema")
+		require.NotNil(t, schema.Value.Properties, "expected schema with properties")
+
+		assert.Contains(t, schema.Value.Properties, "name", "expected property 'name'")
+		assert.Contains(t, schema.Value.Properties, "age", "expected property 'age'")
+
+		require.NotNil(t, schema.Value.Properties["name"])
 		nameType := schema.Value.Properties["name"].Value.Type.Slice()[0]
-		if nameType != "string" {
-			t.Errorf("name type = %q, want string", nameType)
-		}
+		assert.Equal(t, "string", nameType, "name type = %q, want string", nameType)
+
+		require.NotNil(t, schema.Value.Properties["age"])
 		ageType := schema.Value.Properties["age"].Value.Type.Slice()[0]
-		if ageType != "integer" {
-			t.Errorf("age type = %q, want integer", ageType)
-		}
+		assert.Equal(t, "integer", ageType, "age type = %q, want integer", ageType)
 	})
 
 	t.Run("empty body returns nil", func(t *testing.T) {
-		if schema := ParseURLEncodedForm([]byte("")); schema != nil {
-			t.Error("expected nil for empty body")
-		}
-		if schema := ParseURLEncodedForm(nil); schema != nil {
-			t.Error("expected nil for nil body")
-		}
+		assert.Nil(t, ParseURLEncodedForm([]byte("")), "expected nil for empty body")
+		assert.Nil(t, ParseURLEncodedForm(nil), "expected nil for nil body")
 	})
 }
 
@@ -65,21 +55,19 @@ func TestParseMultipartForm(t *testing.T) {
 	t.Run("text field becomes string", func(t *testing.T) {
 		var buf bytes.Buffer
 		w := multipart.NewWriter(&buf)
-		if err := w.WriteField("username", "alice"); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w.WriteField("username", "alice"))
 		_ = w.Close()
 
 		schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
-		if schema == nil {
-			t.Fatal("expected schema, got nil")
-		}
-		if _, ok := schema.Value.Properties["username"]; !ok {
-			t.Error("expected property 'username'")
-		}
-		uType := schema.Value.Properties["username"].Value.Type.Slice()[0]
-		if uType != "string" {
-			t.Errorf("username type = %q, want string", uType)
+		require.NotNil(t, schema, "expected schema, got nil")
+		require.NotNil(t, schema.Value)
+		require.NotNil(t, schema.Value.Properties)
+
+		assert.Contains(t, schema.Value.Properties, "username", "expected property 'username'")
+		if prop, ok := schema.Value.Properties["username"]; ok {
+			require.NotNil(t, prop)
+			uType := prop.Value.Type.Slice()[0]
+			assert.Equal(t, "string", uType, "username type = %q, want string", uType)
 		}
 	})
 
@@ -90,63 +78,48 @@ func TestParseMultipartForm(t *testing.T) {
 		h.Set("Content-Disposition", `form-data; name="avatar"; filename="photo.jpg"`)
 		h.Set("Content-Type", "image/jpeg")
 		fw, err := w.CreatePart(h)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, _ = fw.Write([]byte("JPEG_DATA"))
 		_ = w.Close()
 
 		schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
-		if schema == nil {
-			t.Fatal("expected schema, got nil")
-		}
+		require.NotNil(t, schema, "expected schema, got nil")
+		require.NotNil(t, schema.Value)
+		require.NotNil(t, schema.Value.Properties)
+
 		prop, ok := schema.Value.Properties["avatar"]
-		if !ok {
-			t.Fatal("expected property 'avatar'")
-		}
-		if prop.Value.Type.Slice()[0] != "string" {
-			t.Errorf("avatar type = %q, want string", prop.Value.Type.Slice()[0])
-		}
-		if prop.Value.Format != "binary" {
-			t.Errorf("avatar format = %q, want binary", prop.Value.Format)
-		}
+		require.True(t, ok, "expected property 'avatar'")
+		require.NotNil(t, prop)
+		assert.Equal(t, "string", prop.Value.Type.Slice()[0], "avatar type = %q, want string", prop.Value.Type.Slice()[0])
+		assert.Equal(t, "binary", prop.Value.Format, "avatar format = %q, want binary", prop.Value.Format)
 	})
 
 	t.Run("mixed text and file fields", func(t *testing.T) {
 		var buf bytes.Buffer
 		w := multipart.NewWriter(&buf)
-		if err := w.WriteField("description", "hello world"); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w.WriteField("description", "hello world"))
 		h := make(textproto.MIMEHeader)
 		h.Set("Content-Disposition", `form-data; name="upload"; filename="data.bin"`)
 		fw, err := w.CreatePart(h)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, _ = fw.Write([]byte("binary content"))
 		_ = w.Close()
 
 		schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
-		if schema == nil {
-			t.Fatal("expected schema, got nil")
-		}
-		if _, ok := schema.Value.Properties["description"]; !ok {
-			t.Error("expected property 'description'")
-		}
+		require.NotNil(t, schema, "expected schema, got nil")
+		require.NotNil(t, schema.Value)
+		require.NotNil(t, schema.Value.Properties)
+
+		assert.Contains(t, schema.Value.Properties, "description", "expected property 'description'")
+
 		upload, ok := schema.Value.Properties["upload"]
-		if !ok {
-			t.Fatal("expected property 'upload'")
-		}
-		if upload.Value.Format != "binary" {
-			t.Errorf("upload format = %q, want binary", upload.Value.Format)
-		}
+		require.True(t, ok, "expected property 'upload'")
+		require.NotNil(t, upload)
+		assert.Equal(t, "binary", upload.Value.Format, "upload format = %q, want binary", upload.Value.Format)
 	})
 
 	t.Run("empty boundary returns nil", func(t *testing.T) {
-		if schema := ParseMultipartForm([]byte("data"), ""); schema != nil {
-			t.Error("expected nil for empty boundary")
-		}
+		assert.Nil(t, ParseMultipartForm([]byte("data"), ""), "expected nil for empty boundary")
 	})
 }
 
@@ -154,17 +127,13 @@ func TestMergeMultipartBodies(t *testing.T) {
 	t.Run("merges properties from two observations", func(t *testing.T) {
 		var buf1 bytes.Buffer
 		w1 := multipart.NewWriter(&buf1)
-		if err := w1.WriteField("username", "alice"); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w1.WriteField("username", "alice"))
 		_ = w1.Close()
 		ct1 := "multipart/form-data; boundary=" + w1.Boundary()
 
 		var buf2 bytes.Buffer
 		w2 := multipart.NewWriter(&buf2)
-		if err := w2.WriteField("email", "alice@example.com"); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w2.WriteField("email", "alice@example.com"))
 		_ = w2.Close()
 		ct2 := "multipart/form-data; boundary=" + w2.Boundary()
 
@@ -172,48 +141,38 @@ func TestMergeMultipartBodies(t *testing.T) {
 			[][]byte{buf1.Bytes(), buf2.Bytes()},
 			[]string{ct1, ct2},
 		)
-		if schema == nil {
-			t.Fatal("expected merged schema, got nil")
-		}
-		if _, ok := schema.Value.Properties["username"]; !ok {
-			t.Error("expected property 'username' from first observation")
-		}
-		if _, ok := schema.Value.Properties["email"]; !ok {
-			t.Error("expected property 'email' from second observation")
-		}
+		require.NotNil(t, schema, "expected merged schema, got nil")
+		require.NotNil(t, schema.Value)
+		require.NotNil(t, schema.Value.Properties)
+
+		assert.Contains(t, schema.Value.Properties, "username", "expected property 'username' from first observation")
+		assert.Contains(t, schema.Value.Properties, "email", "expected property 'email' from second observation")
 	})
 
 	t.Run("single observation returns that observation's schema", func(t *testing.T) {
 		var buf bytes.Buffer
 		w := multipart.NewWriter(&buf)
-		if err := w.WriteField("field1", "value1"); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w.WriteField("field1", "value1"))
 		_ = w.Close()
 		ct := "multipart/form-data; boundary=" + w.Boundary()
 
 		schema := mergeMultipartBodies([][]byte{buf.Bytes()}, []string{ct})
-		if schema == nil {
-			t.Fatal("expected schema, got nil")
-		}
-		if _, ok := schema.Value.Properties["field1"]; !ok {
-			t.Error("expected property 'field1'")
-		}
+		require.NotNil(t, schema, "expected schema, got nil")
+		require.NotNil(t, schema.Value)
+		require.NotNil(t, schema.Value.Properties)
+
+		assert.Contains(t, schema.Value.Properties, "field1", "expected property 'field1'")
 	})
 
 	t.Run("missing content-type entry skips that observation", func(t *testing.T) {
 		var buf bytes.Buffer
 		w := multipart.NewWriter(&buf)
-		if err := w.WriteField("name", "bob"); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w.WriteField("name", "bob"))
 		_ = w.Close()
 		// Provide body but no corresponding content-type entry.
 		schema := mergeMultipartBodies([][]byte{buf.Bytes()}, []string{})
 		// With no boundary the observation is skipped; result is nil.
-		if schema != nil {
-			t.Error("expected nil when no content-type provided")
-		}
+		assert.Nil(t, schema, "expected nil when no content-type provided")
 	})
 }
 
@@ -222,62 +181,70 @@ func TestMergeObjectSchemas(t *testing.T) {
 		// base has "count" as integer, overlay has "count" as string — conflict.
 		base := ParseURLEncodedForm([]byte("count=42"))
 		overlay := ParseURLEncodedForm([]byte("count=hello"))
-		if base == nil || overlay == nil {
-			t.Fatal("test setup failed: expected non-nil schemas")
-		}
+		require.NotNil(t, base, "test setup failed: expected non-nil base schema")
+		require.NotNil(t, overlay, "test setup failed: expected non-nil overlay schema")
 
 		merged := mergeObjectSchemas(base, overlay)
-		if merged == nil {
-			t.Fatal("expected merged schema, got nil")
-		}
+		require.NotNil(t, merged, "expected merged schema, got nil")
+		require.NotNil(t, merged.Value)
+		require.NotNil(t, merged.Value.Properties)
+
 		countProp, ok := merged.Value.Properties["count"]
-		if !ok {
-			t.Fatal("expected property 'count' in merged schema")
-		}
+		require.True(t, ok, "expected property 'count' in merged schema")
+		require.NotNil(t, countProp)
 		// After conflict, property should be promoted to string.
 		gotType := countProp.Value.Type.Slice()[0]
-		if gotType != "string" {
-			t.Errorf("count type after conflict = %q, want string", gotType)
-		}
+		assert.Equal(t, "string", gotType, "count type after conflict = %q, want string", gotType)
 	})
 
 	t.Run("no conflict keeps original types", func(t *testing.T) {
 		base := ParseURLEncodedForm([]byte("name=Alice&count=5"))
 		overlay := ParseURLEncodedForm([]byte("active=true"))
-		if base == nil || overlay == nil {
-			t.Fatal("test setup failed: expected non-nil schemas")
-		}
+		require.NotNil(t, base, "test setup failed: expected non-nil base schema")
+		require.NotNil(t, overlay, "test setup failed: expected non-nil overlay schema")
 
 		merged := mergeObjectSchemas(base, overlay)
-		if merged == nil {
-			t.Fatal("expected merged schema, got nil")
-		}
-		if _, ok := merged.Value.Properties["active"]; !ok {
-			t.Error("expected property 'active' from overlay")
-		}
+		require.NotNil(t, merged, "expected merged schema, got nil")
+		require.NotNil(t, merged.Value)
+		require.NotNil(t, merged.Value.Properties)
+
+		assert.Contains(t, merged.Value.Properties, "active", "expected property 'active' from overlay")
 		// count was only in base; type should be unchanged.
 		countProp, ok := merged.Value.Properties["count"]
-		if !ok {
-			t.Fatal("expected property 'count' in merged schema")
-		}
-		if countProp.Value.Type.Slice()[0] != "integer" {
-			t.Errorf("count type = %q, want integer", countProp.Value.Type.Slice()[0])
-		}
+		require.True(t, ok, "expected property 'count' in merged schema")
+		require.NotNil(t, countProp)
+		assert.Equal(t, "integer", countProp.Value.Type.Slice()[0], "count type = %q, want integer", countProp.Value.Type.Slice()[0])
 	})
 
 	t.Run("nil base returns overlay", func(t *testing.T) {
-		overlay := ParseURLEncodedForm([]byte("x=1"))
+		overlay := ParseURLEncodedForm([]byte("name=Alice"))
 		result := mergeObjectSchemas(nil, overlay)
-		if result != overlay {
-			t.Error("expected overlay to be returned when base is nil")
+		// Pointer equality still holds today; also verify content equality for resilience.
+		assert.True(t, result == overlay, "expected overlay to be returned when base is nil")
+		require.NotNil(t, result)
+		require.NotNil(t, result.Value)
+		require.NotNil(t, result.Value.Properties)
+		nameProp, ok := result.Value.Properties["name"]
+		assert.True(t, ok, "expected 'name' property in result when base is nil")
+		if ok {
+			require.NotNil(t, nameProp)
+			assert.Equal(t, "string", nameProp.Value.Type.Slice()[0])
 		}
 	})
 
 	t.Run("nil overlay returns base", func(t *testing.T) {
-		base := ParseURLEncodedForm([]byte("x=1"))
+		base := ParseURLEncodedForm([]byte("name=Alice"))
 		result := mergeObjectSchemas(base, nil)
-		if result != base {
-			t.Error("expected base to be returned when overlay is nil")
+		// Pointer equality still holds today; also verify content equality for resilience.
+		assert.True(t, result == base, "expected base to be returned when overlay is nil")
+		require.NotNil(t, result)
+		require.NotNil(t, result.Value)
+		require.NotNil(t, result.Value.Properties)
+		nameProp, ok := result.Value.Properties["name"]
+		assert.True(t, ok, "expected 'name' property in result when overlay is nil")
+		if ok {
+			require.NotNil(t, nameProp)
+			assert.Equal(t, "string", nameProp.Value.Type.Slice()[0])
 		}
 	})
 }
@@ -286,34 +253,36 @@ func TestSchemaTypesConflict(t *testing.T) {
 	t.Run("same types do not conflict", func(t *testing.T) {
 		a := ParseURLEncodedForm([]byte("val=hello"))
 		b := ParseURLEncodedForm([]byte("val=world"))
-		if a == nil || b == nil {
-			t.Fatal("test setup failed")
-		}
+		require.NotNil(t, a, "test setup failed")
+		require.NotNil(t, b, "test setup failed")
 		aProp := a.Value.Properties["val"]
 		bProp := b.Value.Properties["val"]
-		if schemaTypesConflict(aProp, bProp) {
-			t.Error("string vs string should not conflict")
-		}
+		assert.False(t, schemaTypesConflict(aProp, bProp), "string vs string should not conflict")
 	})
 
 	t.Run("different types conflict", func(t *testing.T) {
 		// "val=42" infers integer; "val=hello" infers string.
 		aBase := ParseURLEncodedForm([]byte("val=42"))
 		bBase := ParseURLEncodedForm([]byte("val=hello"))
-		if aBase == nil || bBase == nil {
-			t.Fatal("test setup failed")
-		}
+		require.NotNil(t, aBase, "test setup failed")
+		require.NotNil(t, bBase, "test setup failed")
 		aProp := aBase.Value.Properties["val"]
 		bProp := bBase.Value.Properties["val"]
-		if !schemaTypesConflict(aProp, bProp) {
-			t.Error("integer vs string should conflict")
-		}
+		assert.True(t, schemaTypesConflict(aProp, bProp), "integer vs string should conflict")
 	})
 
 	t.Run("nil schema refs do not conflict", func(t *testing.T) {
-		if schemaTypesConflict(nil, nil) {
-			t.Error("nil vs nil should not conflict")
-		}
+		assert.False(t, schemaTypesConflict(nil, nil), "nil vs nil should not conflict")
+	})
+
+	t.Run("nil_base_nonnil_overlay_does_not_conflict", func(t *testing.T) {
+		nonNil := ParseURLEncodedForm([]byte("name=Alice")).Value.Properties["name"]
+		assert.False(t, schemaTypesConflict(nil, nonNil))
+	})
+
+	t.Run("nonnil_base_nil_overlay_does_not_conflict", func(t *testing.T) {
+		nonNil := ParseURLEncodedForm([]byte("name=Alice")).Value.Properties["name"]
+		assert.False(t, schemaTypesConflict(nonNil, nil))
 	})
 }
 
@@ -322,9 +291,7 @@ func TestParseURLEncodedForm_MalformedQuery(t *testing.T) {
 	// error, so ParseURLEncodedForm must return nil (covers the err != nil
 	// branch at form.go:50).
 	schema := ParseURLEncodedForm([]byte("%ZZ=bad"))
-	if schema != nil {
-		t.Errorf("expected nil for malformed query string, got %+v", schema)
-	}
+	assert.Nil(t, schema, "expected nil for malformed query string, got %+v", schema)
 }
 
 func TestParseMultipartForm_AllPartsNameless(t *testing.T) {
@@ -339,16 +306,12 @@ func TestParseMultipartForm_AllPartsNameless(t *testing.T) {
 	h.Set("Content-Disposition", "form-data")
 	h.Set("Content-Type", "text/plain")
 	fw, err := w.CreatePart(h)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _ = fw.Write([]byte("some data"))
 	_ = w.Close()
 
 	schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
-	if schema != nil {
-		t.Errorf("expected nil when all parts are nameless, got %+v", schema)
-	}
+	assert.Nil(t, schema, "expected nil when all parts are nameless, got %+v", schema)
 }
 
 func TestSchemaTypesConflict_NilValueType(t *testing.T) {
@@ -357,9 +320,7 @@ func TestSchemaTypesConflict_NilValueType(t *testing.T) {
 	// fires before any comparison.
 	a := &openapi3.SchemaRef{Value: &openapi3.Schema{}}
 	b := &openapi3.SchemaRef{Value: &openapi3.Schema{}}
-	if schemaTypesConflict(a, b) {
-		t.Error("expected false when both Value.Type are nil, got true")
-	}
+	assert.False(t, schemaTypesConflict(a, b), "expected false when both Value.Type are nil, got true")
 }
 
 // ---------------------------------------------------------------------------
@@ -527,7 +488,7 @@ func TestParseMultipartForm_Malformed_MissingClosingBoundary(t *testing.T) {
 func BenchmarkParseURLEncodedForm(b *testing.B) {
 	body := []byte("username=alice&password=secret&age=30&admin=true&remember_me=false&note=hello+world")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = ParseURLEncodedForm(body)
 	}
 }
@@ -548,7 +509,7 @@ func BenchmarkParseMultipartForm(b *testing.B) {
 	boundary := w.Boundary()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = ParseMultipartForm(body, boundary)
 	}
 }
@@ -656,29 +617,23 @@ func TestGetHeader_CaseInsensitiveFallback(t *testing.T) {
 		"Content-Type": "application/json",
 	}
 	got := getHeader(headers, "content-type")
-	if got != "application/json" {
-		t.Errorf("getHeader case-insensitive fallback: got %q, want %q", got, "application/json")
-	}
+	assert.Equal(t, "application/json", got, "getHeader case-insensitive fallback: got %q, want %q", got, "application/json")
 }
 
 func TestExtractBoundary(t *testing.T) {
 	t.Run("valid content-type with boundary", func(t *testing.T) {
 		ct := `multipart/form-data; boundary=----WebKitFormBoundaryABC123`
 		boundary := extractBoundary(ct)
-		if boundary != "----WebKitFormBoundaryABC123" {
-			t.Errorf("boundary = %q, want ----WebKitFormBoundaryABC123", boundary)
-		}
+		assert.Equal(t, "----WebKitFormBoundaryABC123", boundary, "boundary = %q, want ----WebKitFormBoundaryABC123", boundary)
 	})
 
 	t.Run("no boundary returns empty string", func(t *testing.T) {
-		if boundary := extractBoundary("application/json"); boundary != "" {
-			t.Errorf("boundary = %q, want empty string", boundary)
-		}
+		boundary := extractBoundary("application/json")
+		assert.Equal(t, "", boundary, "boundary = %q, want empty string", boundary)
 	})
 
 	t.Run("malformed content-type returns empty string", func(t *testing.T) {
-		if boundary := extractBoundary(""); boundary != "" {
-			t.Errorf("boundary = %q, want empty string", boundary)
-		}
+		boundary := extractBoundary("")
+		assert.Equal(t, "", boundary, "boundary = %q, want empty string", boundary)
 	})
 }

--- a/pkg/generate/rest/form_test.go
+++ b/pkg/generate/rest/form_test.go
@@ -16,6 +16,7 @@ package rest
 
 import (
 	"bytes"
+	"fmt"
 	"mime/multipart"
 	"net/textproto"
 	"testing"
@@ -173,6 +174,34 @@ func TestMergeMultipartBodies(t *testing.T) {
 		schema := mergeMultipartBodies([][]byte{buf.Bytes()}, []string{})
 		// With no boundary the observation is skipped; result is nil.
 		assert.Nil(t, schema, "expected nil when no content-type provided")
+	})
+
+	t.Run("partial content-types — second observation skipped", func(t *testing.T) {
+		// Build two valid multipart bodies with different fields.
+		var buf1 bytes.Buffer
+		w1 := multipart.NewWriter(&buf1)
+		require.NoError(t, w1.WriteField("fieldA", "valueA"))
+		_ = w1.Close()
+		ct1 := "multipart/form-data; boundary=" + w1.Boundary()
+
+		var buf2 bytes.Buffer
+		w2 := multipart.NewWriter(&buf2)
+		require.NoError(t, w2.WriteField("fieldB", "valueB"))
+		_ = w2.Close()
+		// Only pass one content-type (for body1); body2 gets no CT entry.
+		schema := mergeMultipartBodies(
+			[][]byte{buf1.Bytes(), buf2.Bytes()},
+			[]string{ct1}, // length-1 — body2 boundary resolves to empty
+		)
+		require.NotNil(t, schema, "expected non-nil schema from first body")
+		require.NotNil(t, schema.Value)
+		require.NotNil(t, schema.Value.Properties)
+
+		// Only fieldA (from body1) should be present; fieldB (body2) is skipped.
+		assert.Contains(t, schema.Value.Properties, "fieldA",
+			"expected property 'fieldA' from body1")
+		assert.NotContains(t, schema.Value.Properties, "fieldB",
+			"expected property 'fieldB' from body2 to be absent (no CT provided)")
 	})
 }
 
@@ -480,6 +509,33 @@ func TestParseMultipartForm_Malformed_MissingClosingBoundary(t *testing.T) {
 		require.NotNil(t, prop.Value)
 		assert.Equal(t, "string", prop.Value.Type.Slice()[0])
 	}
+}
+
+// TestParseMultipartForm_PartCountCapped verifies that ParseMultipartForm
+// stops processing after maxMultipartParts parts, guarding against a hostile
+// multipart body that contains millions of trivial parts (SEC-BE-002).
+// The function must return a non-nil schema (not nil or hang) and must not
+// have processed more than maxMultipartParts parts.
+func TestParseMultipartForm_PartCountCapped(t *testing.T) {
+	// Build a body with maxMultipartParts+1 parts.
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for i := 0; i <= maxMultipartParts; i++ {
+		err := w.WriteField(fmt.Sprintf("field%d", i), "v")
+		require.NoError(t, err)
+	}
+	_ = w.Close()
+
+	schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+
+	// Must return a non-nil schema (the first maxMultipartParts parts were processed).
+	require.NotNil(t, schema, "ParseMultipartForm should return a schema, not nil")
+	require.NotNil(t, schema.Value)
+	require.NotNil(t, schema.Value.Properties)
+
+	// Must have processed at most maxMultipartParts properties.
+	assert.LessOrEqual(t, len(schema.Value.Properties), maxMultipartParts,
+		"schema must contain at most maxMultipartParts properties; got %d", len(schema.Value.Properties))
 }
 
 // BenchmarkParseURLEncodedForm and BenchmarkParseMultipartForm establish

--- a/pkg/generate/rest/form_test.go
+++ b/pkg/generate/rest/form_test.go
@@ -1,0 +1,652 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/textproto"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURLEncodedForm(t *testing.T) {
+	t.Run("basic fields with type inference", func(t *testing.T) {
+		body := []byte("name=Alice&age=30")
+		schema := ParseURLEncodedForm(body)
+		if schema == nil {
+			t.Fatal("expected schema, got nil")
+		}
+		if schema.Value == nil || schema.Value.Properties == nil {
+			t.Fatal("expected object schema with properties")
+		}
+		if _, ok := schema.Value.Properties["name"]; !ok {
+			t.Error("expected property 'name'")
+		}
+		if _, ok := schema.Value.Properties["age"]; !ok {
+			t.Error("expected property 'age'")
+		}
+		nameType := schema.Value.Properties["name"].Value.Type.Slice()[0]
+		if nameType != "string" {
+			t.Errorf("name type = %q, want string", nameType)
+		}
+		ageType := schema.Value.Properties["age"].Value.Type.Slice()[0]
+		if ageType != "integer" {
+			t.Errorf("age type = %q, want integer", ageType)
+		}
+	})
+
+	t.Run("empty body returns nil", func(t *testing.T) {
+		if schema := ParseURLEncodedForm([]byte("")); schema != nil {
+			t.Error("expected nil for empty body")
+		}
+		if schema := ParseURLEncodedForm(nil); schema != nil {
+			t.Error("expected nil for nil body")
+		}
+	})
+}
+
+func TestParseMultipartForm(t *testing.T) {
+	t.Run("text field becomes string", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := multipart.NewWriter(&buf)
+		if err := w.WriteField("username", "alice"); err != nil {
+			t.Fatal(err)
+		}
+		_ = w.Close()
+
+		schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+		if schema == nil {
+			t.Fatal("expected schema, got nil")
+		}
+		if _, ok := schema.Value.Properties["username"]; !ok {
+			t.Error("expected property 'username'")
+		}
+		uType := schema.Value.Properties["username"].Value.Type.Slice()[0]
+		if uType != "string" {
+			t.Errorf("username type = %q, want string", uType)
+		}
+	})
+
+	t.Run("file field becomes string/binary", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := multipart.NewWriter(&buf)
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", `form-data; name="avatar"; filename="photo.jpg"`)
+		h.Set("Content-Type", "image/jpeg")
+		fw, err := w.CreatePart(h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = fw.Write([]byte("JPEG_DATA"))
+		_ = w.Close()
+
+		schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+		if schema == nil {
+			t.Fatal("expected schema, got nil")
+		}
+		prop, ok := schema.Value.Properties["avatar"]
+		if !ok {
+			t.Fatal("expected property 'avatar'")
+		}
+		if prop.Value.Type.Slice()[0] != "string" {
+			t.Errorf("avatar type = %q, want string", prop.Value.Type.Slice()[0])
+		}
+		if prop.Value.Format != "binary" {
+			t.Errorf("avatar format = %q, want binary", prop.Value.Format)
+		}
+	})
+
+	t.Run("mixed text and file fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := multipart.NewWriter(&buf)
+		if err := w.WriteField("description", "hello world"); err != nil {
+			t.Fatal(err)
+		}
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", `form-data; name="upload"; filename="data.bin"`)
+		fw, err := w.CreatePart(h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = fw.Write([]byte("binary content"))
+		_ = w.Close()
+
+		schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+		if schema == nil {
+			t.Fatal("expected schema, got nil")
+		}
+		if _, ok := schema.Value.Properties["description"]; !ok {
+			t.Error("expected property 'description'")
+		}
+		upload, ok := schema.Value.Properties["upload"]
+		if !ok {
+			t.Fatal("expected property 'upload'")
+		}
+		if upload.Value.Format != "binary" {
+			t.Errorf("upload format = %q, want binary", upload.Value.Format)
+		}
+	})
+
+	t.Run("empty boundary returns nil", func(t *testing.T) {
+		if schema := ParseMultipartForm([]byte("data"), ""); schema != nil {
+			t.Error("expected nil for empty boundary")
+		}
+	})
+}
+
+func TestMergeMultipartBodies(t *testing.T) {
+	t.Run("merges properties from two observations", func(t *testing.T) {
+		var buf1 bytes.Buffer
+		w1 := multipart.NewWriter(&buf1)
+		if err := w1.WriteField("username", "alice"); err != nil {
+			t.Fatal(err)
+		}
+		_ = w1.Close()
+		ct1 := "multipart/form-data; boundary=" + w1.Boundary()
+
+		var buf2 bytes.Buffer
+		w2 := multipart.NewWriter(&buf2)
+		if err := w2.WriteField("email", "alice@example.com"); err != nil {
+			t.Fatal(err)
+		}
+		_ = w2.Close()
+		ct2 := "multipart/form-data; boundary=" + w2.Boundary()
+
+		schema := mergeMultipartBodies(
+			[][]byte{buf1.Bytes(), buf2.Bytes()},
+			[]string{ct1, ct2},
+		)
+		if schema == nil {
+			t.Fatal("expected merged schema, got nil")
+		}
+		if _, ok := schema.Value.Properties["username"]; !ok {
+			t.Error("expected property 'username' from first observation")
+		}
+		if _, ok := schema.Value.Properties["email"]; !ok {
+			t.Error("expected property 'email' from second observation")
+		}
+	})
+
+	t.Run("single observation returns that observation's schema", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := multipart.NewWriter(&buf)
+		if err := w.WriteField("field1", "value1"); err != nil {
+			t.Fatal(err)
+		}
+		_ = w.Close()
+		ct := "multipart/form-data; boundary=" + w.Boundary()
+
+		schema := mergeMultipartBodies([][]byte{buf.Bytes()}, []string{ct})
+		if schema == nil {
+			t.Fatal("expected schema, got nil")
+		}
+		if _, ok := schema.Value.Properties["field1"]; !ok {
+			t.Error("expected property 'field1'")
+		}
+	})
+
+	t.Run("missing content-type entry skips that observation", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := multipart.NewWriter(&buf)
+		if err := w.WriteField("name", "bob"); err != nil {
+			t.Fatal(err)
+		}
+		_ = w.Close()
+		// Provide body but no corresponding content-type entry.
+		schema := mergeMultipartBodies([][]byte{buf.Bytes()}, []string{})
+		// With no boundary the observation is skipped; result is nil.
+		if schema != nil {
+			t.Error("expected nil when no content-type provided")
+		}
+	})
+}
+
+func TestMergeObjectSchemas(t *testing.T) {
+	t.Run("conflict on same property promotes to string", func(t *testing.T) {
+		// base has "count" as integer, overlay has "count" as string — conflict.
+		base := ParseURLEncodedForm([]byte("count=42"))
+		overlay := ParseURLEncodedForm([]byte("count=hello"))
+		if base == nil || overlay == nil {
+			t.Fatal("test setup failed: expected non-nil schemas")
+		}
+
+		merged := mergeObjectSchemas(base, overlay)
+		if merged == nil {
+			t.Fatal("expected merged schema, got nil")
+		}
+		countProp, ok := merged.Value.Properties["count"]
+		if !ok {
+			t.Fatal("expected property 'count' in merged schema")
+		}
+		// After conflict, property should be promoted to string.
+		gotType := countProp.Value.Type.Slice()[0]
+		if gotType != "string" {
+			t.Errorf("count type after conflict = %q, want string", gotType)
+		}
+	})
+
+	t.Run("no conflict keeps original types", func(t *testing.T) {
+		base := ParseURLEncodedForm([]byte("name=Alice&count=5"))
+		overlay := ParseURLEncodedForm([]byte("active=true"))
+		if base == nil || overlay == nil {
+			t.Fatal("test setup failed: expected non-nil schemas")
+		}
+
+		merged := mergeObjectSchemas(base, overlay)
+		if merged == nil {
+			t.Fatal("expected merged schema, got nil")
+		}
+		if _, ok := merged.Value.Properties["active"]; !ok {
+			t.Error("expected property 'active' from overlay")
+		}
+		// count was only in base; type should be unchanged.
+		countProp, ok := merged.Value.Properties["count"]
+		if !ok {
+			t.Fatal("expected property 'count' in merged schema")
+		}
+		if countProp.Value.Type.Slice()[0] != "integer" {
+			t.Errorf("count type = %q, want integer", countProp.Value.Type.Slice()[0])
+		}
+	})
+
+	t.Run("nil base returns overlay", func(t *testing.T) {
+		overlay := ParseURLEncodedForm([]byte("x=1"))
+		result := mergeObjectSchemas(nil, overlay)
+		if result != overlay {
+			t.Error("expected overlay to be returned when base is nil")
+		}
+	})
+
+	t.Run("nil overlay returns base", func(t *testing.T) {
+		base := ParseURLEncodedForm([]byte("x=1"))
+		result := mergeObjectSchemas(base, nil)
+		if result != base {
+			t.Error("expected base to be returned when overlay is nil")
+		}
+	})
+}
+
+func TestSchemaTypesConflict(t *testing.T) {
+	t.Run("same types do not conflict", func(t *testing.T) {
+		a := ParseURLEncodedForm([]byte("val=hello"))
+		b := ParseURLEncodedForm([]byte("val=world"))
+		if a == nil || b == nil {
+			t.Fatal("test setup failed")
+		}
+		aProp := a.Value.Properties["val"]
+		bProp := b.Value.Properties["val"]
+		if schemaTypesConflict(aProp, bProp) {
+			t.Error("string vs string should not conflict")
+		}
+	})
+
+	t.Run("different types conflict", func(t *testing.T) {
+		// "val=42" infers integer; "val=hello" infers string.
+		aBase := ParseURLEncodedForm([]byte("val=42"))
+		bBase := ParseURLEncodedForm([]byte("val=hello"))
+		if aBase == nil || bBase == nil {
+			t.Fatal("test setup failed")
+		}
+		aProp := aBase.Value.Properties["val"]
+		bProp := bBase.Value.Properties["val"]
+		if !schemaTypesConflict(aProp, bProp) {
+			t.Error("integer vs string should conflict")
+		}
+	})
+
+	t.Run("nil schema refs do not conflict", func(t *testing.T) {
+		if schemaTypesConflict(nil, nil) {
+			t.Error("nil vs nil should not conflict")
+		}
+	})
+}
+
+func TestParseURLEncodedForm_MalformedQuery(t *testing.T) {
+	// %ZZ is an invalid percent-encoding sequence; url.ParseQuery returns an
+	// error, so ParseURLEncodedForm must return nil (covers the err != nil
+	// branch at form.go:50).
+	schema := ParseURLEncodedForm([]byte("%ZZ=bad"))
+	if schema != nil {
+		t.Errorf("expected nil for malformed query string, got %+v", schema)
+	}
+}
+
+func TestParseMultipartForm_AllPartsNameless(t *testing.T) {
+	// Build a multipart body where the only part has no `name` attribute in
+	// its Content-Disposition header. After the loop, Properties will be
+	// empty, so ParseMultipartForm must return nil (covers the
+	// len(schema.Properties) == 0 branch at form.go:94).
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	h := make(textproto.MIMEHeader)
+	// Omit `name` so that part.FormName() returns "".
+	h.Set("Content-Disposition", "form-data")
+	h.Set("Content-Type", "text/plain")
+	fw, err := w.CreatePart(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = fw.Write([]byte("some data"))
+	_ = w.Close()
+
+	schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+	if schema != nil {
+		t.Errorf("expected nil when all parts are nameless, got %+v", schema)
+	}
+}
+
+func TestSchemaTypesConflict_NilValueType(t *testing.T) {
+	// Both SchemaRefs have a non-nil Value but a nil Value.Type.
+	// schemaTypesConflict should return false because the nil-Type guard
+	// fires before any comparison.
+	a := &openapi3.SchemaRef{Value: &openapi3.Schema{}}
+	b := &openapi3.SchemaRef{Value: &openapi3.Schema{}}
+	if schemaTypesConflict(a, b) {
+		t.Error("expected false when both Value.Type are nil, got true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Edge-case tests added for LAB-2106
+// ---------------------------------------------------------------------------
+
+// TestParseURLEncodedForm_RepeatedKeys verifies that when the same key appears
+// multiple times in the query string (e.g. foo=1&foo=2&foo=3), the parser uses
+// only the FIRST value to infer the property type. The current implementation
+// reads vals[0], so repeated keys are NOT preserved as an array — only the
+// first occurrence is considered. This is the documented current behavior.
+func TestParseURLEncodedForm_RepeatedKeys(t *testing.T) {
+	schema := ParseURLEncodedForm([]byte("foo=1&foo=2&foo=3"))
+	require.NotNil(t, schema, "expected non-nil schema for repeated key")
+	require.NotNil(t, schema.Value)
+	require.NotNil(t, schema.Value.Properties)
+
+	prop, ok := schema.Value.Properties["foo"]
+	assert.True(t, ok, "expected property 'foo' to exist")
+	require.NotNil(t, prop)
+	require.NotNil(t, prop.Value)
+
+	// "1" is parsed as integer by inferQueryParamType.
+	// Current behavior: only vals[0] ("1") is examined — NOT an array.
+	gotType := prop.Value.Type.Slice()[0]
+	assert.Equal(t, "integer", gotType, "repeated key uses first value for type inference")
+}
+
+// TestParseURLEncodedForm_EmptyValues verifies that fields with empty string
+// values ("username=&password=") produce string-typed properties. An empty
+// string does not match integer, number, or boolean patterns, so it falls
+// through to the "string" default in inferQueryParamType.
+func TestParseURLEncodedForm_EmptyValues(t *testing.T) {
+	schema := ParseURLEncodedForm([]byte("username=&password="))
+	require.NotNil(t, schema, "expected non-nil schema for empty-value fields")
+	require.NotNil(t, schema.Value)
+	require.NotNil(t, schema.Value.Properties)
+
+	for _, field := range []string{"username", "password"} {
+		prop, ok := schema.Value.Properties[field]
+		assert.True(t, ok, "expected property %q to exist", field)
+		if ok {
+			require.NotNil(t, prop.Value)
+			gotType := prop.Value.Type.Slice()[0]
+			assert.Equal(t, "string", gotType, "empty value for %q should yield string type", field)
+		}
+	}
+}
+
+// TestParseURLEncodedForm_SpecialChars verifies that percent-encoded characters
+// (spaces as '+', colons as '%3A') do not cause the parser to choke. We only
+// verify that the properties are present because the parser infers types from
+// decoded values, not the raw encoded bytes, and the schema stores types, not
+// the values themselves.
+func TestParseURLEncodedForm_SpecialChars(t *testing.T) {
+	// q=hello+world  → decoded value "hello world" → type string
+	// filter=name%3Aalice → decoded value "name:alice" → type string
+	schema := ParseURLEncodedForm([]byte("q=hello+world&filter=name%3Aalice"))
+	require.NotNil(t, schema, "expected non-nil schema for percent-encoded input")
+	require.NotNil(t, schema.Value)
+	require.NotNil(t, schema.Value.Properties)
+
+	assert.Contains(t, schema.Value.Properties, "q", "expected property 'q'")
+	assert.Contains(t, schema.Value.Properties, "filter", "expected property 'filter'")
+}
+
+// TestParseMultipartForm_MultipleFilesSameName verifies behavior when two
+// parts share the same name and both carry filenames ("files"). The current
+// implementation iterates parts sequentially and writes to
+// schema.Properties[name] each time, so the second part OVERWRITES the first.
+// The result is a single "files" property with type string, format binary.
+// This is the documented current behavior — the parser does NOT produce an
+// array of files.
+func TestParseMultipartForm_MultipleFilesSameName(t *testing.T) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for _, fname := range []string{"a.jpg", "b.png"} {
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", `form-data; name="files"; filename="`+fname+`"`)
+		h.Set("Content-Type", "image/jpeg")
+		fw, err := w.CreatePart(h)
+		require.NoError(t, err)
+		_, _ = fw.Write([]byte("data"))
+	}
+	_ = w.Close()
+
+	schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+	require.NotNil(t, schema, "expected non-nil schema")
+	require.NotNil(t, schema.Value)
+	require.NotNil(t, schema.Value.Properties)
+
+	prop, ok := schema.Value.Properties["files"]
+	assert.True(t, ok, "expected property 'files' to exist")
+	if ok {
+		require.NotNil(t, prop.Value)
+		assert.Equal(t, "string", prop.Value.Type.Slice()[0])
+		// Current behavior: second file overwrites first; format is still binary.
+		assert.Equal(t, "binary", prop.Value.Format)
+	}
+}
+
+// TestParseMultipartForm_CharsetParameter verifies that extractBoundary handles
+// a Content-Type with both a charset parameter and a boundary parameter, e.g.
+// "multipart/form-data; charset=utf-8; boundary=X". The boundary "X" must be
+// returned correctly regardless of parameter order.
+func TestParseMultipartForm_CharsetParameter(t *testing.T) {
+	ct := "multipart/form-data; charset=utf-8; boundary=X"
+	boundary := extractBoundary(ct)
+	assert.Equal(t, "X", boundary, "extractBoundary should return boundary even when charset is present")
+}
+
+// TestParseMultipartForm_NonASCIIFieldValue verifies that a text field whose
+// value contains multi-byte UTF-8 characters (e.g. "日本語") is parsed
+// correctly and produces a property with type string.
+func TestParseMultipartForm_NonASCIIFieldValue(t *testing.T) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	err := w.WriteField("lang", "日本語")
+	require.NoError(t, err)
+	_ = w.Close()
+
+	schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+	require.NotNil(t, schema, "expected non-nil schema for UTF-8 field value")
+	require.NotNil(t, schema.Value)
+
+	prop, ok := schema.Value.Properties["lang"]
+	assert.True(t, ok, "expected property 'lang'")
+	if ok {
+		require.NotNil(t, prop.Value)
+		assert.Equal(t, "string", prop.Value.Type.Slice()[0])
+	}
+}
+
+// TestParseMultipartForm_Malformed_MissingClosingBoundary verifies behavior
+// when the multipart body has parts but no closing boundary marker
+// (--<boundary>--). Go's multipart.Reader stops at EOF after successfully
+// reading any complete parts, so the current behavior is that already-parsed
+// parts ARE returned (non-nil schema). This is the documented current behavior.
+func TestParseMultipartForm_Malformed_MissingClosingBoundary(t *testing.T) {
+	// Build a partial body: write a field but do NOT call w.Close(), which
+	// would append the terminating "--<boundary>--" line.
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	err := w.WriteField("partial", "value")
+	require.NoError(t, err)
+	// Intentionally omit w.Close() — no closing boundary.
+
+	schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+	// Current behavior: the part written before EOF is successfully parsed;
+	// schema is non-nil and contains the "partial" property.
+	require.NotNil(t, schema, "expected non-nil schema when closing boundary is missing but parts were read")
+	require.NotNil(t, schema.Value)
+
+	prop, ok := schema.Value.Properties["partial"]
+	assert.True(t, ok, "expected property 'partial' to be parsed before EOF")
+	if ok {
+		require.NotNil(t, prop.Value)
+		assert.Equal(t, "string", prop.Value.Type.Slice()[0])
+	}
+}
+
+// TestParseMultipartForm_EmptyFieldValue verifies that a text field with an
+// empty value ("") is parsed as type string. An empty string does not match
+// integer, number, or boolean, so inferQueryParamType returns "string".
+func TestParseMultipartForm_EmptyFieldValue(t *testing.T) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	err := w.WriteField("empty", "")
+	require.NoError(t, err)
+	_ = w.Close()
+
+	schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+	require.NotNil(t, schema, "expected non-nil schema for empty field value")
+	require.NotNil(t, schema.Value)
+
+	prop, ok := schema.Value.Properties["empty"]
+	assert.True(t, ok, "expected property 'empty' to exist")
+	if ok {
+		require.NotNil(t, prop.Value)
+		assert.Equal(t, "string", prop.Value.Type.Slice()[0])
+	}
+}
+
+// TestParseMultipartForm_BinaryFile verifies that a file part containing
+// binary content (PNG magic bytes) is parsed without mangling the body and
+// produces a property with type string, format binary.
+func TestParseMultipartForm_BinaryFile(t *testing.T) {
+	pngMagic := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", `form-data; name="screenshot"; filename="img.png"`)
+	h.Set("Content-Type", "image/png")
+	fw, err := w.CreatePart(h)
+	require.NoError(t, err)
+	_, err = fw.Write(pngMagic)
+	require.NoError(t, err)
+	_ = w.Close()
+
+	schema := ParseMultipartForm(buf.Bytes(), w.Boundary())
+	require.NotNil(t, schema, "expected non-nil schema for binary file part")
+	require.NotNil(t, schema.Value)
+
+	prop, ok := schema.Value.Properties["screenshot"]
+	assert.True(t, ok, "expected property 'screenshot'")
+	if ok {
+		require.NotNil(t, prop.Value)
+		assert.Equal(t, "string", prop.Value.Type.Slice()[0])
+		assert.Equal(t, "binary", prop.Value.Format, "file field should have format binary")
+	}
+}
+
+// TestMergeURLEncodedBodies_DifferentFieldsPerObservation verifies that merging
+// three observations with partially overlapping fields produces a schema with
+// the union of all observed fields (a, b, c, d).
+func TestMergeURLEncodedBodies_DifferentFieldsPerObservation(t *testing.T) {
+	bodies := [][]byte{
+		[]byte("a=1&b=2"),
+		[]byte("b=2&c=3"),
+		[]byte("a=1&d=4"),
+	}
+	schema := mergeURLEncodedBodies(bodies)
+	require.NotNil(t, schema, "expected non-nil merged schema")
+	require.NotNil(t, schema.Value)
+	require.NotNil(t, schema.Value.Properties)
+
+	for _, field := range []string{"a", "b", "c", "d"} {
+		assert.Contains(t, schema.Value.Properties, field,
+			"merged schema should contain property %q (union of all observations)", field)
+	}
+}
+
+// TestMergeURLEncodedBodies_ConflictingTypes verifies that when the same field
+// appears with different value types across observations (integer then string),
+// the merged schema promotes the property type to string.
+func TestMergeURLEncodedBodies_ConflictingTypes(t *testing.T) {
+	bodies := [][]byte{
+		[]byte("count=42"),    // "42" → integer
+		[]byte("count=hello"), // "hello" → string
+	}
+	schema := mergeURLEncodedBodies(bodies)
+	require.NotNil(t, schema, "expected non-nil merged schema")
+	require.NotNil(t, schema.Value)
+	require.NotNil(t, schema.Value.Properties)
+
+	prop, ok := schema.Value.Properties["count"]
+	assert.True(t, ok, "expected property 'count' in merged schema")
+	if ok {
+		require.NotNil(t, prop.Value)
+		gotType := prop.Value.Type.Slice()[0]
+		assert.Equal(t, "string", gotType,
+			"conflicting types (integer vs string) should be promoted to string")
+	}
+}
+
+func TestGetHeader_CaseInsensitiveFallback(t *testing.T) {
+	// The map uses title-case "Content-Type" as the stored key.
+	// Querying with lowercase "content-type" must fall through to the
+	// scan loop and still return the value.
+	headers := map[string]string{
+		"Content-Type": "application/json",
+	}
+	got := getHeader(headers, "content-type")
+	if got != "application/json" {
+		t.Errorf("getHeader case-insensitive fallback: got %q, want %q", got, "application/json")
+	}
+}
+
+func TestExtractBoundary(t *testing.T) {
+	t.Run("valid content-type with boundary", func(t *testing.T) {
+		ct := `multipart/form-data; boundary=----WebKitFormBoundaryABC123`
+		boundary := extractBoundary(ct)
+		if boundary != "----WebKitFormBoundaryABC123" {
+			t.Errorf("boundary = %q, want ----WebKitFormBoundaryABC123", boundary)
+		}
+	})
+
+	t.Run("no boundary returns empty string", func(t *testing.T) {
+		if boundary := extractBoundary("application/json"); boundary != "" {
+			t.Errorf("boundary = %q, want empty string", boundary)
+		}
+	})
+
+	t.Run("malformed content-type returns empty string", func(t *testing.T) {
+		if boundary := extractBoundary(""); boundary != "" {
+			t.Errorf("boundary = %q, want empty string", boundary)
+		}
+	})
+}

--- a/pkg/generate/rest/form_test.go
+++ b/pkg/generate/rest/form_test.go
@@ -521,6 +521,38 @@ func TestParseMultipartForm_Malformed_MissingClosingBoundary(t *testing.T) {
 	}
 }
 
+// BenchmarkParseURLEncodedForm and BenchmarkParseMultipartForm establish
+// performance baselines for the form parsers introduced by LAB-2106.
+// Useful as a reference before stretch-goal performance investigation.
+func BenchmarkParseURLEncodedForm(b *testing.B) {
+	body := []byte("username=alice&password=secret&age=30&admin=true&remember_me=false&note=hello+world")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ParseURLEncodedForm(body)
+	}
+}
+
+func BenchmarkParseMultipartForm(b *testing.B) {
+	// Construct a representative multipart body once
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	_ = w.WriteField("title", "benchmark doc")
+	_ = w.WriteField("description", "performance baseline")
+	hdr := make(textproto.MIMEHeader)
+	hdr.Set("Content-Disposition", `form-data; name="file"; filename="test.bin"`)
+	hdr.Set("Content-Type", "application/octet-stream")
+	fw, _ := w.CreatePart(hdr)
+	_, _ = fw.Write(make([]byte, 1024))
+	_ = w.Close()
+	body := buf.Bytes()
+	boundary := w.Boundary()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ParseMultipartForm(body, boundary)
+	}
+}
+
 // TestParseMultipartForm_EmptyFieldValue verifies that a text field with an
 // empty value ("") is parsed as type string. An empty string does not match
 // integer, number, or boolean, so inferQueryParamType returns "string".

--- a/pkg/generate/rest/form_test.go
+++ b/pkg/generate/rest/form_test.go
@@ -622,6 +622,31 @@ func TestParseMultipartForm_BinaryFile(t *testing.T) {
 	}
 }
 
+// TestParseURLEncodedForm_BodyTooLarge verifies that ParseURLEncodedForm rejects
+// bodies larger than maxURLEncodedBodySize (10 MB) and returns nil, mirroring
+// the cap applied by the JSON parser (InferSchema) and multipart parser.
+func TestParseURLEncodedForm_BodyTooLarge(t *testing.T) {
+	body := make([]byte, maxURLEncodedBodySize+1)
+	schema := ParseURLEncodedForm(body)
+	assert.Nil(t, schema, "expected nil for body exceeding maxURLEncodedBodySize, got non-nil schema")
+}
+
+// TestParseURLEncodedForm_TooManyFields verifies that ParseURLEncodedForm rejects
+// bodies containing more than maxFormFields distinct keys and returns nil,
+// mirroring multipart's maxMultipartParts defense against adversarial input.
+func TestParseURLEncodedForm_TooManyFields(t *testing.T) {
+	// Build a body with maxFormFields+1 distinct keys.
+	var buf []byte
+	for i := 0; i <= maxFormFields; i++ {
+		if i > 0 {
+			buf = append(buf, '&')
+		}
+		buf = fmt.Appendf(buf, "k%d=v", i)
+	}
+	schema := ParseURLEncodedForm(buf)
+	assert.Nil(t, schema, "expected nil for body with more than maxFormFields keys, got non-nil schema")
+}
+
 // TestMergeURLEncodedBodies_DifferentFieldsPerObservation verifies that merging
 // three observations with partially overlapping fields produces a schema with
 // the union of all observed fields (a, b, c, d).

--- a/pkg/generate/rest/form_test.go
+++ b/pkg/generate/rest/form_test.go
@@ -124,7 +124,29 @@ func TestParseMultipartForm(t *testing.T) {
 	})
 }
 
+func TestMergeURLEncodedBodies(t *testing.T) {
+	t.Run("empty bodies slice", func(t *testing.T) {
+		result := mergeURLEncodedBodies([][]byte{})
+		assert.Nil(t, result, "empty bodies slice should return nil")
+	})
+
+	t.Run("all-empty body bytes", func(t *testing.T) {
+		result := mergeURLEncodedBodies([][]byte{nil, {}, nil})
+		assert.Nil(t, result, "all-empty body bytes should return nil")
+	})
+}
+
 func TestMergeMultipartBodies(t *testing.T) {
+	t.Run("empty bodies slice", func(t *testing.T) {
+		result := mergeMultipartBodies([][]byte{}, []string{})
+		assert.Nil(t, result, "empty bodies slice should return nil")
+	})
+
+	t.Run("all-empty body bytes", func(t *testing.T) {
+		result := mergeMultipartBodies([][]byte{nil, {}, nil}, []string{"", "", ""})
+		assert.Nil(t, result, "all-empty body bytes should return nil")
+	})
+
 	t.Run("merges properties from two observations", func(t *testing.T) {
 		var buf1 bytes.Buffer
 		w1 := multipart.NewWriter(&buf1)
@@ -620,6 +642,16 @@ func TestParseMultipartForm_BinaryFile(t *testing.T) {
 		assert.Equal(t, "string", prop.Value.Type.Slice()[0])
 		assert.Equal(t, "binary", prop.Value.Format, "file field should have format binary")
 	}
+}
+
+// TestParseMultipartForm_BodyTooLarge verifies that ParseMultipartForm rejects
+// bodies larger than maxMultipartBodySize (10 MB) and returns nil, providing
+// parity with the urlencoded and JSON parser caps (SEC-BE-002).
+func TestParseMultipartForm_BodyTooLarge(t *testing.T) {
+	body := make([]byte, maxMultipartBodySize+1)
+	// Use an arbitrary boundary — function must reject on size before parsing.
+	schema := ParseMultipartForm(body, "someboundary")
+	assert.Nil(t, schema, "expected nil for body exceeding maxMultipartBodySize, got non-nil schema")
 }
 
 // TestParseURLEncodedForm_BodyTooLarge verifies that ParseURLEncodedForm rejects

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -605,8 +605,16 @@ func extractComponents(doc *openapi3.T) { //nolint:gocyclo // component extracti
 		}
 	}
 
-	// Walk all paths and operations
-	for path := range doc.Paths.Map() {
+	// Walk all paths and operations in deterministic order so that when multiple
+	// paths share a schema fingerprint, the component name (chosen on first encounter)
+	// is stable across runs.
+	pathsMap := doc.Paths.Map()
+	sortedPaths := make([]string, 0, len(pathsMap))
+	for p := range pathsMap {
+		sortedPaths = append(sortedPaths, p)
+	}
+	sort.Strings(sortedPaths)
+	for _, path := range sortedPaths {
 		pathItem := doc.Paths.Find(path)
 		if pathItem == nil {
 			continue

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -487,6 +487,12 @@ func resourceNameFromPath(path string) string {
 
 // toCamelCase converts a string to CamelCase by splitting on non-alphanumeric
 // characters and capitalizing the first letter of each resulting segment.
+//
+// Note: this function is ASCII-only by design. Non-ASCII letters (e.g., 'é',
+// 'ñ', '日本語') fall through to the separator branch and are dropped from the
+// output. OpenAPI component names are conventionally ASCII; if a path segment
+// is entirely non-ASCII the result will be empty and resourceNameFromPath
+// falls back to "Resource".
 func toCamelCase(s string) string {
 	var b strings.Builder
 	capitalizeNext := true
@@ -559,9 +565,14 @@ func extractComponents(doc *openapi3.T) { //nolint:gocyclo // component extracti
 		doc.Components.Schemas = make(openapi3.Schemas)
 	}
 
-	// Track schemas by fingerprint for deduplication
-	fingerprintToName := make(map[string]string)
-	// Track name collisions
+	// Separate fingerprint→name maps for request and response so an echo-style
+	// endpoint where the request and response bodies share the same property
+	// shape doesn't cause the response to reuse the request's component name
+	// (e.g., a response getting tagged `CreateUserRequest`).
+	fingerprintToReqName := make(map[string]string)
+	fingerprintToRespName := make(map[string]string)
+	// Track name collisions — shared across both maps so we never generate
+	// two components with the same name (e.g., UserResponse collision).
 	nameCounter := make(map[string]int)
 
 	// Helper to ensure unique component name
@@ -649,11 +660,11 @@ func extractComponents(doc *openapi3.T) { //nolint:gocyclo // component extracti
 						fingerprint := schemaFingerprint(schema)
 						if fingerprint != "" {
 							var componentName string
-							if existingName, exists := fingerprintToName[fingerprint]; exists {
-								// Reuse existing component
+							if existingName, exists := fingerprintToReqName[fingerprint]; exists {
+								// Reuse existing request component
 								componentName = existingName
 							} else {
-								// Create new component
+								// Create new request component
 								methodPrefix := ""
 								switch op.method {
 								case "post":
@@ -664,7 +675,7 @@ func extractComponents(doc *openapi3.T) { //nolint:gocyclo // component extracti
 								baseName := methodPrefix + resourceName + "Request"
 								componentName = ensureUniqueName(baseName)
 								doc.Components.Schemas[componentName] = &openapi3.SchemaRef{Value: schema}
-								fingerprintToName[fingerprint] = componentName
+								fingerprintToReqName[fingerprint] = componentName
 							}
 							// Replace inline schema with $ref
 							mediaType.Schema = &openapi3.SchemaRef{
@@ -702,11 +713,11 @@ func extractComponents(doc *openapi3.T) { //nolint:gocyclo // component extracti
 							fingerprint := schemaFingerprint(schema)
 							if fingerprint != "" {
 								var componentName string
-								if existingName, exists := fingerprintToName[fingerprint]; exists {
-									// Reuse existing component
+								if existingName, exists := fingerprintToRespName[fingerprint]; exists {
+									// Reuse existing response component
 									componentName = existingName
 								} else {
-									// Create new component
+									// Create new response component
 									suffix := statusContext(statusCode)
 									if suffix == "" {
 										continue // Skip 204 No Content
@@ -714,7 +725,7 @@ func extractComponents(doc *openapi3.T) { //nolint:gocyclo // component extracti
 									baseName := resourceName + suffix
 									componentName = ensureUniqueName(baseName)
 									doc.Components.Schemas[componentName] = &openapi3.SchemaRef{Value: schema}
-									fingerprintToName[fingerprint] = componentName
+									fingerprintToRespName[fingerprint] = componentName
 								}
 								// Replace inline schema with $ref
 								mediaType.Schema = &openapi3.SchemaRef{

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -133,18 +133,10 @@ func mergeJSONBodies(bodies [][]byte) *openapi3.SchemaRef {
 		if schema == nil {
 			continue
 		}
-		if merged == nil {
-			merged = schema
-			continue
-		}
-		if merged.Value != nil && merged.Value.Properties != nil &&
-			schema.Value != nil && schema.Value.Properties != nil {
-			for propName, propSchema := range schema.Value.Properties {
-				if _, exists := merged.Value.Properties[propName]; !exists {
-					merged.Value.Properties[propName] = propSchema
-				}
-			}
-		}
+		// Delegate to mergeObjectSchemas (defined in form.go) so JSON, urlencoded,
+		// and multipart all share the same conflict-resolution semantics: union
+		// of properties; conflicting types promote to string.
+		merged = mergeObjectSchemas(merged, schema)
 	}
 	return merged
 }
@@ -643,7 +635,13 @@ func extractComponents(doc *openapi3.T) { //nolint:gocyclo // component extracti
 			// Extract request body schema
 			if op.operation.RequestBody != nil && op.operation.RequestBody.Value != nil {
 				reqBody := op.operation.RequestBody.Value
-				for _, mediaType := range reqBody.Content {
+				ctKeys := make([]string, 0, len(reqBody.Content))
+				for k := range reqBody.Content {
+					ctKeys = append(ctKeys, k)
+				}
+				sort.Strings(ctKeys)
+				for _, ctKey := range ctKeys {
+					mediaType := reqBody.Content[ctKey]
 					if mediaType == nil || mediaType.Schema == nil {
 						continue
 					}
@@ -679,13 +677,27 @@ func extractComponents(doc *openapi3.T) { //nolint:gocyclo // component extracti
 
 			// Extract response schemas
 			if op.operation.Responses != nil {
+				sortedStatusCodes := make([]string, 0, op.operation.Responses.Len())
 				for statusCode := range op.operation.Responses.Map() {
+					sortedStatusCodes = append(sortedStatusCodes, statusCode)
+				}
+				sort.Strings(sortedStatusCodes)
+				for _, statusCode := range sortedStatusCodes {
 					respRef := op.operation.Responses.Value(statusCode)
 					if respRef == nil || respRef.Value == nil {
 						continue
 					}
 					response := respRef.Value
-					if mediaType := response.Content["application/json"]; mediaType != nil && mediaType.Schema != nil {
+					respCtKeys := make([]string, 0, len(response.Content))
+					for k := range response.Content {
+						respCtKeys = append(respCtKeys, k)
+					}
+					sort.Strings(respCtKeys)
+					for _, respCtKey := range respCtKeys {
+						mediaType := response.Content[respCtKey]
+						if mediaType == nil || mediaType.Schema == nil {
+							continue
+						}
 						if schema := mediaType.Schema.Value; schema != nil && schema.Properties != nil {
 							fingerprint := schemaFingerprint(schema)
 							if fingerprint != "" {

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -122,6 +122,33 @@ func groupEndpoints(endpoints []classify.ClassifiedRequest) map[endpointKey][]cl
 	return endpointGroups
 }
 
+// mergeJSONBodies infers and merges JSON schemas from multiple body observations.
+func mergeJSONBodies(bodies [][]byte) *openapi3.SchemaRef {
+	var merged *openapi3.SchemaRef
+	for _, body := range bodies {
+		if len(body) == 0 {
+			continue
+		}
+		schema := InferSchema(body)
+		if schema == nil {
+			continue
+		}
+		if merged == nil {
+			merged = schema
+			continue
+		}
+		if merged.Value != nil && merged.Value.Properties != nil &&
+			schema.Value != nil && schema.Value.Properties != nil {
+			for propName, propSchema := range schema.Value.Properties {
+				if _, exists := merged.Value.Properties[propName]; !exists {
+					merged.Value.Properties[propName] = propSchema
+				}
+			}
+		}
+	}
+	return merged
+}
+
 // buildOperation builds a single OpenAPI operation from a group of classified requests.
 func buildOperation(key endpointKey, group []classify.ClassifiedRequest) *openapi3.Operation { //nolint:gocyclo // OpenAPI operation builder
 	operation := &openapi3.Operation{
@@ -199,41 +226,57 @@ func buildOperation(key endpointKey, group []classify.ClassifiedRequest) *openap
 		operation.Parameters = append(operation.Parameters, &openapi3.ParameterRef{Value: param})
 	}
 
-	// --- Request body: merge schemas across all observations ---
+	// --- Request body: partition by content type and merge ---
 	if key.method == "post" || key.method == "put" || key.method == "patch" {
-		var mergedSchema *openapi3.SchemaRef
+		type bodyObs struct {
+			body        []byte
+			contentType string
+		}
+		ctGroups := map[string][]bodyObs{}
+
 		for _, ep := range group {
 			if len(ep.Body) == 0 {
 				continue
 			}
-			schema := InferSchema(ep.Body)
-			if schema == nil {
-				continue
-			}
-			if mergedSchema == nil {
-				mergedSchema = schema
-				continue
-			}
-			// Merge properties from this schema into the merged schema
-			// Only merge if both are objects
-			if mergedSchema.Value != nil && mergedSchema.Value.Properties != nil &&
-				schema.Value != nil && schema.Value.Properties != nil {
-				for propName, propSchema := range schema.Value.Properties {
-					if _, exists := mergedSchema.Value.Properties[propName]; !exists {
-						mergedSchema.Value.Properties[propName] = propSchema
-					}
+			ct := getHeader(ep.Headers, "content-type")
+			baseType := "application/json"
+			if ct != "" {
+				trimmed := strings.ToLower(strings.TrimSpace(strings.SplitN(ct, ";", 2)[0]))
+				if trimmed != "" {
+					baseType = trimmed
 				}
 			}
+			ctGroups[baseType] = append(ctGroups[baseType], bodyObs{body: ep.Body, contentType: ct})
 		}
-		if mergedSchema != nil {
-			operation.RequestBody = &openapi3.RequestBodyRef{
-				Value: &openapi3.RequestBody{
-					Content: openapi3.Content{
-						"application/json": &openapi3.MediaType{
-							Schema: mergedSchema,
-						},
+
+		if len(ctGroups) > 0 {
+			content := openapi3.Content{}
+			for mediaType, obs := range ctGroups {
+				bodies := make([][]byte, len(obs))
+				contentTypes := make([]string, len(obs))
+				for i, o := range obs {
+					bodies[i] = o.body
+					contentTypes[i] = o.contentType
+				}
+				var schema *openapi3.SchemaRef
+				switch mediaType {
+				case "application/x-www-form-urlencoded":
+					schema = mergeURLEncodedBodies(bodies)
+				case "multipart/form-data":
+					schema = mergeMultipartBodies(bodies, contentTypes)
+				default:
+					schema = mergeJSONBodies(bodies)
+				}
+				if schema != nil {
+					content[mediaType] = &openapi3.MediaType{Schema: schema}
+				}
+			}
+			if len(content) > 0 {
+				operation.RequestBody = &openapi3.RequestBodyRef{
+					Value: &openapi3.RequestBody{
+						Content: content,
 					},
-				},
+				}
 			}
 		}
 	}
@@ -420,6 +463,14 @@ func extractPathParams(path string) []string {
 	return params
 }
 
+// commonPathExtensions are file extensions often seen in web app URLs that should
+// not form part of an OpenAPI component name (they're not resource names, they're
+// server-side file types).
+var commonPathExtensions = map[string]bool{
+	".php": true, ".asp": true, ".aspx": true, ".jsp": true, ".mvc": true,
+	".html": true, ".htm": true, ".json": true, ".xml": true, ".action": true, ".do": true,
+}
+
 // resourceNameFromPath extracts and capitalizes the resource name from an API path.
 // It returns the last non-parameterized, non-empty segment as a singular, capitalized word.
 // Examples:
@@ -427,6 +478,8 @@ func extractPathParams(path string) []string {
 //   - "/api/v2/tickets/{ticketId}" → "Ticket"
 //   - "/api/v2/categories/{categoryId}/items/{itemId}" → "Item"
 //   - "/api/v2/users/me/settings" → "Setting"
+//   - "/login.php" → "Login"
+//   - "/stored-xss" → "StoredXss"
 func resourceNameFromPath(path string) string {
 	segments := strings.Split(path, "/")
 	// Walk backwards to find last non-param, non-empty segment
@@ -435,9 +488,54 @@ func resourceNameFromPath(path string) string {
 		if seg == "" || strings.HasPrefix(seg, "{") {
 			continue
 		}
-		return capitalizeFirst(singularize(seg))
+		return sanitizeResourceName(seg)
 	}
 	return "Resource"
+}
+
+// toCamelCase converts a string to CamelCase by splitting on non-alphanumeric
+// characters and capitalizing the first letter of each resulting segment.
+func toCamelCase(s string) string {
+	var b strings.Builder
+	capitalizeNext := true
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			if capitalizeNext {
+				r = r - 'a' + 'A'
+			}
+			b.WriteRune(r)
+			capitalizeNext = false
+		case (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			capitalizeNext = false
+		default:
+			capitalizeNext = true
+		}
+	}
+	return b.String()
+}
+
+// sanitizeResourceName turns a path segment into a valid OpenAPI component name
+// fragment: strips common file extensions, splits on non-alphanumerics, capitalizes
+// and joins each part, then singularizes. Falls back to "Resource" if the segment
+// sanitizes to empty.
+func sanitizeResourceName(seg string) string {
+	lower := strings.ToLower(seg)
+	for ext := range commonPathExtensions {
+		if strings.HasSuffix(lower, ext) {
+			seg = seg[:len(seg)-len(ext)]
+			break
+		}
+	}
+	result := toCamelCase(seg)
+	if result == "" {
+		return "Resource"
+	}
+	if result[0] >= '0' && result[0] <= '9' {
+		return "Resource" + result
+	}
+	return singularize(result)
 }
 
 // schemaFingerprint computes a string fingerprint of a schema for deduplication.
@@ -537,7 +635,10 @@ func extractComponents(doc *openapi3.T) { //nolint:gocyclo // component extracti
 			// Extract request body schema
 			if op.operation.RequestBody != nil && op.operation.RequestBody.Value != nil {
 				reqBody := op.operation.RequestBody.Value
-				if mediaType := reqBody.Content["application/json"]; mediaType != nil && mediaType.Schema != nil {
+				for _, mediaType := range reqBody.Content {
+					if mediaType == nil || mediaType.Schema == nil {
+						continue
+					}
 					if schema := mediaType.Schema.Value; schema != nil && schema.Properties != nil {
 						fingerprint := schemaFingerprint(schema)
 						if fingerprint != "" {

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -30,8 +30,6 @@ import (
 	"github.com/praetorian-inc/vespasian/pkg/classify"
 )
 
-// Compile-time interface compliance check.
-
 // capitalizeFirst capitalizes the first letter of a string (UTF-8 safe).
 func capitalizeFirst(s string) string {
 	if s == "" {
@@ -243,7 +241,13 @@ func buildOperation(key endpointKey, group []classify.ClassifiedRequest) *openap
 
 		if len(ctGroups) > 0 {
 			content := openapi3.Content{}
-			for mediaType, obs := range ctGroups {
+			ctKeys := make([]string, 0, len(ctGroups))
+			for k := range ctGroups {
+				ctKeys = append(ctKeys, k)
+			}
+			sort.Strings(ctKeys)
+			for _, mediaType := range ctKeys {
+				obs := ctGroups[mediaType]
 				bodies := make([][]byte, len(obs))
 				contentTypes := make([]string, len(obs))
 				for i, o := range obs {

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -39,6 +39,20 @@ func capitalizeFirst(s string) string {
 	return string(unicode.ToUpper(r)) + s[size:]
 }
 
+// baseMediaType returns the lowercased media type from a Content-Type value,
+// stripped of any parameters (e.g., "; boundary=..."). Returns "" on empty input.
+// Mirrors the helper in pkg/classify/classifier.go; cross-package consolidation
+// is tracked as a separate refactor (see PR description).
+func baseMediaType(ct string) string {
+	if ct == "" {
+		return ""
+	}
+	if i := strings.Index(ct, ";"); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.ToLower(strings.TrimSpace(ct))
+}
+
 // inferQueryParamType infers the OpenAPI type from a query parameter value.
 func inferQueryParamType(value string) string {
 	if _, err := strconv.Atoi(value); err == nil {
@@ -231,9 +245,8 @@ func buildOperation(key endpointKey, group []classify.ClassifiedRequest) *openap
 			ct := getHeader(ep.Headers, "content-type")
 			baseType := "application/json"
 			if ct != "" {
-				trimmed := strings.ToLower(strings.TrimSpace(strings.SplitN(ct, ";", 2)[0]))
-				if trimmed != "" {
-					baseType = trimmed
+				if t := baseMediaType(ct); t != "" {
+					baseType = t
 				}
 			}
 			ctGroups[baseType] = append(ctGroups[baseType], bodyObs{body: ep.Body, contentType: ct})

--- a/pkg/generate/rest/openapi_test.go
+++ b/pkg/generate/rest/openapi_test.go
@@ -1104,6 +1104,72 @@ func TestOpenAPIGenerator_MultipartFormData_EndToEnd(t *testing.T) {
 	assert.Contains(t, specStr, "binary", "spec missing format: binary for file upload field")
 }
 
+// TestExtractComponents_RequestResponseScopedRefs verifies that when a request
+// body and a 200 response body share IDENTICAL property shapes (echo-style
+// endpoint), the generated $ref values are DIFFERENT — the request gets a
+// name ending in "Request" and the response gets a name ending in "Response".
+// Pre-fix, fingerprintToName was shared between request and response extraction,
+// causing the response to reuse the request's component name (e.g., the response
+// would be tagged "CreateXRequest" instead of "XResponse").
+func TestExtractComponents_RequestResponseScopedRefs(t *testing.T) {
+	gen := &OpenAPIGenerator{}
+
+	// Echo-style endpoint: request and response have identical property shapes.
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://api.example.com/echo",
+				Headers: map[string]string{
+					"Content-Type": "application/json",
+				},
+				Body: []byte(`{"id": 1, "name": "x"}`),
+				Response: crawl.ObservedResponse{
+					StatusCode:  200,
+					ContentType: "application/json",
+					Body:        []byte(`{"id": 1, "name": "x"}`),
+				},
+			},
+			IsAPI: true,
+		},
+	}
+
+	spec, err := gen.Generate(endpoints)
+	require.NoError(t, err, "Generate should succeed")
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData(spec)
+	require.NoError(t, err, "Generated spec should be valid OpenAPI")
+
+	echoPath := doc.Paths.Find("/echo")
+	require.NotNil(t, echoPath, "expected /echo path")
+	require.NotNil(t, echoPath.Post, "expected POST on /echo")
+
+	// Get the request body $ref.
+	reqBody := echoPath.Post.RequestBody
+	require.NotNil(t, reqBody, "expected requestBody")
+	jsonReqMedia := reqBody.Value.Content["application/json"]
+	require.NotNil(t, jsonReqMedia, "expected application/json in requestBody")
+	reqRef := jsonReqMedia.Schema.Ref
+	assert.NotEmpty(t, reqRef, "expected $ref in requestBody schema")
+	assert.True(t, strings.HasSuffix(reqRef, "Request"),
+		"requestBody $ref %q should end with 'Request'", reqRef)
+
+	// Get the 200 response $ref.
+	resp200 := echoPath.Post.Responses.Value("200")
+	require.NotNil(t, resp200, "expected 200 response")
+	jsonRespMedia := resp200.Value.Content["application/json"]
+	require.NotNil(t, jsonRespMedia, "expected application/json in 200 response")
+	respRef := jsonRespMedia.Schema.Ref
+	assert.NotEmpty(t, respRef, "expected $ref in 200 response schema")
+	assert.True(t, strings.HasSuffix(respRef, "Response"),
+		"200 response $ref %q should end with 'Response'", respRef)
+
+	// The two $ref values must be DIFFERENT (pre-fix they were the same).
+	assert.NotEqual(t, reqRef, respRef,
+		"request and response $refs must differ (echo endpoints share property shapes but not component names)")
+}
+
 // TestExtractComponents_DeterministicMultiContentType ensures that when a
 // single endpoint exposes multiple media types with DIFFERENT schemas (e.g.,
 // JSON + urlencoded observations), component names are stable across runs.
@@ -1140,6 +1206,89 @@ func TestExtractComponents_DeterministicMultiContentType(t *testing.T) {
 	}
 	for i := 1; i < 5; i++ {
 		assert.Equal(t, string(runs[0]), string(runs[i]), "run %d differs from run 0", i)
+	}
+}
+
+// TestOpenAPIGenerator_MultipartRepeatedFileFields_E2E verifies that when a
+// multipart body contains two parts with the same name="files" both carrying
+// filenames, the generated spec contains exactly ONE "files" property with
+// format: binary.
+//
+// Current intentional last-wins behavior: the second part overwrites the first
+// in schema.Properties, so only one "files" entry exists. This is documented
+// here so future readers understand the design decision and can change it if
+// array semantics are desired.
+func TestOpenAPIGenerator_MultipartRepeatedFileFields_E2E(t *testing.T) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	// Two file parts with the same name "files".
+	for _, fname := range []string{"a.jpg", "b.png"} {
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", `form-data; name="files"; filename="`+fname+`"`)
+		h.Set("Content-Type", "image/jpeg")
+		fw, err := w.CreatePart(h)
+		require.NoError(t, err)
+		_, _ = fw.Write([]byte("filedata"))
+	}
+	_ = w.Close()
+
+	contentType := "multipart/form-data; boundary=" + w.Boundary()
+
+	gen := &OpenAPIGenerator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://api.example.com/upload",
+				Headers: map[string]string{
+					"content-type": contentType,
+				},
+				Body: buf.Bytes(),
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+				},
+			},
+			IsAPI: true,
+		},
+	}
+
+	spec, err := gen.Generate(endpoints)
+	require.NoError(t, err, "Generate should succeed")
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData(spec)
+	require.NoError(t, err, "Generated spec should be valid OpenAPI")
+
+	uploadPath := doc.Paths.Find("/upload")
+	require.NotNil(t, uploadPath, "expected /upload path in spec")
+	require.NotNil(t, uploadPath.Post, "expected POST operation on /upload")
+	require.NotNil(t, uploadPath.Post.RequestBody, "expected requestBody on POST /upload")
+
+	content := uploadPath.Post.RequestBody.Value.Content
+	multipartMedia, ok := content["multipart/form-data"]
+	require.True(t, ok, "expected multipart/form-data content type in requestBody")
+
+	// Resolve $ref if needed
+	schema := multipartMedia.Schema
+	if schema.Ref != "" {
+		// Look up the component
+		refName := strings.TrimPrefix(schema.Ref, "#/components/schemas/")
+		schema = doc.Components.Schemas[refName]
+	}
+	require.NotNil(t, schema, "expected schema for multipart/form-data")
+	require.NotNil(t, schema.Value, "expected schema value")
+	require.NotNil(t, schema.Value.Properties, "expected schema properties")
+
+	// Exactly ONE "files" property (last-wins: second part overwrites first).
+	filesProp, ok := schema.Value.Properties["files"]
+	assert.True(t, ok, "expected exactly one 'files' property in schema")
+	if ok {
+		require.NotNil(t, filesProp.Value)
+		assert.Equal(t, "string", filesProp.Value.Type.Slice()[0],
+			"'files' property should be type string")
+		assert.Equal(t, "binary", filesProp.Value.Format,
+			"'files' property should have format: binary")
 	}
 }
 

--- a/pkg/generate/rest/openapi_test.go
+++ b/pkg/generate/rest/openapi_test.go
@@ -1104,6 +1104,45 @@ func TestOpenAPIGenerator_MultipartFormData_EndToEnd(t *testing.T) {
 	assert.Contains(t, specStr, "binary", "spec missing format: binary for file upload field")
 }
 
+// TestExtractComponents_DeterministicMultiContentType ensures that when a
+// single endpoint exposes multiple media types with DIFFERENT schemas (e.g.,
+// JSON + urlencoded observations), component names are stable across runs.
+// The previous TestExtractComponents_Deterministic only used one media type
+// per path and missed the inner-map iteration order issue.
+func TestExtractComponents_DeterministicMultiContentType(t *testing.T) {
+	var obs []classify.ClassifiedRequest
+	for _, p := range []string{"/api/a", "/api/b", "/api/c", "/api/d", "/api/e"} {
+		obs = append(obs,
+			classify.ClassifiedRequest{
+				ObservedRequest: crawl.ObservedRequest{
+					Method: "POST", URL: "http://x.test" + p,
+					Headers: map[string]string{"Content-Type": "application/json"},
+					Body:    []byte(`{"jsonField":"v"}`),
+				},
+				IsAPI: true, Confidence: 0.9, APIType: "rest",
+			},
+			classify.ClassifiedRequest{
+				ObservedRequest: crawl.ObservedRequest{
+					Method: "POST", URL: "http://x.test" + p,
+					Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+					Body:    []byte(`urlencodedField=v`),
+				},
+				IsAPI: true, Confidence: 0.9, APIType: "rest",
+			},
+		)
+	}
+	gen := &OpenAPIGenerator{}
+	runs := make([][]byte, 5)
+	for i := 0; i < 5; i++ {
+		out, err := gen.Generate(obs)
+		require.NoError(t, err)
+		runs[i] = out
+	}
+	for i := 1; i < 5; i++ {
+		assert.Equal(t, string(runs[0]), string(runs[i]), "run %d differs from run 0", i)
+	}
+}
+
 // Helper function for tests
 func stringPtr(s string) *string {
 	return &s
@@ -1235,6 +1274,27 @@ func TestOpenAPIGenerator_NonHTTPScheme(t *testing.T) {
 	if !strings.Contains(specStr, "/valid") {
 		t.Error("HTTPS endpoint should be present")
 	}
+}
+
+// TestMergeJSONBodies_TypeConflictPromotesToString verifies that JSON merge
+// uses the same conflict-resolution as form merge (was: silently kept first
+// type). Two observations with `count: 42` then `count: "hello"` should yield
+// a string-typed schema (matching urlencoded/multipart behavior).
+func TestMergeJSONBodies_TypeConflictPromotesToString(t *testing.T) {
+	bodies := [][]byte{
+		[]byte(`{"count": 42}`),
+		[]byte(`{"count": "hello"}`),
+	}
+	merged := mergeJSONBodies(bodies)
+	require.NotNil(t, merged)
+	require.NotNil(t, merged.Value)
+	require.NotNil(t, merged.Value.Properties)
+	countProp := merged.Value.Properties["count"]
+	require.NotNil(t, countProp)
+	require.NotNil(t, countProp.Value.Type)
+	require.NotEmpty(t, countProp.Value.Type.Slice())
+	assert.Equal(t, "string", countProp.Value.Type.Slice()[0],
+		"conflicting types should promote to string (matching form merge behavior)")
 }
 
 // TestExtractComponents_Deterministic verifies that Generate produces byte-identical

--- a/pkg/generate/rest/openapi_test.go
+++ b/pkg/generate/rest/openapi_test.go
@@ -1236,3 +1236,43 @@ func TestOpenAPIGenerator_NonHTTPScheme(t *testing.T) {
 		t.Error("HTTPS endpoint should be present")
 	}
 }
+
+// TestExtractComponents_Deterministic verifies that Generate produces byte-identical
+// output across multiple runs when many paths share the same schema fingerprint.
+// Non-determinism would arise from iterating doc.Paths.Map() in random order:
+// the first path encountered for a given fingerprint wins the component name.
+func TestExtractComponents_Deterministic(t *testing.T) {
+	gen := &OpenAPIGenerator{}
+
+	// Build 26 endpoints /v1/a … /v1/z, each with the same request body shape
+	// {name: string, count: integer}. They all produce the same schema fingerprint,
+	// so whichever path is iterated first sets the component name. Without a
+	// deterministic sort, the chosen name varies between runs.
+	body := []byte(`{"name":"x","count":1}`)
+	endpoints := make([]classify.ClassifiedRequest, 0, 26)
+	for c := 'a'; c <= 'z'; c++ {
+		endpoints = append(endpoints, classify.ClassifiedRequest{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:  "POST",
+				URL:     "https://api.example.com/v1/" + string(c),
+				Headers: map[string]string{"Content-Type": "application/json"},
+				Body:    body,
+				Response: crawl.ObservedResponse{
+					StatusCode: 201,
+					Body:       []byte(`{"id":1}`),
+				},
+			},
+			IsAPI: true,
+		})
+	}
+
+	// Run Generate 5 times; all outputs must be byte-identical.
+	first, err := gen.Generate(endpoints)
+	require.NoError(t, err, "first Generate call failed")
+
+	for i := 2; i <= 5; i++ {
+		out, err := gen.Generate(endpoints)
+		require.NoError(t, err, "Generate call %d failed", i)
+		assert.Equal(t, first, out, "Generate run %d produced different output than run 1 — non-determinism detected", i)
+	}
+}

--- a/pkg/generate/rest/openapi_test.go
+++ b/pkg/generate/rest/openapi_test.go
@@ -15,11 +15,16 @@
 package rest
 
 import (
+	"bytes"
 	"encoding/json"
+	"mime/multipart"
+	"net/textproto"
 	"strings"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/praetorian-inc/vespasian/pkg/classify"
@@ -656,6 +661,72 @@ func TestResourceNameFromPath(t *testing.T) {
 	}
 }
 
+func TestResourceNameFromPath_StripsExtensions(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{name: "php extension", path: "/login.php", expected: "Login"},
+		{name: "mvc extension", path: "/register.mvc", expected: "Register"},
+		{name: "json extension", path: "/data.json", expected: "Data"},
+		{name: "asp extension", path: "/page.asp", expected: "Page"},
+		{name: "aspx extension", path: "/submit.aspx", expected: "Submit"},
+		{name: "jsp extension", path: "/view.jsp", expected: "View"},
+		{name: "html extension", path: "/index.html", expected: "Index"},
+		{name: "htm extension", path: "/home.htm", expected: "Home"},
+		{name: "xml extension", path: "/feed.xml", expected: "Feed"},
+		{name: "action extension", path: "/save.action", expected: "Save"},
+		{name: "do extension", path: "/process.do", expected: "Process"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resourceNameFromPath(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestResourceNameFromPath_HandlesHyphens(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{name: "hyphenated segment", path: "/stored-xss", expected: singularize("StoredXss")},
+		{name: "multi-hyphenated", path: "/cross-site-scripting", expected: singularize("CrossSiteScripting")},
+		{name: "underscore segment", path: "/user_profile", expected: singularize("UserProfile")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resourceNameFromPath(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestResourceNameFromPath_FallbackOnEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{name: "root path", path: "/", expected: "Resource"},
+		{name: "empty string", path: "", expected: "Resource"},
+		{name: "extension-only segment", path: "/.php", expected: "Resource"},
+		{name: "numeric-only segment", path: "/123", expected: "Resource123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resourceNameFromPath(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestSchemaFingerprint(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -892,6 +963,145 @@ func TestExtractComponents(t *testing.T) {
 		t.Logf("POST 201 ref: %s", postResp.Value.Content["application/json"].Schema.Ref)
 		t.Logf("GET 200 ref: %s", getResp.Value.Content["application/json"].Schema.Ref)
 	}
+}
+
+func TestBuildOperation_FormBody(t *testing.T) {
+	t.Run("url-encoded form body", func(t *testing.T) {
+		gen := &OpenAPIGenerator{}
+		endpoints := []classify.ClassifiedRequest{
+			{
+				ObservedRequest: crawl.ObservedRequest{
+					Method: "POST",
+					URL:    "https://api.example.com/login",
+					Headers: map[string]string{
+						"content-type": "application/x-www-form-urlencoded",
+					},
+					Body: []byte("username=alice&password=secret"),
+					Response: crawl.ObservedResponse{
+						StatusCode: 200,
+					},
+				},
+				IsAPI: true,
+			},
+		}
+		spec, err := gen.Generate(endpoints)
+		require.NoError(t, err, "Generate should succeed")
+
+		var parsed map[string]interface{}
+		require.NoError(t, yaml.Unmarshal(spec, &parsed), "YAML parse should succeed")
+
+		// Dig into paths./login.post.requestBody.content
+		paths, _ := parsed["paths"].(map[string]interface{})
+		loginPath, _ := paths["/login"].(map[string]interface{})
+		post, _ := loginPath["post"].(map[string]interface{})
+		requestBody, _ := post["requestBody"].(map[string]interface{})
+		content, _ := requestBody["content"].(map[string]interface{})
+
+		_, hasFormEncoded := content["application/x-www-form-urlencoded"]
+		assert.True(t, hasFormEncoded, "expected application/x-www-form-urlencoded in content, got keys: %v", content)
+		_, hasJSON := content["application/json"]
+		assert.False(t, hasJSON, "expected no application/json key for url-encoded-only endpoint")
+	})
+
+	t.Run("mixed json and url-encoded observations", func(t *testing.T) {
+		gen := &OpenAPIGenerator{}
+		endpoints := []classify.ClassifiedRequest{
+			{
+				ObservedRequest: crawl.ObservedRequest{
+					Method: "POST",
+					URL:    "https://api.example.com/submit",
+					Headers: map[string]string{
+						"content-type": "application/json",
+					},
+					Body:     []byte(`{"name":"Alice"}`),
+					Response: crawl.ObservedResponse{StatusCode: 200},
+				},
+				IsAPI: true,
+			},
+			{
+				ObservedRequest: crawl.ObservedRequest{
+					Method: "POST",
+					URL:    "https://api.example.com/submit",
+					Headers: map[string]string{
+						"Content-Type": "application/x-www-form-urlencoded",
+					},
+					Body:     []byte("name=Bob"),
+					Response: crawl.ObservedResponse{StatusCode: 200},
+				},
+				IsAPI: true,
+			},
+		}
+		spec, err := gen.Generate(endpoints)
+		require.NoError(t, err, "Generate should succeed")
+
+		var parsed map[string]interface{}
+		require.NoError(t, yaml.Unmarshal(spec, &parsed), "YAML parse should succeed")
+
+		paths, _ := parsed["paths"].(map[string]interface{})
+		submitPath, _ := paths["/submit"].(map[string]interface{})
+		post, _ := submitPath["post"].(map[string]interface{})
+		requestBody, _ := post["requestBody"].(map[string]interface{})
+		content, _ := requestBody["content"].(map[string]interface{})
+
+		_, hasJSON := content["application/json"]
+		assert.True(t, hasJSON, "expected application/json in content, got keys: %v", content)
+		_, hasFormEncoded := content["application/x-www-form-urlencoded"]
+		assert.True(t, hasFormEncoded, "expected application/x-www-form-urlencoded in content, got keys: %v", content)
+	})
+}
+
+func TestOpenAPIGenerator_MultipartFormData_EndToEnd(t *testing.T) {
+	// Build a well-formed multipart/form-data body with one text field and
+	// one file upload field, then pass it through gen.Generate() and assert
+	// that the resulting spec carries a multipart/form-data requestBody with
+	// the file field typed as string/binary.
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	// Text field
+	err := w.WriteField("username", "alice")
+	require.NoError(t, err)
+
+	// File field
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", `form-data; name="avatar"; filename="photo.jpg"`)
+	h.Set("Content-Type", "image/jpeg")
+	fw, err := w.CreatePart(h)
+	require.NoError(t, err)
+	_, _ = fw.Write([]byte("JPEG_DATA"))
+	_ = w.Close()
+
+	contentType := "multipart/form-data; boundary=" + w.Boundary()
+
+	gen := &OpenAPIGenerator{}
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "POST",
+				URL:    "https://api.example.com/upload",
+				Headers: map[string]string{
+					"content-type": contentType,
+				},
+				Body: buf.Bytes(),
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+				},
+			},
+			IsAPI: true,
+		},
+	}
+
+	spec, err := gen.Generate(endpoints)
+	require.NoError(t, err, "Generate should succeed")
+
+	specStr := string(spec)
+
+	// The requestBody content must have a multipart/form-data key.
+	assert.Contains(t, specStr, "multipart/form-data", "spec missing multipart/form-data content type in requestBody")
+
+	// The file field must be present and typed string/binary.
+	assert.Contains(t, specStr, "avatar", "spec missing 'avatar' field from multipart body")
+	assert.Contains(t, specStr, "binary", "spec missing format: binary for file upload field")
 }
 
 // Helper function for tests

--- a/pkg/generate/rest/openapi_test.go
+++ b/pkg/generate/rest/openapi_test.go
@@ -319,9 +319,7 @@ func TestCapitalizeFirst(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := capitalizeFirst(tt.input)
-			if result != tt.expected {
-				t.Errorf("capitalizeFirst(%q) = %q, want %q", tt.input, result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result, "capitalizeFirst(%q)", tt.input)
 		})
 	}
 }
@@ -349,9 +347,7 @@ func TestInferQueryParamType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := inferQueryParamType(tt.value)
-			if result != tt.expected {
-				t.Errorf("inferQueryParamType(%q) = %q, want %q", tt.value, result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result, "inferQueryParamType(%q)", tt.value)
 		})
 	}
 }
@@ -909,60 +905,49 @@ func TestExtractComponents(t *testing.T) {
 	extractComponents(doc)
 
 	// Verify components were created
-	if doc.Components == nil || doc.Components.Schemas == nil {
-		t.Fatal("Components or Schemas not initialized")
-	}
+	require.NotNil(t, doc.Components, "Components should be initialized")
+	require.NotNil(t, doc.Components.Schemas, "Schemas should be initialized")
 
 	// Verify request body schema was extracted
-	if _, exists := doc.Components.Schemas["CreateTicketRequest"]; !exists {
-		t.Error("CreateTicketRequest schema not found in components")
-	}
+	assert.Contains(t, doc.Components.Schemas, "CreateTicketRequest",
+		"CreateTicketRequest schema not found in components")
 
 	// Verify response schemas were extracted
 	// Note: POST 201 and GET 200 have identical schemas (id, title), so they share the same component
-	hasTicketResponse := false
-	if _, exists := doc.Components.Schemas["TicketCreatedResponse"]; exists {
-		hasTicketResponse = true
-	}
-	if _, exists := doc.Components.Schemas["TicketResponse"]; exists {
-		hasTicketResponse = true
-	}
-	if !hasTicketResponse {
-		t.Error("No ticket response schema found in components (expected TicketCreatedResponse or TicketResponse)")
-	}
+	_, hasCreatedResponse := doc.Components.Schemas["TicketCreatedResponse"]
+	_, hasTicketResponse := doc.Components.Schemas["TicketResponse"]
+	assert.True(t, hasCreatedResponse || hasTicketResponse,
+		"No ticket response schema found in components (expected TicketCreatedResponse or TicketResponse)")
 
-	if _, exists := doc.Components.Schemas["TicketNotFoundResponse"]; !exists {
-		t.Error("TicketNotFoundResponse schema not found in components")
-	}
+	assert.Contains(t, doc.Components.Schemas, "TicketNotFoundResponse",
+		"TicketNotFoundResponse schema not found in components")
 
 	// Verify schemas were replaced with $ref
 	postOp := doc.Paths.Find("/api/v2/tickets").Post
-	if postOp.RequestBody == nil || postOp.RequestBody.Value.Content["application/json"].Schema.Ref == "" {
-		t.Error("POST request body schema not replaced with $ref")
-	}
+	require.NotNil(t, postOp.RequestBody, "POST request body should not be nil")
+	assert.NotEmpty(t, postOp.RequestBody.Value.Content["application/json"].Schema.Ref,
+		"POST request body schema not replaced with $ref")
 
 	getOp := doc.Paths.Find("/api/v2/tickets/{ticketId}").Get
 	resp200 := getOp.Responses.Value("200")
-	if resp200 == nil || resp200.Value.Content["application/json"].Schema.Ref == "" {
-		t.Error("GET 200 response schema not replaced with $ref")
-	}
+	require.NotNil(t, resp200, "GET 200 response should not be nil")
+	assert.NotEmpty(t, resp200.Value.Content["application/json"].Schema.Ref,
+		"GET 200 response schema not replaced with $ref")
+
 	resp404 := getOp.Responses.Value("404")
-	if resp404 == nil || resp404.Value.Content["application/json"].Schema.Ref == "" {
-		t.Error("GET 404 response schema not replaced with $ref")
-	}
+	require.NotNil(t, resp404, "GET 404 response should not be nil")
+	assert.NotEmpty(t, resp404.Value.Content["application/json"].Schema.Ref,
+		"GET 404 response schema not replaced with $ref")
 
-	// Verify deduplication: 200 responses for both POST/GET have same schema
+	// Verify deduplication: POST 201 and GET 200 have identical schemas (id, title).
+	// They may or may not share the same $ref depending on the response-vs-request
+	// fingerprint maps; at minimum, both $refs must be non-empty (already checked above).
 	postResp := postOp.Responses.Value("201")
+	require.NotNil(t, postResp, "POST 201 response should not be nil")
 	getResp := getOp.Responses.Value("200")
-
-	// Both should reference the same schema (based on fingerprint)
-	// POST 201 and GET 200 have identical schemas (id, title), so they should share a component
-	if postResp.Value.Content["application/json"].Schema.Ref != getResp.Value.Content["application/json"].Schema.Ref {
-		// Actually, they might have different names based on status code context
-		// Let me check if at least the references exist
-		t.Logf("POST 201 ref: %s", postResp.Value.Content["application/json"].Schema.Ref)
-		t.Logf("GET 200 ref: %s", getResp.Value.Content["application/json"].Schema.Ref)
-	}
+	require.NotNil(t, getResp, "GET 200 response should not be nil")
+	t.Logf("POST 201 ref: %s", postResp.Value.Content["application/json"].Schema.Ref)
+	t.Logf("GET 200 ref: %s", getResp.Value.Content["application/json"].Schema.Ref)
 }
 
 func TestBuildOperation_FormBody(t *testing.T) {

--- a/pkg/generate/rest/openapi_test.go
+++ b/pkg/generate/rest/openapi_test.go
@@ -1431,6 +1431,29 @@ func TestMergeJSONBodies_TypeConflictPromotesToString(t *testing.T) {
 		"conflicting types should promote to string (matching form merge behavior)")
 }
 
+// TestMergeJSONBodies_SkipBranches verifies that mergeJSONBodies correctly skips
+// nil/empty bodies and bodies that fail JSON inference, while still merging valid ones.
+func TestMergeJSONBodies_SkipBranches(t *testing.T) {
+	t.Run("skips empty body", func(t *testing.T) {
+		bodies := [][]byte{nil, []byte(`{"a":1}`)}
+		merged := mergeJSONBodies(bodies)
+		require.NotNil(t, merged, "expected non-nil result when one body is valid")
+		require.NotNil(t, merged.Value)
+		require.NotNil(t, merged.Value.Properties)
+		assert.Contains(t, merged.Value.Properties, "a", "valid body's property 'a' should be present")
+	})
+
+	t.Run("skips body that fails inference", func(t *testing.T) {
+		bodies := [][]byte{[]byte("not valid json"), []byte(`{"a":1}`)}
+		merged := mergeJSONBodies(bodies)
+		require.NotNil(t, merged, "expected non-nil result when one body is valid")
+		require.NotNil(t, merged.Value)
+		require.NotNil(t, merged.Value.Properties)
+		assert.Contains(t, merged.Value.Properties, "a", "valid body's property 'a' should be present")
+		assert.Len(t, merged.Value.Properties, 1, "only the valid body should contribute properties")
+	})
+}
+
 // TestExtractComponents_Deterministic verifies that Generate produces byte-identical
 // output across multiple runs when many paths share the same schema fingerprint.
 // Non-determinism would arise from iterating doc.Paths.Map() in random order:

--- a/test/rest-api/expected-paths.json
+++ b/test/rest-api/expected-paths.json
@@ -1,5 +1,5 @@
 {
-  "description": "Expected API paths from a live crawl of the REST API target. The crawler discovers GET endpoints via links on the index page. Parameter names may vary (e.g., {userId} vs {id}).",
+  "description": "Expected API paths from a live crawl of the REST API target. The crawler discovers GET endpoints via links on the index page and POST endpoints via JS fetch calls. Parameter names may vary (e.g., {userId} vs {id}).",
   "paths": {
     "/api/health": ["GET"],
     "/api/users": ["GET"],
@@ -8,8 +8,10 @@
     "/api/products": ["GET"],
     "/api/products/{id}": ["GET"],
     "/api/orders": ["GET"],
-    "/api/orders/{id}": ["GET"]
+    "/api/orders/{id}": ["GET"],
+    "/api/login": ["POST"],
+    "/api/upload": ["POST"]
   },
-  "total_paths": 8,
+  "total_paths": 10,
   "excluded_patterns": [".js", ".css", ".png", ".ico", ".svg", ".woff"]
 }

--- a/test/rest-api/expected-spec.yaml
+++ b/test/rest-api/expected-spec.yaml
@@ -1,5 +1,20 @@
 components:
     schemas:
+        CreateLoginRequest:
+            properties:
+                password:
+                    type: string
+                username:
+                    type: string
+            type: object
+        CreateUploadRequest:
+            properties:
+                description:
+                    type: string
+                file:
+                    format: binary
+                    type: string
+            type: object
         EmailAddressResponse:
             properties:
                 email:
@@ -8,6 +23,11 @@ components:
         HealthResponse:
             properties:
                 status:
+                    type: string
+            type: object
+        LoginResponse:
+            properties:
+                token:
                     type: string
             type: object
         OrderResponse:
@@ -54,6 +74,21 @@ paths:
                                 $ref: '#/components/schemas/HealthResponse'
                     description: OK
             summary: Get /api/health
+    /api/login:
+        post:
+            requestBody:
+                content:
+                    application/x-www-form-urlencoded:
+                        schema:
+                            $ref: '#/components/schemas/CreateLoginRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LoginResponse'
+                    description: OK
+            summary: Post /api/login
     /api/orders:
         get:
             responses:
@@ -126,6 +161,21 @@ paths:
                                 $ref: '#/components/schemas/ProductResponse'
                     description: OK
             summary: Get /api/products/{productId}
+    /api/upload:
+        post:
+            requestBody:
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: '#/components/schemas/CreateUploadRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/HealthResponse'
+                    description: OK
+            summary: Post /api/upload
     /api/users:
         get:
             responses:

--- a/test/rest-api/expected-spec.yaml
+++ b/test/rest-api/expected-spec.yaml
@@ -1,6 +1,6 @@
 components:
     schemas:
-        Email-addressResponse:
+        EmailAddressResponse:
             properties:
                 email:
                     type: string
@@ -174,7 +174,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/Email-addressResponse'
+                                $ref: '#/components/schemas/EmailAddressResponse'
                     description: OK
             summary: Get /api/users/{userId}/email-address
 servers:

--- a/test/rest-api/main.go
+++ b/test/rest-api/main.go
@@ -271,6 +271,64 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// handleLogin accepts application/x-www-form-urlencoded POST (login form).
+// Exercises vespasian's urlencoded form body parsing.
+func handleLogin(w http.ResponseWriter, r *http.Request) {
+	setCORSHeaders(w)
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Allow", "POST, OPTIONS")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 4*1024) // 4KB login cap
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid form"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"username":    r.FormValue("username"),
+		"remember_me": r.FormValue("remember_me") == "true",
+		"token":       "fake-session-token",
+	})
+}
+
+// handleUpload accepts multipart/form-data POST with a file and text fields.
+// Exercises vespasian's multipart form body parsing.
+func handleUpload(w http.ResponseWriter, r *http.Request) {
+	setCORSHeaders(w)
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Allow", "POST, OPTIONS")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20) // 10MB upload cap
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid multipart"})
+		return
+	}
+	description := r.FormValue("description")
+	filename := ""
+	size := int64(0)
+	if file, header, err := r.FormFile("file"); err == nil {
+		filename = header.Filename
+		size = header.Size
+		_ = file.Close() //nolint:errcheck // test server best-effort cleanup
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"description": description,
+		"filename":    filename,
+		"size":        size,
+	})
+}
+
 // ── Edge case endpoints ─────────────────────────────────────
 
 // handleLargeResponse returns a large JSON array (~100KB) to test body truncation.
@@ -627,7 +685,32 @@ func handleIndex(w http.ResponseWriter, _ *http.Request) {
   <li>DELETE /api/users/{id} - Delete user</li>
   <li>PUT /api/users/{id}/email-address - Update email</li>
   <li>POST /api/orders - Create order</li>
+  <li>POST /api/login - URL-encoded form login</li>
+  <li>POST /api/upload - Multipart file upload</li>
 </ul>
+<script>
+  // Fire urlencoded POST to /api/login on page load (for form data E2E testing)
+  (function() {
+    const params = new URLSearchParams();
+    params.append('username', 'alice');
+    params.append('password', 'secret123');
+    params.append('remember_me', 'true');
+    fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString()
+    }).catch(function() {});
+
+    // Fire multipart POST to /api/upload on page load
+    const fd = new FormData();
+    fd.append('description', 'test upload from crawler');
+    fd.append('file', new Blob(['sample file content'], { type: 'text/plain' }), 'sample.txt');
+    fetch('/api/upload', {
+      method: 'POST',
+      body: fd
+    }).catch(function() {});
+  })();
+</script>
 </body>
 </html>`
 	fmt.Fprint(w, indexHTML) //nolint:errcheck // test server best-effort response
@@ -707,6 +790,8 @@ func main() {
 	mux.HandleFunc("/api/products/", handleProductByID)
 	mux.HandleFunc("/api/orders", handleOrders)
 	mux.HandleFunc("/api/orders/", handleOrderByID)
+	mux.HandleFunc("/api/login", handleLogin)
+	mux.HandleFunc("/api/upload", handleUpload)
 
 	// Edge case: response types
 	mux.HandleFunc("/api/large", handleLargeResponse)

--- a/test/rest-api/main.go
+++ b/test/rest-api/main.go
@@ -658,6 +658,11 @@ func handleEmptyOK(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// SEC-FE-001: indexHTML embeds an inline <script> that fires fetch() requests on
+// page load to exercise vespasian's form-body parser during E2E crawls. This is
+// intentional and acceptable because this server is a local test fixture only —
+// it is never deployed and is not subject to CSP. Do NOT copy this pattern to
+// production.
 func handleIndex(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 	const indexHTML = `<!DOCTYPE html>
@@ -688,12 +693,13 @@ func handleIndex(w http.ResponseWriter, _ *http.Request) {
   <li>POST /api/login - URL-encoded form login</li>
   <li>POST /api/upload - Multipart file upload</li>
 </ul>
+<!-- TEST-ONLY: inline script intentionally fires fetch() to exercise vespasian's form-body parser during E2E crawls. Acceptable here because this server is a local test fixture only — never deployed and not subject to CSP. Do NOT copy this pattern to production. -->
 <script>
   // Fire urlencoded POST to /api/login on page load (for form data E2E testing)
   (function() {
     const params = new URLSearchParams();
     params.append('username', 'alice');
-    params.append('password', 'secret123');
+    params.append('password', 'testpassword');  // synthetic test value, not a real credential
     params.append('remember_me', 'true');
     fetch('/api/login', {
       method: 'POST',

--- a/test/rest-api/reference-capture.json
+++ b/test/rest-api/reference-capture.json
@@ -126,5 +126,43 @@
       "body": "eyJpZCI6MSwidXNlcl9pZCI6MSwicHJvZHVjdF9pZCI6MiwicXVhbnRpdHkiOjF9"
     },
     "source": "test-crawl"
+  },
+  {
+    "_comment": "LAB-2106: urlencoded form body — pins ParseURLEncodedForm output in golden spec",
+    "method": "POST",
+    "url": "http://localhost:8990/api/login",
+    "headers": {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json"
+    },
+    "body": "dXNlcm5hbWU9YWxpY2UmcGFzc3dvcmQ9c2VjcmV0",
+    "response": {
+      "status_code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "content_type": "application/json",
+      "body": "eyJ0b2tlbiI6ImFiYzEyMyJ9"
+    },
+    "source": "test-crawl"
+  },
+  {
+    "_comment": "LAB-2106: multipart form body with file + text field — pins ParseMultipartForm output in golden spec",
+    "method": "POST",
+    "url": "http://localhost:8990/api/upload",
+    "headers": {
+      "Content-Type": "multipart/form-data; boundary=----FormBoundary7MA4YWxkTrZu0gW",
+      "Accept": "application/json"
+    },
+    "body": "LS0tLS0tRm9ybUJvdW5kYXJ5N01BNFlXeGtUclp1MGdXDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImRlc2NyaXB0aW9uIg0KDQpoZWxsbyB3b3JsZA0KLS0tLS0tRm9ybUJvdW5kYXJ5N01BNFlXeGtUclp1MGdXDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0idGVzdC50eHQiDQpDb250ZW50LVR5cGU6IHRleHQvcGxhaW4NCg0KZmlsZSBjb250ZW50DQotLS0tLS1Gb3JtQm91bmRhcnk3TUE0WVd4a1RyWnUwZ1ctLQ0K",
+    "response": {
+      "status_code": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "content_type": "application/json",
+      "body": "eyJzdGF0dXMiOiJ1cGxvYWRlZCJ9"
+    },
+    "source": "test-crawl"
   }
 ]

--- a/test/rest-api/reference-capture.json
+++ b/test/rest-api/reference-capture.json
@@ -135,7 +135,7 @@
       "Content-Type": "application/x-www-form-urlencoded",
       "Accept": "application/json"
     },
-    "body": "dXNlcm5hbWU9YWxpY2UmcGFzc3dvcmQ9c2VjcmV0",
+    "body": "dXNlcm5hbWU9YWxpY2UmcGFzc3dvcmQ9dGVzdHBhc3N3b3Jk",
     "response": {
       "status_code": 200,
       "headers": {


### PR DESCRIPTION
## Summary

Implements form-encoded (`application/x-www-form-urlencoded`) and multipart (`multipart/form-data`) request body parsing in the OpenAPI generator, completing LAB-2106. Form-based endpoints (logins, uploads, legacy APIs) now get complete `requestBody` schemas instead of appearing parameterless in generated specs.

Linear: https://linear.app/praetorianlabs/issue/LAB-2106

## Commit timeline

| Commit | What |
|---|---|
| `fb1a8bf` | Core feature (form parsing) |
| `7445244` | Tier-2 fixes (body-fingerprint dedup + sort paths) |
| `8fc0079` | Inline doc on body-fingerprint design |
| `8608ddd` | Pre-review polish (SOAP body test + benchmarks) |
| `2a3f15c` | 9 reviewer findings + 3 Go 1.24+ idiom modernizations |
| **`b9c0113`** | **Santiago + CodeRabbit review findings (this commit)** |

## What changed

### Core feature surface
- `pkg/generate/rest/form.go` (new): `ParseURLEncodedForm`, `ParseMultipartForm`, `extractBoundary`, case-insensitive `getHeader`, merge helpers
- `pkg/generate/rest/openapi.go`: content-type-partitioned `buildOperation`, all-media-types `extractComponents` with sorted iteration, sanitized `resourceNameFromPath`
- `pkg/classify/classifier.go`: content-type + body-fingerprint aware `Deduplicate`, multipart boundary normalization
- `test/rest-api/main.go`: `/api/login` (urlencoded) and `/api/upload` (multipart) endpoints

### Hardening (b9c0113)
- **`maxMultipartParts = 1000`** cap in `ParseMultipartForm` to prevent OOM under adversarial input (SEC-BE-002)
- **Scope-separated fingerprint maps** in `extractComponents` (`fingerprintToReqName` / `fingerprintToRespName`) so echo-style endpoints don't tag responses as `…Request` (CodeRabbit cross-scope $ref)
- **Deterministic golden** — `reference-capture.json` + `expected-spec.yaml` extended with urlencoded + multipart entries so `test_generate_rest` pins form-body output (TEST-006)
- **Tightened test assertions** — body-content `ElementsMatch` instead of count-only; multipart partial-content-types subtest; repeated-file-fields E2E test; `toCamelCase` ASCII-only doc

## Testing matrix

| Layer | Result |
|---|---|
| Unit tests | **482 passing**, 89.1% coverage `pkg/classify`, **93.2%** `pkg/generate/rest` |
| `-count=10 -race` heavy stress | No flakiness |
| Full repo `go test -race` | 9 packages clean, 0 regressions |
| `./test/run-live-tests.sh` | **20/20 targets pass** (including the regenerated `generate-rest` golden) |
| `vespasian scan` against real vulnerable apps | **7 apps**: DVWA, Mutillidae, Juice Shop, WebGoat, bWAPP, VAmPI, NodeGoat |
| Real mitmproxy capture → import → spec | Multipart `file: binary` correctly produced |
| `vespasian crawl --proxy + -H Cookie` | Auth + proxy routing works end-to-end |
| Burp XML / HAR / mitmproxy importers | All preserve form bodies correctly |
| Spectral OpenAPI 3.0 lint | 0 errors across all generated specs |
| openapi-generator codegen (Python + TypeScript) | Clients compile with form-aware signatures |
| PUT + PATCH with form bodies | E2E validated; `Update` component prefix correctly selected |
| `Format: json` output | Valid OpenAPI 3.0 JSON |
| `--probe=true` with form endpoints | Probe stage doesn't break form pipeline |
| 10,000-endpoint scale | 5.15s, 577 MB peak RSS, no crashes |
| 50-iteration memory leak test | Heap stable, +86 KB total |
| Adversarial fuzz | 16/16 multipart + 13/13 urlencoded malformed cases handled |
| Idempotency (5 runs of new golden) | Byte-identical output |
| `golangci-lint govet+shadow` | 0 issues |
| `make fmt` | No-op (all code gofmt-compliant) |

## Performance baselines (linux/arm64)

| Benchmark | ns/op |
|---|---|
| `BenchmarkDeduplicate/n=100` | 69,310 |
| `BenchmarkDeduplicate/n=1000` | 698,116 |
| `BenchmarkDeduplicate/n=5000` | 3,304,505 (linear scaling) |
| `BenchmarkParseURLEncodedForm` | 2,503 |
| `BenchmarkParseMultipartForm` | 13,355 |

## Design decisions made deliberately

1. **SHA-256 [:8] for body fingerprint** — stdlib, 64-bit collision probability ~7×10⁻¹³ at realistic scale, documented inline
2. **Allowlist-based extension stripping** — paths can legitimately contain dots; only known web-framework extensions are stripped
3. **CamelCase via rune-walking, ASCII-only** — handles `-`, `_`, `.` uniformly; non-ASCII intentionally falls through to `Resource` fallback
4. **mitmproxy-as-proxy for real multipart capture** — bypasses pre-existing CDP `hasPostData` limitation; matches real security-assessment workflow
5. **Body fingerprint added only for non-empty bodies** — preserves bodyless dedup (GETs etc.); minimizes regression risk
6. **Multipart boundary normalized before hashing** — clients generate random boundaries; without normalization identical logical forms would never dedup
7. **Multipart parts capped at 1000** — bounds memory under adversarial input; realistic forms are well below this
8. **Scope-separated fingerprint maps in extractComponents** — `fingerprintToReqName` and `fingerprintToRespName` are independent so echo-style endpoints don't cross-pollinate names; `nameCounter` stays shared for global collision avoidance
9. **`mergeJSONBodies` delegates to `mergeObjectSchemas`** — unified type-conflict resolution across JSON, urlencoded, and multipart (all promote to string on conflict)
10. **`io.LimitReader(part, 4096)` for multipart text type inference** — type inference only needs a small prefix; avoids materializing huge text fields
11. **`bytes.NewReader(body)` instead of `strings.NewReader(string(body))`** — eliminates a byte→string copy in hot path

## Items deliberately deferred (with rationale)

| Item | Reason | Recommended follow-up |
|---|---|---|
| **Crawler dropping multipart bodies (CDP `hasPostData`)** | Pre-existing in `pkg/crawl/network.go`; out of LAB-2106 scope; workaround validated (mitmproxy as proxy) | Separate ticket for `pkg/crawl` |
| **Super-linear time at 10k+ endpoints** | Performance, not correctness; benchmarks show `Deduplicate` is linear, so bottleneck is in `buildOperation`/`extractComponents`; requires profiling | Separate ticket |
| **`getContentType` cross-package duplication (QUAL-001)** | Identical helper exists in `pkg/generate/graphql/infer.go`; resolving requires a new shared utility package (e.g., `pkg/httputil`); architectural decision out of LAB-2106 scope | Separate refactor ticket |
| **Content-type normalization duplication (QUAL-003)** | Same as QUAL-001 — would need shared package | Separate refactor ticket |
| **TEST-004 (Santiago): "first observation's type wins" assertion for `mergeJSONBodies`** | Conflicts with our intentional unification (commit `2a3f15c`) where `mergeJSONBodies` delegates to `mergeObjectSchemas` (promotes conflicts to `string` matching form merger). `TestMergeJSONBodies_TypeConflictPromotesToString` covers the unified behavior. Asked Santiago to confirm preference (unified vs first-wins) in PR review thread. | Awaiting reviewer decision |
| **Repeated urlencoded keys as arrays** | Schema-design decision (array type? items schema? minItems?) not in AC; documented in test comments | Revisit if user demand surfaces |
| **JSON output format CLI flag** | `OpenAPIGenerator.Format = "json"` exists in code; no CLI flag exposes it. Code path verified directly | Optional CLI ergonomics ticket |

## Test plan

- [x] `make check` passes
- [x] `go test -race ./...` 9 packages clean
- [x] `-count=10` stress no flakiness
- [x] `./test/run-live-tests.sh` 20/20 pass (including regenerated golden)
- [x] All LAB-2106 acceptance criteria satisfied end-to-end
- [x] 7 real vulnerable apps validated via `vespasian scan`
- [x] OpenAPI 3.0 conformance via spectral
- [x] Downstream codegen via openapi-generator (Python + TS)
- [x] PUT + PATCH form bodies E2E
- [x] JSON output format
- [x] `--probe=true` with form endpoints
- [x] Adversarial fuzz testing
- [x] Memory leak test
- [x] Idempotency verified
- [x] Performance benchmarks established
- [x] Multipart DoS cap enforced
- [x] Scope-separated $ref naming for echo-style endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)