### PR TITLE
fix: bump titus-scan SHA to include preflight permissions fix

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   scan:
-    uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@debcee1fd3a78e908b1f89d8f2bef0644c454cbc  # v2.2.0
+    uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@e2da966933b2c8f02a32540e7bd5812f93a056fb  # v2.2.1
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
Bumps titus-scan.yml SHA to include the `pull-requests: read` preflight permissions fix (public-workflows #58). Without this, the preflight 403s when checking PR file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)