### PR TITLE
feat(rest): expand path parameter detection beyond UUIDs and numeric IDs (LAB-2107)

### DIFF
--- a/pkg/generate/rest/doc.go
+++ b/pkg/generate/rest/doc.go
@@ -19,14 +19,17 @@
 //
 // Key components:
 //   - [OpenAPIGenerator] produces a valid OpenAPI 3.0 document in YAML format.
-//   - Path normalization replaces dynamic path segments with parameterized
-//     templates. Single-path detection covers UUIDs, MongoDB ObjectIDs,
-//     numeric IDs, short hex hashes, and base64/base64url tokens.
-//     Observation-based detection ([NormalizePathsWithNames]) additionally
-//     identifies slug-style identifiers when multiple distinct values are
-//     observed at the same path position. Known literals (`me`, `current`,
-//     `self`, `new`, `list`, `search`) are preserved against all forms of
-//     parameterization.
+//   - [NormalizePathsWithNames] is the primary normalization entry point. It
+//     accepts a population of observed paths and returns a map of input path
+//     to template path, performing both single-path regex detection (UUIDs,
+//     MongoDB ObjectIDs, numeric IDs, short hex hashes, base64/base64url
+//     tokens) and observation-based slug detection across the population.
+//     Known literals (`me`, `current`, `self`, `new`, `list`, `search`) are
+//     preserved against all forms of parameterization.
+//   - [NormalizePathWithNames] is a single-path convenience that performs
+//     only the regex-detection pass; callers that have a population of
+//     paths should prefer [NormalizePathsWithNames] so slug detection can
+//     fire.
 //   - Schema inference examines response JSON to generate OpenAPI schema
 //     objects with depth and property guards.
 package rest

--- a/pkg/generate/rest/doc.go
+++ b/pkg/generate/rest/doc.go
@@ -14,13 +14,19 @@
 
 // Package rest generates OpenAPI 3.0 specifications from classified REST
 // requests. It handles path normalization (collapsing /users/42 and /users/87
-// into /users/{id}), UUID detection, context-aware parameter naming, and JSON
-// schema inference from response bodies.
+// into /users/{id}), dynamic-segment detection, context-aware parameter
+// naming, and JSON schema inference from response bodies.
 //
 // Key components:
 //   - [OpenAPIGenerator] produces a valid OpenAPI 3.0 document in YAML format.
-//   - Path normalization replaces numeric and UUID path segments with
-//     parameterized templates while preserving known literals (/me, /self).
+//   - Path normalization replaces dynamic path segments with parameterized
+//     templates. Single-path detection covers UUIDs, MongoDB ObjectIDs,
+//     numeric IDs, short hex hashes, and base64/base64url tokens.
+//     Observation-based detection ([NormalizePathsWithNames]) additionally
+//     identifies slug-style identifiers when multiple distinct values are
+//     observed at the same path position. Known literals (`me`, `current`,
+//     `self`, `new`, `list`, `search`) are preserved against all forms of
+//     parameterization.
 //   - Schema inference examines response JSON to generate OpenAPI schema
 //     objects with depth and property guards.
 package rest

--- a/pkg/generate/rest/normalize.go
+++ b/pkg/generate/rest/normalize.go
@@ -20,87 +20,359 @@ import (
 	"strings"
 )
 
-var (
-	// uuidRegex matches UUIDs in paths (8-4-4-4-12 format)
-	uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
-	// numericRegex matches purely numeric segments
-	numericRegex = regexp.MustCompile(`^[0-9]+$`)
+// paramKind classifies a path segment that has been identified as a dynamic
+// parameter. The kind drives the suffix used when deriving a parameter name
+// from context (e.g., users/{userId} for IDs, articles/{articleSlug} for slugs).
+type paramKind int
+
+const (
+	kindLiteral paramKind = iota
+	kindUUID
+	kindObjectID
+	kindNumeric
+	kindShortHex
+	kindBase64
+	kindSlug // assigned only by observation-based detection
 )
 
+var (
+	// uuidRegex matches UUIDs in paths (8-4-4-4-12 format).
+	uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	// numericRegex matches purely numeric segments.
+	numericRegex = regexp.MustCompile(`^[0-9]+$`)
+	// objectIDRegex matches MongoDB ObjectIDs: exactly 24 hex characters.
+	objectIDRegex = regexp.MustCompile(`^[0-9a-fA-F]{24}$`)
+	// shortHexRegex matches short hex hashes: 6-12 hex characters.
+	// Pure-numeric strings are excluded by the caller so they classify as kindNumeric instead.
+	shortHexRegex = regexp.MustCompile(`^[0-9a-fA-F]{6,12}$`)
+	// base64Regex matches base64 / base64url tokens that are at least 16
+	// characters long. The base64 character set is constrained to URL-safe
+	// characters; standard base64 may also include `+` and `/`, both of which
+	// are valid in path segments after percent-decoding.
+	base64Regex = regexp.MustCompile(`^[A-Za-z0-9_\-+/]{16,}={0,2}$`)
+)
+
+// knownLiterals are exact path segment values that must be preserved as
+// literals even if their text would otherwise match a dynamic-segment regex.
+// These are conventional REST literals for "self-relative" or action-style
+// endpoints (e.g., `/users/me`, `/items/search`).
+var knownLiterals = map[string]struct{}{
+	"me":      {},
+	"current": {},
+	"self":    {},
+	"new":     {},
+	"list":    {},
+	"search":  {},
+}
+
+// classifyParamSegment determines whether a path segment is a dynamic-parameter
+// candidate based on its text alone. It returns kindLiteral for empty
+// segments, known literals, and any segment whose shape does not match a
+// known dynamic pattern. Callers that have a population of paths can promote
+// kindLiteral results to kindSlug via observation-based detection.
+func classifyParamSegment(segment string) paramKind {
+	if segment == "" {
+		return kindLiteral
+	}
+	if _, ok := knownLiterals[segment]; ok {
+		return kindLiteral
+	}
+	switch {
+	case uuidRegex.MatchString(segment):
+		return kindUUID
+	case objectIDRegex.MatchString(segment):
+		return kindObjectID
+	case numericRegex.MatchString(segment):
+		return kindNumeric
+	case shortHexRegex.MatchString(segment):
+		// numericRegex was checked first, so an all-digit segment cannot reach
+		// here. The remaining hex strings are short hashes.
+		return kindShortHex
+	case isBase64Token(segment):
+		return kindBase64
+	}
+	return kindLiteral
+}
+
+// isBase64Token returns true when segment looks like an opaque base64 token.
+// A base64 token mixes character classes (alpha + digit, or includes the
+// base64-specific punctuation `+`/`/`/`=`). This guard prevents long
+// lower-case slugs (e.g., `the-best-blog-post-ever`) from classifying as
+// base64.
+func isBase64Token(segment string) bool {
+	if !base64Regex.MatchString(segment) {
+		return false
+	}
+	if strings.ContainsAny(segment, "+/=") {
+		return true
+	}
+	hasUpper := strings.ContainsFunc(segment, func(r rune) bool { return r >= 'A' && r <= 'Z' })
+	hasLower := strings.ContainsFunc(segment, func(r rune) bool { return r >= 'a' && r <= 'z' })
+	hasDigit := strings.ContainsFunc(segment, func(r rune) bool { return r >= '0' && r <= '9' })
+	// Require a mix of letter cases with digits when no base64-specific
+	// punctuation is present. A pure lowercase + digit string with hyphens
+	// looks like a slug, not a token.
+	return hasUpper && hasLower && hasDigit
+}
+
 // NormalizePath normalizes a URL path for OpenAPI specification.
-// It replaces UUIDs and numeric segments with {id} placeholders.
+// It replaces dynamic path segments (UUIDs, MongoDB ObjectIDs, numeric IDs,
+// short hex hashes, base64 tokens) with `{id}` placeholders. Known
+// literal segments (e.g., `me`, `current`) are preserved.
 // Kept for backward compatibility.
 func NormalizePath(path string) string {
-	// Split path into segments
 	segments := strings.Split(path, "/")
-
 	for i, segment := range segments {
-		// Skip empty segments
 		if segment == "" {
 			continue
 		}
-
-		// Replace UUIDs with {id}
-		if uuidRegex.MatchString(segment) {
-			segments[i] = "{id}"
-			continue
-		}
-
-		// Replace numeric IDs with {id}
-		if numericRegex.MatchString(segment) {
+		if classifyParamSegment(segment) != kindLiteral {
 			segments[i] = "{id}"
 		}
 	}
-
 	return strings.Join(segments, "/")
 }
 
-// NormalizePathWithNames normalizes a URL path with context-aware parameter names.
-// It replaces UUIDs and numeric segments with named placeholders based on preceding path segments.
+// NormalizePathWithNames normalizes a URL path with context-aware parameter
+// names based on the preceding path segment. It detects UUIDs, MongoDB
+// ObjectIDs, numeric IDs, short hex hashes, and base64 tokens.
+//
 // Examples:
-//   - /users/42 -> /users/{userId}
-//   - /posts/5/comments/7 -> /posts/{postId}/comments/{commentId}
-//   - /categories/123 -> /categories/{categoryId}
+//
+//   - /users/42                                    -> /users/{userId}
+//   - /posts/5/comments/7                          -> /posts/{postId}/comments/{commentId}
+//   - /articles/507f1f77bcf86cd799439011           -> /articles/{articleId}   (MongoDB ObjectID)
+//   - /commits/a1b2c3d4                            -> /commits/{commitId}     (short hex)
+//   - /tokens/ZXhhbXBsZS1iYXNlNjR1cmwtdG9rZW4      -> /tokens/{tokenToken}    (base64)
+//   - /users/me                                    -> /users/me               (literal preserved)
+//
+// For slug-style identifiers that vary across observed paths, use
+// NormalizePathsWithNames which performs observation-based detection.
 func NormalizePathWithNames(path string) string {
 	segments := strings.Split(path, "/")
-
+	kinds := make([]paramKind, len(segments))
 	for i, segment := range segments {
-		// Skip empty segments
-		if segment == "" {
-			continue
-		}
+		kinds[i] = classifyParamSegment(segment)
+	}
+	applyKindsToSegments(segments, kinds)
+	deduplicateParamNames(segments)
+	return strings.Join(segments, "/")
+}
 
-		// Check if this segment is an ID (UUID or numeric)
-		isID := uuidRegex.MatchString(segment) || numericRegex.MatchString(segment)
-		if !isID {
-			continue
-		}
+// pathInfo holds a single path split into segments along with the
+// classification of each segment.
+type pathInfo struct {
+	segments []string
+	kinds    []paramKind
+}
 
-		// Find parameter name from context (previous non-empty, non-parameterized segment)
-		paramName := "id" // default fallback
-		for j := i - 1; j >= 0; j-- {
-			if segments[j] != "" && !strings.HasPrefix(segments[j], "{") {
-				paramName = paramNameFromContext(segments[j])
-				break
+// posKey uniquely identifies a path position across observations: same
+// surrounding shape and same path length collapse into the same bucket.
+type posKey struct {
+	prefix string
+	index  int
+	suffix string
+	length int
+}
+
+// NormalizePathsWithNames runs NormalizePathWithNames on each input path and
+// then performs observation-based detection: any path position whose value
+// varies across paths sharing the same prefix and suffix shape is promoted
+// to a slug-style parameter.
+//
+// Returns a map keyed by the original input path. When the same path appears
+// multiple times the map collapses to a single normalized entry, which is
+// the desired behavior for grouping observed endpoints.
+func NormalizePathsWithNames(paths []string) map[string]string {
+	if len(paths) == 0 {
+		return map[string]string{}
+	}
+
+	infos := classifyPaths(paths)
+	varyingPositions := findVaryingPositions(infos)
+	promoteVaryingPositions(infos, varyingPositions)
+	return renderNormalizedPaths(paths, infos)
+}
+
+// classifyPaths splits each input path and classifies each segment by its
+// regex / literal kind.
+func classifyPaths(paths []string) []pathInfo {
+	infos := make([]pathInfo, len(paths))
+	for i, p := range paths {
+		segs := strings.Split(p, "/")
+		kinds := make([]paramKind, len(segs))
+		for j, s := range segs {
+			kinds[j] = classifyParamSegment(s)
+		}
+		infos[i] = pathInfo{segments: segs, kinds: kinds}
+	}
+	return infos
+}
+
+// findVaryingPositions returns the set of position buckets whose literal
+// segments vary across observations and therefore qualify for slug-style
+// parameter promotion.
+func findVaryingPositions(infos []pathInfo) map[posKey]struct{} {
+	values := make(map[posKey]map[string]struct{})
+	for _, info := range infos {
+		for i, seg := range info.segments {
+			if !isObservationCandidate(info, i, seg) {
+				continue
+			}
+			key := positionKey(info, i)
+			set, ok := values[key]
+			if !ok {
+				set = make(map[string]struct{})
+				values[key] = set
+			}
+			set[seg] = struct{}{}
+		}
+	}
+	varying := make(map[posKey]struct{})
+	for key, set := range values {
+		if len(set) >= 2 {
+			varying[key] = struct{}{}
+		}
+	}
+	return varying
+}
+
+// promoteVaryingPositions rewrites the kind of each segment that lies in a
+// varying position bucket from kindLiteral to kindSlug.
+func promoteVaryingPositions(infos []pathInfo, varying map[posKey]struct{}) {
+	if len(varying) == 0 {
+		return
+	}
+	for idx := range infos {
+		info := infos[idx]
+		for i, seg := range info.segments {
+			if !isObservationCandidate(info, i, seg) {
+				continue
+			}
+			if _, ok := varying[positionKey(info, i)]; ok {
+				info.kinds[i] = kindSlug
 			}
 		}
+		infos[idx] = info
+	}
+}
 
+// renderNormalizedPaths produces the final map of input paths to normalized
+// paths. Duplicate input paths collapse to a single entry.
+func renderNormalizedPaths(paths []string, infos []pathInfo) map[string]string {
+	out := make(map[string]string, len(paths))
+	for i, p := range paths {
+		if _, done := out[p]; done {
+			continue
+		}
+		segments := append([]string(nil), infos[i].segments...)
+		applyKindsToSegments(segments, infos[i].kinds)
+		deduplicateParamNames(segments)
+		out[p] = strings.Join(segments, "/")
+	}
+	return out
+}
+
+// isObservationCandidate reports whether segment i of info is eligible for
+// observation-based slug promotion. Empty segments, non-literal segments,
+// known literals, and the very first non-empty literal of a path are all
+// excluded.
+func isObservationCandidate(info pathInfo, i int, seg string) bool {
+	if seg == "" || info.kinds[i] != kindLiteral {
+		return false
+	}
+	if _, ok := knownLiterals[seg]; ok {
+		return false
+	}
+	return hasLiteralContext(info.segments[:i], info.kinds[:i])
+}
+
+// positionKey computes the bucket key for the segment at index i of info.
+func positionKey(info pathInfo, i int) posKey {
+	return posKey{
+		prefix: shapeKey(info.segments[:i], info.kinds[:i]),
+		index:  i,
+		suffix: shapeKey(info.segments[i+1:], info.kinds[i+1:]),
+		length: len(info.segments),
+	}
+}
+
+// hasLiteralContext reports whether a path slice contains at least one
+// non-empty literal segment. Observation-based detection requires this so
+// that the very first resource segment of a path (which is the resource
+// type, not a parameter) cannot be promoted to a parameter.
+func hasLiteralContext(segments []string, kinds []paramKind) bool {
+	for i, s := range segments {
+		if s == "" {
+			continue
+		}
+		if kinds[i] == kindLiteral {
+			return true
+		}
+	}
+	return false
+}
+
+// shapeKey produces a normalized "shape" representation of a path slice that
+// collapses any already-classified parameter to a single placeholder. This
+// allows two paths with different parameter names but the same structural
+// shape to share an observation-bucket.
+func shapeKey(segments []string, kinds []paramKind) string {
+	parts := make([]string, len(segments))
+	for i, s := range segments {
+		switch kinds[i] {
+		case kindLiteral:
+			parts[i] = s
+		default:
+			parts[i] = "{}"
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+// applyKindsToSegments rewrites segments in place: any non-literal kind is
+// replaced with `{<contextName>}` derived from the preceding non-empty,
+// non-parameterized segment.
+func applyKindsToSegments(segments []string, kinds []paramKind) {
+	for i := range segments {
+		if kinds[i] == kindLiteral {
+			continue
+		}
+		paramName := contextualParamName(segments, kinds, i)
 		segments[i] = "{" + paramName + "}"
 	}
+}
 
-	// Deduplicate parameter names: {id}, {id2}, {id3}, etc.
-	seen := make(map[string]int)
-	for i, segment := range segments {
-		if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
-			name := segment[1 : len(segment)-1]
-			seen[name]++
-			if seen[name] > 1 {
-				segments[i] = "{" + name + strconv.Itoa(seen[name]) + "}"
-			}
+// contextualParamName returns the parameter name for the segment at index i,
+// based on the nearest preceding literal segment and the kind of the segment.
+func contextualParamName(segments []string, kinds []paramKind, i int) string {
+	prev := ""
+	for j := i - 1; j >= 0; j-- {
+		if segments[j] == "" {
+			continue
+		}
+		if kinds[j] == kindLiteral {
+			prev = segments[j]
+			break
 		}
 	}
+	return paramNameFromKind(prev, kinds[i])
+}
 
-	return strings.Join(segments, "/")
+// deduplicateParamNames ensures unique parameter names within a path.
+// Repeated names get a numeric suffix: {id}, {id2}, {id3}, ...
+func deduplicateParamNames(segments []string) {
+	seen := make(map[string]int)
+	for i, segment := range segments {
+		if !strings.HasPrefix(segment, "{") || !strings.HasSuffix(segment, "}") {
+			continue
+		}
+		name := segment[1 : len(segment)-1]
+		seen[name]++
+		if seen[name] > 1 {
+			segments[i] = "{" + name + strconv.Itoa(seen[name]) + "}"
+		}
+	}
 }
 
 // sanitizeParamName removes characters that are not safe for OpenAPI parameter names.
@@ -119,15 +391,28 @@ func sanitizeParamName(name string) string {
 	return result
 }
 
-// paramNameFromContext derives a parameter name from a path segment.
-// Examples:
-//   - "users" -> "userId"
-//   - "categories" -> "categoryId"
-//   - "addresses" -> "addressId"
-//   - "data" -> "dataId" (no trailing 's')
-func paramNameFromContext(segment string) string {
-	singular := singularize(segment)
-	return sanitizeParamName(singular + "Id")
+// paramNameFromKind derives a parameter name from a path segment and the kind
+// of the parameter being named. ID-style kinds use the `Id` suffix; base64
+// tokens use `Token`; slugs use `Slug`. An empty preceding segment yields
+// the bare suffix in lowercase form (`id`, `token`, `slug`).
+func paramNameFromKind(prevSegment string, kind paramKind) string {
+	suffix := suffixForKind(kind)
+	if prevSegment == "" {
+		return strings.ToLower(suffix)
+	}
+	singular := singularize(prevSegment)
+	return sanitizeParamName(singular + suffix)
+}
+
+func suffixForKind(kind paramKind) string {
+	switch kind {
+	case kindBase64:
+		return "Token"
+	case kindSlug:
+		return "Slug"
+	default:
+		return "Id"
+	}
 }
 
 // singularize converts a plural word to singular (naive implementation).

--- a/pkg/generate/rest/normalize.go
+++ b/pkg/generate/rest/normalize.go
@@ -225,6 +225,14 @@ func NormalizePath(path string) string {
 //
 // For slug-style identifiers that vary across observed paths, use
 // NormalizePathsWithNames which performs observation-based detection.
+//
+// This function remains exported as a single-path utility for callers that
+// only have one path to normalize and intentionally do not need slug
+// detection (e.g., ad-hoc tooling, debug utilities, simple migrations). The
+// production OpenAPI generation pipeline does not call this function — it
+// uses NormalizePathsWithNames so observation-based detection can fire
+// across the full population. New code with access to a population of
+// paths should prefer NormalizePathsWithNames.
 func NormalizePathWithNames(path string) string {
 	segments := strings.Split(path, "/")
 	kinds := make([]paramKind, len(segments))
@@ -252,6 +260,13 @@ type posKey struct {
 	length int
 }
 
+// segLoc is a (path, segment) coordinate used by promoteVaryingPositions
+// and unifyMixedKindsAtSamePosition to record which segments need to be
+// rewritten in a separate pass.
+type segLoc struct {
+	pathIdx, segIdx int
+}
+
 // NormalizePathsWithNames classifies each input path's segments by regex /
 // literal kind, then performs observation-based detection: a position whose
 // literal segment value varies across paths sharing the same prefix and
@@ -271,24 +286,21 @@ type posKey struct {
 // position's bucket is a singleton. Add overlapping observations (e.g.,
 // `/repos/alice/proj1` together with `/repos/alice/proj2` and
 // `/repos/bob/proj1`) to anchor the inference.
+//
+// Saturation behavior: if the maxPromotionRounds cap fires (see SEC-BE-001
+// note below), any segments that did not converge to kindSlug remain
+// kindLiteral and pass through unchanged in the returned map. The function
+// has no error channel and does not signal cap saturation to the caller
+// today; downstream consumers receive a partially-normalized result. A
+// debug logging hook for cap-saturation events is a reasonable future
+// addition but is not in scope for LAB-2107.
 func NormalizePathsWithNames(paths []string) map[string]string {
 	if len(paths) == 0 {
 		return map[string]string{}
 	}
 
 	infos := classifyPaths(paths)
-	// Bound the fixed-point iteration to a small constant. Each round can
-	// only convert kindLiteral to kindSlug (monotonic), so termination is
-	// guaranteed by the size of the literal set; under realistic API
-	// captures fewer than five rounds are required. The cap protects
-	// against pathological inputs (deeply-nested adversarial paths) where
-	// the loop could otherwise reach O(S) iterations and produce an O(N*S^3)
-	// CPU-DoS surface at the generate step. After the cap, any remaining
-	// unpromoted segments stay literal — best-effort detection — and
-	// unifyMixedKindsAtSamePosition still runs on whatever kinds are
-	// present. See SEC-BE-001 in the LAB-2107 review history.
-	const maxPromotionRounds = 8
-	for round := 0; round < maxPromotionRounds; round++ {
+	for i := 0; i < maxPromotionRounds; i++ {
 		varying := findVaryingPositions(infos)
 		if len(varying) == 0 {
 			break
@@ -307,6 +319,22 @@ func NormalizePathsWithNames(paths []string) map[string]string {
 	return renderNormalizedPaths(paths, infos)
 }
 
+// maxPromotionRounds bounds the fixed-point iteration in
+// NormalizePathsWithNames. Each round can only convert kindLiteral to
+// kindSlug (monotonic), so termination is guaranteed by the size of the
+// literal set; under realistic API captures fewer than five rounds are
+// required. The cap protects against pathological inputs (deeply-nested
+// adversarial paths) where the loop could otherwise reach O(S) iterations
+// and produce an O(N*S^3) CPU-DoS surface at the generate step. After the
+// cap, any remaining unpromoted segments stay literal — best-effort
+// detection — and unifyMixedKindsAtSamePosition still runs on whatever
+// kinds are present. See SEC-BE-001 in the LAB-2107 review history.
+//
+// This is a `var` (not a `const`) so tests can lower it with t.Setenv-style
+// save/restore to verify the saturation contract under controlled
+// conditions. Production code MUST NOT mutate this value.
+var maxPromotionRounds = 8
+
 // unifyMixedKindsAtSamePosition collapses regex-classified kinds onto
 // kindSlug when an observation-promoted slug shares the same shape position
 // in another path. Without this pass, /articles/my-first-post,
@@ -319,8 +347,7 @@ func NormalizePathsWithNames(paths []string) map[string]string {
 // (UUID, ObjectID, numeric, short hex, base64) is unified onto kindSlug
 // so a single template emerges. Literal segments are not touched.
 func unifyMixedKindsAtSamePosition(infos []pathInfo) {
-	type loc struct{ pathIdx, segIdx int }
-	groups := make(map[posKey][]loc)
+	groups := make(map[posKey][]segLoc)
 	hasSlug := make(map[posKey]bool)
 	hasOther := make(map[posKey]bool)
 	for pIdx := range infos {
@@ -330,7 +357,7 @@ func unifyMixedKindsAtSamePosition(infos []pathInfo) {
 				continue
 			}
 			key := positionKey(*info, sIdx)
-			groups[key] = append(groups[key], loc{pIdx, sIdx})
+			groups[key] = append(groups[key], segLoc{pIdx, sIdx})
 			if k == kindSlug {
 				hasSlug[key] = true
 			} else {
@@ -417,11 +444,10 @@ func findVaryingPositions(infos []pathInfo) map[posKey]struct{} {
 // round is promoted at the end of the round, giving the outer fixed-point
 // loop a clean view of the next round's candidate set.
 func promoteVaryingPositions(infos []pathInfo, varying map[posKey]struct{}) bool {
-	type loc struct{ pathIdx, segIdx int }
 	// len(infos) is the number of paths and is a reasonable upper-bound
 	// hint for typical API captures (a single promotion per path is
 	// common); the slice grows beyond if more positions promote per path.
-	toPromote := make([]loc, 0, len(infos))
+	toPromote := make([]segLoc, 0, len(infos))
 	for idx := range infos {
 		info := &infos[idx]
 		for i, seg := range info.segments {
@@ -432,7 +458,7 @@ func promoteVaryingPositions(infos []pathInfo, varying map[posKey]struct{}) bool
 				continue
 			}
 			if info.kinds[i] != kindSlug {
-				toPromote = append(toPromote, loc{idx, i})
+				toPromote = append(toPromote, segLoc{idx, i})
 			}
 		}
 	}
@@ -528,6 +554,20 @@ func shapeKey(segments []string, kinds []paramKind) string {
 // applyKindsToSegments rewrites segments in place: any non-literal kind is
 // replaced with `{<contextName>}` derived from the preceding non-empty,
 // non-parameterized segment.
+//
+// Mutation safety: this loop walks left-to-right and rewrites segments[i]
+// before computing contextualParamName for i+1. The backwards walk in
+// contextualParamName looks for the nearest preceding *literal* segment
+// (kinds[j] == kindLiteral). When a previous index j was rewritten in this
+// loop, kinds[j] is non-literal, so the backwards walk skips j and reads
+// only segments whose value has NOT been touched. The in-place strategy
+// is therefore safe — no snapshot is required — and matches the cheaper
+// single-pass design of NormalizePathWithNames.
+//
+// promoteVaryingPositions has a different invariant (it computes posKey
+// from segments + kinds for SUBSEQUENT positions in the same path, not
+// preceding ones) and therefore uses a two-pass strategy. Do not assume
+// the patterns are interchangeable.
 func applyKindsToSegments(segments []string, kinds []paramKind) {
 	for i := range segments {
 		if kinds[i] == kindLiteral {

--- a/pkg/generate/rest/normalize.go
+++ b/pkg/generate/rest/normalize.go
@@ -302,6 +302,11 @@ func unifyMixedKindsAtSamePosition(infos []pathInfo) {
 			}
 		}
 	}
+	// Map iteration order is non-deterministic in Go, but the inner
+	// assignment (kinds[i] = kindSlug) is idempotent and reaches a single
+	// fixed final state. The observable output of NormalizePathsWithNames is
+	// therefore deterministic regardless of which order keys are visited.
+	// Adding any order-sensitive operation here would break that invariant.
 	for key, locs := range groups {
 		if !hasSlug[key] || !hasOther[key] {
 			continue
@@ -362,14 +367,20 @@ func findVaryingPositions(infos []pathInfo) map[posKey]struct{} {
 // least one segment was promoted, so callers can break out of fixed-point
 // iteration loops without performing redundant work.
 //
-// We iterate by index and mutate kinds in place. The kinds slice is shared
-// with the caller's pathInfo by virtue of Go's slice header — there is no
-// struct copy/write-back step.
+// Promotions are computed against an immutable snapshot of `kinds`, then
+// applied in a second pass. Mutating `kinds` while iterating would change
+// the shape used to compute positionKey for subsequent positions in the
+// same path — producing keys that no longer match `varying` and silently
+// suppressing promotion of those positions in this round. The atomic
+// two-pass strategy ensures every position eligible at the start of the
+// round is promoted at the end of the round, giving the outer fixed-point
+// loop a clean view of the next round's candidate set.
 func promoteVaryingPositions(infos []pathInfo, varying map[posKey]struct{}) bool {
 	if len(varying) == 0 {
 		return false
 	}
-	promoted := false
+	type loc struct{ pathIdx, segIdx int }
+	var toPromote []loc
 	for idx := range infos {
 		info := &infos[idx]
 		for i, seg := range info.segments {
@@ -380,12 +391,17 @@ func promoteVaryingPositions(infos []pathInfo, varying map[posKey]struct{}) bool
 				continue
 			}
 			if info.kinds[i] != kindSlug {
-				info.kinds[i] = kindSlug
-				promoted = true
+				toPromote = append(toPromote, loc{idx, i})
 			}
 		}
 	}
-	return promoted
+	if len(toPromote) == 0 {
+		return false
+	}
+	for _, l := range toPromote {
+		infos[l.pathIdx].kinds[l.segIdx] = kindSlug
+	}
+	return true
 }
 
 // renderNormalizedPaths produces the final map of input paths to normalized
@@ -525,6 +541,14 @@ func deduplicateParamNames(segments []string) {
 // characters or as word separators that produce unusable accessors. For
 // example, the context segment `my-service` yields the suffix `myService`
 // rather than `my-service`.
+//
+// Precondition: callers in this package only invoke sanitizeParamName with
+// the output of singularize(prevSegment) appended to a kind-suffix (`Id`,
+// `Token`, `Slug`). prevSegment is a URL path literal, so it cannot start
+// with `-` or `.`. If a future caller passes input beginning with a
+// separator, the first surviving lowercase letter will be uppercased and
+// emit a PascalCase-first name (e.g., `-user` → `User`). The function does
+// not validate the precondition; uphold it at the call site.
 func sanitizeParamName(name string) string {
 	var b strings.Builder
 	upperNext := false

--- a/pkg/generate/rest/normalize.go
+++ b/pkg/generate/rest/normalize.go
@@ -62,6 +62,15 @@ var (
 	// leading digit to be non-zero — `v1`, `v2`, `v123` qualify but
 	// `v0`, `v01`, `v001` do not (none of those are conventional REST
 	// version markers).
+	//
+	// Design note on `v0`: a small number of APIs do publish under
+	// `/v0/...` for alpha or pre-release surfaces. We deliberately keep
+	// `v0` OUT of the scaffold set so that paths like `/v0/users/<varying>`
+	// participate in observation-based promotion rather than being treated
+	// as protected resource scaffold. If a future maintainer is tempted to
+	// relax this regex to `^v[0-9]+$`, note that doing so will suppress
+	// promotion of resource-type segments under `/v0/...` and require new
+	// regression tests to lock in the desired behavior.
 	versionPrefixRegex = regexp.MustCompile(`^v[1-9][0-9]*$`)
 )
 
@@ -157,6 +166,16 @@ func classifyParamSegment(segment string) paramKind {
 // base64-specific punctuation `+`/`/`/`=`). This guard prevents long
 // lower-case slugs (e.g., `the-best-blog-post-ever`) from classifying as
 // base64.
+//
+// Trade-off: an all-uppercase base64-shaped token without `+`/`/`/`=`
+// punctuation (e.g., `ABCDEF0123456789XY`) returns false and falls
+// through to kindLiteral. This is the symmetric cost of requiring mixed
+// case + digit to reject all-lowercase slugs; it is asymmetric with
+// isShortHexHash, which DOES accept all-uppercase hex strings (because
+// short-SHA refs are commonly uppercased while base64 tokens are not).
+// All-uppercase base64 in URL path positions is rare; if encountered, the
+// observation-based pass in NormalizePathsWithNames will still detect it
+// as a slug given enough varying observations.
 func isBase64Token(segment string) bool {
 	if !base64Regex.MatchString(segment) {
 		return false
@@ -201,7 +220,7 @@ func NormalizePath(path string) string {
 //   - /posts/5/comments/7                          -> /posts/{postId}/comments/{commentId}
 //   - /articles/507f1f77bcf86cd799439011           -> /articles/{articleId}   (MongoDB ObjectID)
 //   - /commits/a1b2c3d4                            -> /commits/{commitId}     (short hex)
-//   - /tokens/ZXhhbXBsZS1iYXNlNjR1cmwtdG9rZW4      -> /tokens/{tokenToken}    (base64)
+//   - /sessions/AbCdEfGhIj1234567890XY             -> /sessions/{sessionToken} (base64)
 //   - /users/me                                    -> /users/me               (literal preserved)
 //
 // For slug-style identifiers that vary across observed paths, use
@@ -258,11 +277,28 @@ func NormalizePathsWithNames(paths []string) map[string]string {
 	}
 
 	infos := classifyPaths(paths)
-	for {
+	// Bound the fixed-point iteration to a small constant. Each round can
+	// only convert kindLiteral to kindSlug (monotonic), so termination is
+	// guaranteed by the size of the literal set; under realistic API
+	// captures fewer than five rounds are required. The cap protects
+	// against pathological inputs (deeply-nested adversarial paths) where
+	// the loop could otherwise reach O(S) iterations and produce an O(N*S^3)
+	// CPU-DoS surface at the generate step. After the cap, any remaining
+	// unpromoted segments stay literal — best-effort detection — and
+	// unifyMixedKindsAtSamePosition still runs on whatever kinds are
+	// present. See SEC-BE-001 in the LAB-2107 review history.
+	const maxPromotionRounds = 8
+	for round := 0; round < maxPromotionRounds; round++ {
 		varying := findVaryingPositions(infos)
 		if len(varying) == 0 {
 			break
 		}
+		// Defensive guard: if findVaryingPositions returned a non-empty
+		// set, promoteVaryingPositions is expected to convert at least one
+		// segment (the find phase only surfaces literal candidates).
+		// promoteVaryingPositions returning false here would indicate an
+		// internal contract break; we exit the loop safely rather than
+		// spin.
 		if !promoteVaryingPositions(infos, varying) {
 			break
 		}
@@ -367,6 +403,11 @@ func findVaryingPositions(infos []pathInfo) map[posKey]struct{} {
 // least one segment was promoted, so callers can break out of fixed-point
 // iteration loops without performing redundant work.
 //
+// Caller contract: `varying` is non-empty. The sole caller in this package
+// (NormalizePathsWithNames) only reaches this function with a non-empty
+// varying set; we therefore do not include a defensive `len(varying)==0`
+// short-circuit.
+//
 // Promotions are computed against an immutable snapshot of `kinds`, then
 // applied in a second pass. Mutating `kinds` while iterating would change
 // the shape used to compute positionKey for subsequent positions in the
@@ -376,11 +417,11 @@ func findVaryingPositions(infos []pathInfo) map[posKey]struct{} {
 // round is promoted at the end of the round, giving the outer fixed-point
 // loop a clean view of the next round's candidate set.
 func promoteVaryingPositions(infos []pathInfo, varying map[posKey]struct{}) bool {
-	if len(varying) == 0 {
-		return false
-	}
 	type loc struct{ pathIdx, segIdx int }
-	var toPromote []loc
+	// len(infos) is the number of paths and is a reasonable upper-bound
+	// hint for typical API captures (a single promotion per path is
+	// common); the slice grows beyond if more positions promote per path.
+	toPromote := make([]loc, 0, len(infos))
 	for idx := range infos {
 		info := &infos[idx]
 		for i, seg := range info.segments {

--- a/pkg/generate/rest/normalize.go
+++ b/pkg/generate/rest/normalize.go
@@ -44,12 +44,19 @@ var (
 	objectIDRegex = regexp.MustCompile(`^[0-9a-fA-F]{24}$`)
 	// shortHexRegex matches short hex hashes: 6-12 hex characters.
 	// Pure-numeric strings are excluded by the caller so they classify as kindNumeric instead.
+	// The caller (isShortHexHash) additionally requires at least one digit or
+	// uppercase letter to avoid matching pure-lowercase English words that
+	// happen to consist of [a-f] characters (e.g., "facade", "decade").
 	shortHexRegex = regexp.MustCompile(`^[0-9a-fA-F]{6,12}$`)
 	// base64Regex matches base64 / base64url tokens that are at least 16
 	// characters long. The base64 character set is constrained to URL-safe
 	// characters; standard base64 may also include `+` and `/`, both of which
 	// are valid in path segments after percent-decoding.
 	base64Regex = regexp.MustCompile(`^[A-Za-z0-9_\-+/]{16,}={0,2}$`)
+	// versionPrefixRegex matches "v" followed by one or more digits — the
+	// conventional API version segment (v1, v2, v123). Used by isPathPrefix
+	// to skip these segments when looking for resource-type context.
+	versionPrefixRegex = regexp.MustCompile(`^v[0-9]+$`)
 )
 
 // knownLiterals are exact path segment values that must be preserved as
@@ -63,6 +70,47 @@ var knownLiterals = map[string]struct{}{
 	"new":     {},
 	"list":    {},
 	"search":  {},
+}
+
+// pathPrefixes are scaffold segments that wrap an API surface but do not
+// themselves identify a resource. When an observed path looks like
+// `/api/users` or `/v1/posts`, the leading scaffold should not count as the
+// "resource type" preceding a parameter — otherwise observation-based
+// detection would conflate distinct resource types (`users`, `posts`) into a
+// single varying parameter.
+var pathPrefixes = map[string]struct{}{
+	"api":  {},
+	"apis": {},
+	"rest": {},
+}
+
+// isPathPrefix reports whether a literal segment is a known API scaffold
+// (api / rest / version segments like v1, v2). isObservationCandidate uses
+// this to skip paths whose only preceding literal context is a scaffold —
+// the segment immediately following such a scaffold is the resource type
+// and must not be parameterized.
+func isPathPrefix(segment string) bool {
+	if _, ok := pathPrefixes[segment]; ok {
+		return true
+	}
+	return versionPrefixRegex.MatchString(segment)
+}
+
+// isShortHexHash reports whether a segment looks like a short hex hash
+// (e.g., a git short-SHA `a1b2c3d4`). It requires the regex match plus at
+// least one digit or uppercase A-F so that pure-lowercase English words
+// composed of [a-f] characters (e.g., "facade", "decade", "beaded") are
+// not misclassified as hashes.
+func isShortHexHash(segment string) bool {
+	if !shortHexRegex.MatchString(segment) {
+		return false
+	}
+	for _, r := range segment {
+		if (r >= '0' && r <= '9') || (r >= 'A' && r <= 'F') {
+			return true
+		}
+	}
+	return false
 }
 
 // classifyParamSegment determines whether a path segment is a dynamic-parameter
@@ -84,9 +132,7 @@ func classifyParamSegment(segment string) paramKind {
 		return kindObjectID
 	case numericRegex.MatchString(segment):
 		return kindNumeric
-	case shortHexRegex.MatchString(segment):
-		// numericRegex was checked first, so an all-digit segment cannot reach
-		// here. The remaining hex strings are short hashes.
+	case isShortHexHash(segment):
 		return kindShortHex
 	case isBase64Token(segment):
 		return kindBase64
@@ -175,22 +221,40 @@ type posKey struct {
 	length int
 }
 
-// NormalizePathsWithNames runs NormalizePathWithNames on each input path and
-// then performs observation-based detection: any path position whose value
-// varies across paths sharing the same prefix and suffix shape is promoted
-// to a slug-style parameter.
+// NormalizePathsWithNames classifies each input path's segments by regex /
+// literal kind, then performs observation-based detection: a position whose
+// literal segment value varies across paths sharing the same prefix and
+// suffix shape (and same path length) is promoted to a slug-style
+// parameter. Promotion runs to a fixed point — promoting one position can
+// change the shape of a sibling position, exposing additional varying
+// buckets — so the function iterates until no further promotions occur.
 //
 // Returns a map keyed by the original input path. When the same path appears
 // multiple times the map collapses to a single normalized entry, which is
 // the desired behavior for grouping observed endpoints.
+//
+// Limitation: detection requires at least two literal observations sharing
+// both prefix and suffix shape. Pure-diagonal observations such as
+// `[/repos/alice/proj1, /repos/bob/proj2, /repos/carol/proj3]` — where every
+// (owner, project) pair is unique — cannot be promoted, because each
+// position's bucket is a singleton. Add overlapping observations (e.g.,
+// `/repos/alice/proj1` together with `/repos/alice/proj2` and
+// `/repos/bob/proj1`) to anchor the inference.
 func NormalizePathsWithNames(paths []string) map[string]string {
 	if len(paths) == 0 {
 		return map[string]string{}
 	}
 
 	infos := classifyPaths(paths)
-	varyingPositions := findVaryingPositions(infos)
-	promoteVaryingPositions(infos, varyingPositions)
+	for {
+		varying := findVaryingPositions(infos)
+		if len(varying) == 0 {
+			break
+		}
+		if !promoteVaryingPositions(infos, varying) {
+			break
+		}
+	}
 	return renderNormalizedPaths(paths, infos)
 }
 
@@ -238,23 +302,34 @@ func findVaryingPositions(infos []pathInfo) map[posKey]struct{} {
 }
 
 // promoteVaryingPositions rewrites the kind of each segment that lies in a
-// varying position bucket from kindLiteral to kindSlug.
-func promoteVaryingPositions(infos []pathInfo, varying map[posKey]struct{}) {
+// varying position bucket from kindLiteral to kindSlug. Returns true when at
+// least one segment was promoted, so callers can break out of fixed-point
+// iteration loops without performing redundant work.
+//
+// We iterate by index and mutate kinds in place. The kinds slice is shared
+// with the caller's pathInfo by virtue of Go's slice header — there is no
+// struct copy/write-back step.
+func promoteVaryingPositions(infos []pathInfo, varying map[posKey]struct{}) bool {
 	if len(varying) == 0 {
-		return
+		return false
 	}
+	promoted := false
 	for idx := range infos {
-		info := infos[idx]
+		info := &infos[idx]
 		for i, seg := range info.segments {
-			if !isObservationCandidate(info, i, seg) {
+			if !isObservationCandidate(*info, i, seg) {
 				continue
 			}
-			if _, ok := varying[positionKey(info, i)]; ok {
+			if _, ok := varying[positionKey(*info, i)]; !ok {
+				continue
+			}
+			if info.kinds[i] != kindSlug {
 				info.kinds[i] = kindSlug
+				promoted = true
 			}
 		}
-		infos[idx] = info
 	}
+	return promoted
 }
 
 // renderNormalizedPaths produces the final map of input paths to normalized
@@ -298,17 +373,24 @@ func positionKey(info pathInfo, i int) posKey {
 }
 
 // hasLiteralContext reports whether a path slice contains at least one
-// non-empty literal segment. Observation-based detection requires this so
-// that the very first resource segment of a path (which is the resource
-// type, not a parameter) cannot be promoted to a parameter.
+// non-empty literal segment that is NOT a known API scaffold (`api`, `rest`,
+// or a `v\d+` version marker). Observation-based detection requires this so
+// that the very first resource segment of a path — including paths that
+// start with a scaffold like `/api/users` or `/v1/users` — cannot be
+// promoted to a parameter. The scaffold by itself is not enough context to
+// identify the next segment as a parameter rather than a resource type.
 func hasLiteralContext(segments []string, kinds []paramKind) bool {
 	for i, s := range segments {
 		if s == "" {
 			continue
 		}
-		if kinds[i] == kindLiteral {
-			return true
+		if kinds[i] != kindLiteral {
+			continue
 		}
+		if isPathPrefix(s) {
+			continue
+		}
+		return true
 	}
 	return false
 }
@@ -404,6 +486,9 @@ func paramNameFromKind(prevSegment string, kind paramKind) string {
 	return sanitizeParamName(singular + suffix)
 }
 
+// suffixForKind returns the parameter name suffix associated with a paramKind:
+// "Token" for base64 tokens, "Slug" for observation-promoted slugs, "Id" for
+// every other identifier-shaped kind (UUID, ObjectID, numeric, short hex).
 func suffixForKind(kind paramKind) string {
 	switch kind {
 	case kindBase64:

--- a/pkg/generate/rest/normalize.go
+++ b/pkg/generate/rest/normalize.go
@@ -41,6 +41,11 @@ var (
 	// numericRegex matches purely numeric segments.
 	numericRegex = regexp.MustCompile(`^[0-9]+$`)
 	// objectIDRegex matches MongoDB ObjectIDs: exactly 24 hex characters.
+	// Hex strings of intermediate length (13-23 characters) are intentionally
+	// not classified as a parameter kind by the regex pass — they are
+	// uncommon as identifiers in real APIs. If observed varying across paths
+	// they will still be promoted by observation-based detection in
+	// NormalizePathsWithNames.
 	objectIDRegex = regexp.MustCompile(`^[0-9a-fA-F]{24}$`)
 	// shortHexRegex matches short hex hashes: 6-12 hex characters.
 	// Pure-numeric strings are excluded by the caller so they classify as kindNumeric instead.
@@ -53,10 +58,11 @@ var (
 	// characters; standard base64 may also include `+` and `/`, both of which
 	// are valid in path segments after percent-decoding.
 	base64Regex = regexp.MustCompile(`^[A-Za-z0-9_\-+/]{16,}={0,2}$`)
-	// versionPrefixRegex matches "v" followed by one or more digits — the
-	// conventional API version segment (v1, v2, v123). Used by isPathPrefix
-	// to skip these segments when looking for resource-type context.
-	versionPrefixRegex = regexp.MustCompile(`^v[0-9]+$`)
+	// versionPrefixRegex matches "v" followed by digits, requiring the
+	// leading digit to be non-zero — `v1`, `v2`, `v123` qualify but
+	// `v0`, `v01`, `v001` do not (none of those are conventional REST
+	// version markers).
+	versionPrefixRegex = regexp.MustCompile(`^v[1-9][0-9]*$`)
 )
 
 // knownLiterals are exact path segment values that must be preserved as
@@ -101,6 +107,12 @@ func isPathPrefix(segment string) bool {
 // least one digit or uppercase A-F so that pure-lowercase English words
 // composed of [a-f] characters (e.g., "facade", "decade", "beaded") are
 // not misclassified as hashes.
+//
+// Trade-off: all-uppercase hex words (e.g., "FACADE", "DECADE") still
+// classify as hashes because their uppercase A-F characters satisfy the
+// discriminator. URL path segments are almost never all-uppercase English
+// words, so this edge case is accepted in exchange for catching real
+// uppercase short-SHAs like "ABCDEF".
 func isShortHexHash(segment string) bool {
 	if !shortHexRegex.MatchString(segment) {
 		return false
@@ -255,7 +267,51 @@ func NormalizePathsWithNames(paths []string) map[string]string {
 			break
 		}
 	}
+	unifyMixedKindsAtSamePosition(infos)
 	return renderNormalizedPaths(paths, infos)
+}
+
+// unifyMixedKindsAtSamePosition collapses regex-classified kinds onto
+// kindSlug when an observation-promoted slug shares the same shape position
+// in another path. Without this pass, /articles/my-first-post,
+// /articles/507f1f77bcf86cd799439011, and /articles/another-post would
+// produce two distinct OpenAPI path templates — /articles/{articleSlug}
+// for the slug observations and /articles/{articleId} for the ObjectID —
+// even though they describe the same parameterized endpoint. Whenever a
+// position has been promoted to kindSlug for any path, any other path
+// whose segment at the same position is a different non-literal kind
+// (UUID, ObjectID, numeric, short hex, base64) is unified onto kindSlug
+// so a single template emerges. Literal segments are not touched.
+func unifyMixedKindsAtSamePosition(infos []pathInfo) {
+	type loc struct{ pathIdx, segIdx int }
+	groups := make(map[posKey][]loc)
+	hasSlug := make(map[posKey]bool)
+	hasOther := make(map[posKey]bool)
+	for pIdx := range infos {
+		info := &infos[pIdx]
+		for sIdx, k := range info.kinds {
+			if k == kindLiteral {
+				continue
+			}
+			key := positionKey(*info, sIdx)
+			groups[key] = append(groups[key], loc{pIdx, sIdx})
+			if k == kindSlug {
+				hasSlug[key] = true
+			} else {
+				hasOther[key] = true
+			}
+		}
+	}
+	for key, locs := range groups {
+		if !hasSlug[key] || !hasOther[key] {
+			continue
+		}
+		for _, l := range locs {
+			if infos[l.pathIdx].kinds[l.segIdx] != kindSlug {
+				infos[l.pathIdx].kinds[l.segIdx] = kindSlug
+			}
+		}
+	}
 }
 
 // classifyPaths splits each input path and classifies each segment by its
@@ -457,20 +513,43 @@ func deduplicateParamNames(segments []string) {
 	}
 }
 
-// sanitizeParamName removes characters that are not safe for OpenAPI parameter names.
-// Allows alphanumeric characters, underscores, hyphens, and dots.
+// sanitizeParamName produces an OpenAPI-friendly parameter name.
+//
+// Allowed characters: alphanumeric and underscore. Hyphens and dots are
+// converted to camelCase boundaries: the next ASCII lowercase letter after
+// a `-` or `.` is uppercased, and the separator is dropped. Other
+// characters are dropped silently. An empty result becomes "id".
+//
+// This makes parameter names compatible with the wide majority of OpenAPI
+// client generators, many of which treat hyphens/dots as invalid identifier
+// characters or as word separators that produce unusable accessors. For
+// example, the context segment `my-service` yields the suffix `myService`
+// rather than `my-service`.
 func sanitizeParamName(name string) string {
 	var b strings.Builder
+	upperNext := false
 	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
+		switch {
+		case r == '-' || r == '.':
+			upperNext = true
+		case r >= 'a' && r <= 'z':
+			if upperNext {
+				b.WriteRune(r - ('a' - 'A'))
+			} else {
+				b.WriteRune(r)
+			}
+			upperNext = false
+		case r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_':
 			b.WriteRune(r)
+			upperNext = false
+		default:
+			// Drop disallowed characters silently.
 		}
 	}
-	result := b.String()
-	if result == "" {
+	if b.Len() == 0 {
 		return "id"
 	}
-	return result
+	return b.String()
 }
 
 // paramNameFromKind derives a parameter name from a path segment and the kind

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -546,6 +546,53 @@ func TestNormalizePathsWithNames_ResourceTypeBehindPathPrefixNeverPromoted(t *te
 	}
 }
 
+func TestNormalizePathsWithNames_VersionPrefixBoundary(t *testing.T) {
+	// versionPrefixRegex is `^v[1-9][0-9]*$` (round-3 tightening). v0, v01,
+	// v001 are NOT scaffold prefixes — `/v0/users/<varying>` therefore has
+	// non-scaffold literal context (`v0`) and the observation pass DOES
+	// promote the trailing varying segment, while v1/v2 (real prefixes)
+	// still suppress promotion of the immediately-following resource segment.
+	t.Run("v0 is not a scaffold so users segment is observable", func(t *testing.T) {
+		paths := []string{"/v0/users/alice", "/v0/users/bob", "/v0/users/carol"}
+		got := NormalizePathsWithNames(paths)
+		for _, p := range paths {
+			if got[p] != "/v0/users/{userSlug}" {
+				t.Errorf("path %q normalized to %q, want /v0/users/{userSlug}", p, got[p])
+			}
+		}
+	})
+	t.Run("v01 with leading zero is not a scaffold", func(t *testing.T) {
+		paths := []string{"/v01/users/alice", "/v01/users/bob", "/v01/users/carol"}
+		got := NormalizePathsWithNames(paths)
+		for _, p := range paths {
+			if got[p] != "/v01/users/{userSlug}" {
+				t.Errorf("path %q normalized to %q, want /v01/users/{userSlug}", p, got[p])
+			}
+		}
+	})
+	t.Run("v001 with multiple leading zeros is not a scaffold", func(t *testing.T) {
+		paths := []string{"/v001/items/foo", "/v001/items/bar", "/v001/items/baz"}
+		got := NormalizePathsWithNames(paths)
+		for _, p := range paths {
+			if got[p] != "/v001/items/{itemSlug}" {
+				t.Errorf("path %q normalized to %q, want /v001/items/{itemSlug}", p, got[p])
+			}
+		}
+	})
+	t.Run("v1 IS a scaffold so users stays literal", func(t *testing.T) {
+		// Sanity check that v1 still behaves as a scaffold (covered also by
+		// ResourceTypeBehindPathPrefixNeverPromoted, but worth a direct
+		// contrast against the v0 case to make the boundary explicit).
+		paths := []string{"/v1/users", "/v1/posts", "/v1/articles"}
+		got := NormalizePathsWithNames(paths)
+		for _, p := range paths {
+			if got[p] != p {
+				t.Errorf("v1 scaffold path %q was promoted: got %q", p, got[p])
+			}
+		}
+	})
+}
+
 func TestNormalizePathsWithNames_PromotesAfterPathPrefix(t *testing.T) {
 	// The segment AFTER the resource type — even when a scaffold prefix is
 	// present — should still be promoted when it varies. /api/users/<id> is
@@ -609,6 +656,49 @@ func TestNormalizePathsWithNames_SinglePathNoSlug(t *testing.T) {
 	got := NormalizePathsWithNames(paths)
 	if got["/articles/my-only-post"] != "/articles/my-only-post" {
 		t.Errorf("single observation parameterized: %v", got)
+	}
+}
+
+func TestNormalizePathsWithNames_MixedKindsUnifyAcrossAllRegexKinds(t *testing.T) {
+	// unifyMixedKindsAtSamePosition uses the same `hasOther` map for every
+	// non-slug kind, so a position holding slug + UUID + ObjectID + ShortHex
+	// + numeric must fully collapse onto kindSlug. This guards against a
+	// future refactor that special-cases one kind (e.g., only collapsing
+	// kindObjectID) and silently leaves other regex kinds emitting their
+	// own templates alongside the slug.
+	paths := []string{
+		"/articles/my-first-post",                        // observation-promoted slug
+		"/articles/my-second-post",                       // observation-promoted slug (anchors variation)
+		"/articles/550e8400-e29b-41d4-a716-446655440000", // UUID
+		"/articles/507f1f77bcf86cd799439011",             // ObjectID (24 hex)
+		"/articles/AbCdEf12",                             // short hex (uppercase + digit)
+		"/articles/42",                                   // numeric
+	}
+	got := NormalizePathsWithNames(paths)
+	const want = "/articles/{articleSlug}"
+	for _, p := range paths {
+		if got[p] != want {
+			t.Errorf("path %q normalized to %q, want %q", p, got[p], want)
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_SlugOnlyNoOpUnification(t *testing.T) {
+	// When every observation at a shape position is already kindSlug (no
+	// regex-classified peer), unifyMixedKindsAtSamePosition's `!hasOther`
+	// branch fires and the function does nothing. Output is identical to
+	// the post-promotion state. This locks in that the unification pass is
+	// inert when there is nothing to unify.
+	paths := []string{
+		"/items/foo-1",
+		"/items/bar-2",
+		"/items/baz-3",
+	}
+	got := NormalizePathsWithNames(paths)
+	for _, p := range paths {
+		if got[p] != "/items/{itemSlug}" {
+			t.Errorf("path %q normalized to %q, want /items/{itemSlug}", p, got[p])
+		}
 	}
 }
 
@@ -729,6 +819,9 @@ func TestNormalizePathsWithNames_EmptyAndDuplicateInputs(t *testing.T) {
 	if got["/users/42"] != "/users/{userId}" {
 		t.Errorf("got %q for /users/42", got["/users/42"])
 	}
+	if got["/users/43"] != "/users/{userId}" {
+		t.Errorf("got %q for /users/43", got["/users/43"])
+	}
 }
 
 func TestParamNameFromKind_NoContextFallbacks(t *testing.T) {
@@ -808,12 +901,16 @@ func TestSanitizeParamName_HyphenAndDotConversion(t *testing.T) {
 	}
 }
 
-func TestNormalizePathsWithNames_DepthFiveMultiVarying(t *testing.T) {
-	// Depth-5 paths with overlap at multiple positions exercise the
-	// fixed-point iteration of promoteVaryingPositions across more than
-	// two adjacent literal positions. A regression that artificially caps
-	// iteration at one extra round will not promote the deepest position
-	// and therefore fails this test.
+func TestNormalizePathsWithNames_DeepPathsAcrossPositions(t *testing.T) {
+	// Depth-5 smoke test: owner (position 2), project (position 3), and the
+	// trailing numeric segment (position 5) all parameterize. Owner and
+	// project are slug-shaped and vary across observations with enough
+	// overlap that strict bucketing in a single round identifies both as
+	// varying; the trailing numeric is regex-classified as kindNumeric and
+	// renders with the `Id` suffix. This test exercises multi-position
+	// promotion plus the slug+numeric rendering through deep paths — it
+	// does NOT prove the fixed-point property (see
+	// TestNormalizePathsWithNames_FixedPointIterationRequired for that).
 	paths := []string{
 		"/repos/alice/proj1/issues/1",
 		"/repos/alice/proj1/issues/2",
@@ -822,13 +919,44 @@ func TestNormalizePathsWithNames_DepthFiveMultiVarying(t *testing.T) {
 		"/repos/bob/proj2/issues/2",
 	}
 	got := NormalizePathsWithNames(paths)
-	// Owner (position 2) and project (position 3) are slug-shaped and
-	// vary across observations — they are promoted to kindSlug by the
-	// fixed-point iteration. The trailing numeric segments at position 5
-	// are regex-classified as kindNumeric on the first pass and rendered
-	// with the conventional `Id` suffix; they don't go through the
-	// observation pass at all. All three positions are parameterized.
 	const want = "/repos/{repoSlug}/{repoSlug2}/issues/{issueId}"
+	for _, p := range paths {
+		if got[p] != want {
+			t.Errorf("path %q normalized to %q, want %q", p, got[p], want)
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_FixedPointIterationRequired(t *testing.T) {
+	// This fixture genuinely requires more than one promotion round.
+	//
+	// In round 1, only the alice/proj-a + bob/proj-a pair shares a suffix
+	// (proj-a) so position 2 promotes only at those two paths; the alice
+	// and bob "loners" (alice/proj-b and bob/proj-c) sit in singleton
+	// suffix-buckets at position 2 and are NOT promoted in round 1.
+	// Position 3 shares the prefix /repos/alice between alice/proj-a and
+	// alice/proj-b (and /repos/bob between bob/proj-a and bob/proj-c) so
+	// position 3 promotes for all four paths in round 1.
+	//
+	// After round 1, position 2 of alice/proj-b and bob/proj-c is still
+	// kindLiteral but their position-3 segments are now kindSlug. The
+	// suffix shape collapses to "/{}" — which matches the suffix shape of
+	// alice/proj-a and bob/proj-a (also "/{}" after round-1 promotion).
+	// In round 2, alice/proj-b's position 2 bucket joins bob/proj-c's
+	// position 2 bucket via the shared "/{}" suffix shape. The bucket
+	// gains both alice and bob → varying → promote.
+	//
+	// A capped-iteration implementation (single round) would leave
+	// alice/proj-b at /repos/alice/{repoSlug} and bob/proj-c at
+	// /repos/bob/{repoSlug} — three distinct paths instead of one.
+	paths := []string{
+		"/repos/alice/proj-a",
+		"/repos/alice/proj-b",
+		"/repos/bob/proj-a",
+		"/repos/bob/proj-c",
+	}
+	got := NormalizePathsWithNames(paths)
+	const want = "/repos/{repoSlug}/{repoSlug2}"
 	for _, p := range paths {
 		if got[p] != want {
 			t.Errorf("path %q normalized to %q, want %q", p, got[p], want)

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -15,6 +15,7 @@
 package rest
 
 import (
+	"sort"
 	"testing"
 )
 
@@ -132,6 +133,59 @@ func TestNormalizePath_LiteralPreservation(t *testing.T) {
 	}
 }
 
+func TestNormalizePath_DynamicSegmentExpansion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "mongodb objectid",
+			input:    "/articles/507f1f77bcf86cd799439011",
+			expected: "/articles/{id}",
+		},
+		{
+			name:     "short hex hash 8 chars",
+			input:    "/commits/a1b2c3d4",
+			expected: "/commits/{id}",
+		},
+		{
+			name:     "short hex hash 12 chars",
+			input:    "/commits/abcdef012345",
+			expected: "/commits/{id}",
+		},
+		{
+			name:     "base64url token",
+			input:    "/tokens/eyJhbGciOiJIUzI1NiJ9X-_test",
+			expected: "/tokens/{id}",
+		},
+		{
+			name:     "base64 with mixed case and digits",
+			input:    "/sessions/AbCdEfGhIj1234567890",
+			expected: "/sessions/{id}",
+		},
+		{
+			name:     "no false positive on simple slug",
+			input:    "/articles/my-blog-post",
+			expected: "/articles/my-blog-post",
+		},
+		{
+			name:     "no false positive on dictionary word",
+			input:    "/users/profile",
+			expected: "/users/profile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizePath(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalizePath(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestNormalizePathWithNames_ContextAwareNaming(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -195,6 +249,85 @@ func TestNormalizePathWithNames_ContextAwareNaming(t *testing.T) {
 			result := NormalizePathWithNames(tt.input)
 			if result != tt.expected {
 				t.Errorf("NormalizePathWithNames(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizePathWithNames_NewKinds(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "mongodb objectid contextual name",
+			input:    "/articles/507f1f77bcf86cd799439011",
+			expected: "/articles/{articleId}",
+		},
+		{
+			name:     "short hex hash contextual name",
+			input:    "/commits/a1b2c3d4",
+			expected: "/commits/{commitId}",
+		},
+		{
+			name:     "short hex hash 6 chars",
+			input:    "/blobs/abc123",
+			expected: "/blobs/{blobId}",
+		},
+		{
+			name:     "base64url token uses Token suffix",
+			input:    "/sessions/AbCdEfGhIj1234567890XY",
+			expected: "/sessions/{sessionToken}",
+		},
+		{
+			name:     "base64 with padding uses Token suffix",
+			input:    "/api/keys/ZXhhbXBsZS10b2tlbi1kYXRh",
+			expected: "/api/keys/{keyToken}",
+		},
+		{
+			name:     "ObjectID embedded among literals",
+			input:    "/v1/users/507f1f77bcf86cd799439011/avatar",
+			expected: "/v1/users/{userId}/avatar",
+		},
+		{
+			name:     "literal preserved despite shape similar to short hex",
+			input:    "/users/list",
+			expected: "/users/list",
+		},
+		{
+			name:     "literal me preserved",
+			input:    "/users/me/profile",
+			expected: "/users/me/profile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizePathWithNames(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalizePathWithNames(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizePathWithNames_NoFalsePositiveOnDictionaryWords(t *testing.T) {
+	// Dictionary words and slugs must not be parameterized by the single-path
+	// pass — only the observation-based pass may promote them to parameters.
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"articles slug", "/articles/my-blog-post"},
+		{"users profile", "/users/profile"},
+		{"common english word", "/items/recommendation"},
+		{"slug with digits", "/articles/2024-year-in-review"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NormalizePathWithNames(c.path); got != c.path {
+				t.Errorf("NormalizePathWithNames(%q) = %q, want unchanged literal", c.path, got)
 			}
 		})
 	}
@@ -283,5 +416,210 @@ func TestNormalizePathWithNames_ConsecutiveIDs(t *testing.T) {
 				t.Errorf("NormalizePathWithNames(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestNormalizePathsWithNames_SlugObservation(t *testing.T) {
+	paths := []string{
+		"/articles/my-first-post",
+		"/articles/my-second-post",
+		"/articles/yet-another-post",
+	}
+	got := NormalizePathsWithNames(paths)
+
+	// All three slug-style observations should collapse to a single
+	// parameterized path because the position varies across observations.
+	want := map[string]string{
+		"/articles/my-first-post":    "/articles/{articleSlug}",
+		"/articles/my-second-post":   "/articles/{articleSlug}",
+		"/articles/yet-another-post": "/articles/{articleSlug}",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("path %q normalized to %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_LiteralNotPromotedAcrossPositions(t *testing.T) {
+	paths := []string{
+		"/users/me/profile",
+		"/users/jane/profile",
+		"/users/bob/profile",
+	}
+	got := NormalizePathsWithNames(paths)
+
+	// `me` is a known literal and must not be parameterized even though
+	// `jane` and `bob` vary at the same position. The two non-literal
+	// observations promote that position to a slug; the `me` observation
+	// stays literal.
+	if got["/users/me/profile"] != "/users/me/profile" {
+		t.Errorf("literal `me` was rewritten: got %q", got["/users/me/profile"])
+	}
+	if got["/users/jane/profile"] != "/users/{userSlug}/profile" {
+		t.Errorf("varying segment not parameterized: got %q", got["/users/jane/profile"])
+	}
+	if got["/users/bob/profile"] != "/users/{userSlug}/profile" {
+		t.Errorf("varying segment not parameterized: got %q", got["/users/bob/profile"])
+	}
+}
+
+func TestNormalizePathsWithNames_RootResourceNeverPromoted(t *testing.T) {
+	// Different first-segment resource types must not collapse into a single
+	// slug parameter just because they vary at the same position index.
+	paths := []string{
+		"/users",
+		"/posts",
+		"/articles",
+		"/sessions",
+	}
+	got := NormalizePathsWithNames(paths)
+	for _, p := range paths {
+		if got[p] != p {
+			t.Errorf("root resource %q was promoted: got %q", p, got[p])
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_SinglePathNoSlug(t *testing.T) {
+	// One observation cannot demonstrate variation, so the literal segment
+	// must be preserved.
+	paths := []string{"/articles/my-only-post"}
+	got := NormalizePathsWithNames(paths)
+	if got["/articles/my-only-post"] != "/articles/my-only-post" {
+		t.Errorf("single observation parameterized: %v", got)
+	}
+}
+
+func TestNormalizePathsWithNames_RegressionUUIDAndNumeric(t *testing.T) {
+	paths := []string{
+		"/users/42",
+		"/users/43",
+		"/users/550e8400-e29b-41d4-a716-446655440000",
+		"/posts/1",
+		"/posts/2",
+	}
+	got := NormalizePathsWithNames(paths)
+	want := map[string]string{
+		"/users/42": "/users/{userId}",
+		"/users/43": "/users/{userId}",
+		"/users/550e8400-e29b-41d4-a716-446655440000": "/users/{userId}",
+		"/posts/1": "/posts/{postId}",
+		"/posts/2": "/posts/{postId}",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("path %q normalized to %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_MixedKinds(t *testing.T) {
+	paths := []string{
+		"/articles/my-first-post",
+		"/articles/507f1f77bcf86cd799439011", // ObjectID
+		"/articles/another-post",
+	}
+	got := NormalizePathsWithNames(paths)
+	want := map[string]string{
+		"/articles/my-first-post":            "/articles/{articleSlug}",
+		"/articles/507f1f77bcf86cd799439011": "/articles/{articleId}",
+		"/articles/another-post":             "/articles/{articleSlug}",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("path %q normalized to %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_DifferentShapesNotConflated(t *testing.T) {
+	// Same position index but different prefix/suffix shapes. The two slug
+	// positions are independent, so each must be evaluated within its own
+	// shape bucket.
+	paths := []string{
+		"/articles/foo",
+		"/articles/bar",
+		"/users/me",
+		"/users/baz",
+	}
+	got := NormalizePathsWithNames(paths)
+
+	// /articles position has two distinct values -> slug.
+	if got["/articles/foo"] != "/articles/{articleSlug}" {
+		t.Errorf("articles/foo got %q", got["/articles/foo"])
+	}
+	if got["/articles/bar"] != "/articles/{articleSlug}" {
+		t.Errorf("articles/bar got %q", got["/articles/bar"])
+	}
+	// /users position has only one non-literal value (`baz`); `me` is excluded
+	// from observation. With only one varying value, no promotion.
+	if got["/users/me"] != "/users/me" {
+		t.Errorf("users/me literal lost: %q", got["/users/me"])
+	}
+	if got["/users/baz"] != "/users/baz" {
+		t.Errorf("users/baz prematurely promoted: %q", got["/users/baz"])
+	}
+}
+
+func TestNormalizePathsWithNames_EmptyAndDuplicateInputs(t *testing.T) {
+	if got := NormalizePathsWithNames(nil); len(got) != 0 {
+		t.Errorf("NormalizePathsWithNames(nil) = %v, want empty map", got)
+	}
+
+	dupPaths := []string{"/users/42", "/users/42", "/users/43"}
+	got := NormalizePathsWithNames(dupPaths)
+	if len(got) != 2 {
+		// Sort for stable error output
+		keys := make([]string, 0, len(got))
+		for k := range got {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		t.Errorf("expected 2 distinct keys, got %d: %v", len(got), keys)
+	}
+	if got["/users/42"] != "/users/{userId}" {
+		t.Errorf("got %q for /users/42", got["/users/42"])
+	}
+}
+
+func TestParamNameFromKind_NoContextFallbacks(t *testing.T) {
+	cases := []struct {
+		kind paramKind
+		want string
+	}{
+		{kindUUID, "id"},
+		{kindObjectID, "id"},
+		{kindNumeric, "id"},
+		{kindShortHex, "id"},
+		{kindBase64, "token"},
+		{kindSlug, "slug"},
+	}
+	for _, c := range cases {
+		if got := paramNameFromKind("", c.kind); got != c.want {
+			t.Errorf("paramNameFromKind(\"\", %v) = %q, want %q", c.kind, got, c.want)
+		}
+	}
+}
+
+func TestIsBase64Token(t *testing.T) {
+	cases := []struct {
+		segment string
+		want    bool
+	}{
+		{"AbCdEfGhIj1234567890", true},               // mixed case + digits, length 20
+		{"ZXhhbXBsZS10b2tlbi1kYXRh", true},           // base64-looking
+		{"my-very-long-blog-post-title-here", false}, // pure-lower slug
+		{"abcdef0123456789", false},                  // all hex/lower-digit, no upper -> not base64
+		{"short", false},                             // too short
+		{"AbCdEfGhIj++==", false},                    // length 14, below threshold
+		{"Aa1Bb2Cc3Dd4Ee5Ff6", true},                 // mixed case + digits, length >= 16
+		{"AaaaaaaaaaaaaaaaaaaaB", false},             // missing digit -> reject
+		{"012345678901234567890123", false},          // pure digits handled by numeric kind, base64 alone false (no upper/lower)
+	}
+	for _, c := range cases {
+		if got := isBase64Token(c.segment); got != c.want {
+			t.Errorf("isBase64Token(%q) = %v, want %v", c.segment, got, c.want)
+		}
 	}
 }

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -15,7 +15,9 @@
 package rest
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -1025,4 +1027,92 @@ func TestIsBase64Token(t *testing.T) {
 			t.Errorf("isBase64Token(%q) = %v, want %v", c.segment, got, c.want)
 		}
 	}
+}
+
+func TestNormalizePathsWithNames_MaxPromotionRoundsCap(t *testing.T) {
+	// Locks in the saturation contract for the maxPromotionRounds = 8 cap
+	// (normalize.go around `const maxPromotionRounds = 8`), the SEC-BE-001
+	// defense against CPU-DoS on pathological inputs. The cap MUST guarantee
+	// that NormalizePathsWithNames terminates with a well-formed result for
+	// any input, regardless of how many rounds the algorithm would otherwise
+	// require to fully converge.
+	//
+	// We assert two properties:
+	//
+	//   (a) Saturation safety — even on a deliberately complex fixture
+	//       the function returns without panicking, every input path
+	//       appears in the output map (no silent drops), and every output
+	//       is a non-empty string that begins with `/` (a valid path
+	//       template). Some segments may remain literal at saturation —
+	//       that is the documented best-effort contract.
+	//
+	//   (b) Cap-not-silently-lowered — the cap value MUST be at least 2.
+	//       The fixture below is one that requires exactly 2 rounds to
+	//       fully converge (every path resolves to /repos/{repoSlug}/{repoSlug2}).
+	//       If a future refactor silently lowers the cap to 1, the
+	//       expected templates will not appear and the assertion fails.
+	//       This sub-property is also implicitly covered by
+	//       TestNormalizePathsWithNames_FixedPointIterationRequired but is
+	//       repeated here so the cap-monitor test is self-contained.
+
+	t.Run("saturation_safety_on_deep_overlap_fixture", func(t *testing.T) {
+		// Construct a deeply-nested fixture with multiple varying positions
+		// and partial overlap. Realistic inputs like this converge in
+		// 2-3 rounds; the test does not depend on hitting the cap, only
+		// on the saturation invariants holding.
+		var paths []string
+		owners := []string{"alice", "bob", "carol", "dave", "eve"}
+		repos := []string{"proj-a", "proj-b", "proj-c"}
+		issues := []string{"1", "2", "3"}
+		for _, o := range owners {
+			for _, r := range repos {
+				for _, i := range issues {
+					paths = append(paths, fmt.Sprintf("/svc/repos/%s/%s/issues/%s", o, r, i))
+				}
+			}
+		}
+
+		got := NormalizePathsWithNames(paths)
+
+		// Saturation invariant 1: every input path is preserved as a key.
+		for _, p := range paths {
+			out, ok := got[p]
+			if !ok {
+				t.Errorf("input path %q missing from output map (cap may have dropped paths)", p)
+				continue
+			}
+			if out == "" {
+				t.Errorf("path %q produced empty output", p)
+			}
+			if !strings.HasPrefix(out, "/") {
+				t.Errorf("path %q produced non-path output %q", p, out)
+			}
+		}
+
+		// Saturation invariant 2: output map size never exceeds input size
+		// (deduplication is the only path that reduces it).
+		if len(got) > len(paths) {
+			t.Errorf("got %d output entries, want at most %d", len(got), len(paths))
+		}
+	})
+
+	t.Run("cap_supports_at_least_two_rounds", func(t *testing.T) {
+		// Fixture mirrors TestNormalizePathsWithNames_FixedPointIterationRequired:
+		// genuinely needs round 2 to converge. If the cap is silently
+		// lowered to 1, alice/proj-b and bob/proj-c stay literal at
+		// position 2.
+		paths := []string{
+			"/repos/alice/proj-a",
+			"/repos/alice/proj-b",
+			"/repos/bob/proj-a",
+			"/repos/bob/proj-c",
+		}
+		got := NormalizePathsWithNames(paths)
+		const want = "/repos/{repoSlug}/{repoSlug2}"
+		for _, p := range paths {
+			if got[p] != want {
+				t.Errorf("path %q normalized to %q, want %q — maxPromotionRounds may have been silently lowered below 2", p, got[p], want)
+			}
+		}
+	})
 }

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -276,6 +276,20 @@ func TestNormalizePathWithNames_NewKinds(t *testing.T) {
 			expected: "/blobs/{blobId}",
 		},
 		{
+			// Positive coverage for the uppercase A-F discriminator branch
+			// of isShortHexHash. Uppercase hex like "ABCDEF" is a real
+			// short-SHA shape; without this case the uppercase clause has
+			// no positive test.
+			name:     "uppercase short hex hash",
+			input:    "/commits/ABCDEF",
+			expected: "/commits/{commitId}",
+		},
+		{
+			name:     "mixed-case short hex hash",
+			input:    "/commits/AbCdEf12",
+			expected: "/commits/{commitId}",
+		},
+		{
 			name:     "base64url token uses Token suffix",
 			input:    "/sessions/AbCdEfGhIj1234567890XY",
 			expected: "/sessions/{sessionToken}",
@@ -516,6 +530,7 @@ func TestNormalizePathsWithNames_ResourceTypeBehindPathPrefixNeverPromoted(t *te
 	// "literal context" is the scaffold itself — which is not a resource.
 	groups := [][]string{
 		{"/api/users", "/api/posts", "/api/articles"},
+		{"/apis/users", "/apis/posts", "/apis/articles"},
 		{"/v1/users", "/v1/posts", "/v1/articles"},
 		{"/v2/products", "/v2/orders", "/v2/customers"},
 		{"/api/v1/users", "/api/v1/posts", "/api/v1/articles"},
@@ -621,6 +636,12 @@ func TestNormalizePathsWithNames_RegressionUUIDAndNumeric(t *testing.T) {
 }
 
 func TestNormalizePathsWithNames_MixedKinds(t *testing.T) {
+	// When an observation-promoted slug coexists at the same path position
+	// with a regex-classified kind (here, an ObjectID), the post-process
+	// unification collapses them onto kindSlug so a single OpenAPI path
+	// template emerges. Without this, downstream tooling would see two
+	// distinct templates (/articles/{articleSlug} and /articles/{articleId})
+	// for the same parameterized endpoint.
 	paths := []string{
 		"/articles/my-first-post",
 		"/articles/507f1f77bcf86cd799439011", // ObjectID
@@ -629,8 +650,29 @@ func TestNormalizePathsWithNames_MixedKinds(t *testing.T) {
 	got := NormalizePathsWithNames(paths)
 	want := map[string]string{
 		"/articles/my-first-post":            "/articles/{articleSlug}",
-		"/articles/507f1f77bcf86cd799439011": "/articles/{articleId}",
+		"/articles/507f1f77bcf86cd799439011": "/articles/{articleSlug}",
 		"/articles/another-post":             "/articles/{articleSlug}",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("path %q normalized to %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_MixedKindsWithoutSlugObservation(t *testing.T) {
+	// When no slug observation is promoted (single observation of a slug
+	// shape), the regex-classified kind keeps its template; the literal
+	// stays literal. Unification only runs when a slug actually exists at
+	// the shape position.
+	paths := []string{
+		"/articles/my-only-post",             // 1 literal observation, not promoted
+		"/articles/507f1f77bcf86cd799439011", // ObjectID, regex-classified
+	}
+	got := NormalizePathsWithNames(paths)
+	want := map[string]string{
+		"/articles/my-only-post":             "/articles/my-only-post",
+		"/articles/507f1f77bcf86cd799439011": "/articles/{articleId}",
 	}
 	for k, v := range want {
 		if got[k] != v {
@@ -704,6 +746,92 @@ func TestParamNameFromKind_NoContextFallbacks(t *testing.T) {
 	for _, c := range cases {
 		if got := paramNameFromKind("", c.kind); got != c.want {
 			t.Errorf("paramNameFromKind(\"\", %v) = %q, want %q", c.kind, got, c.want)
+		}
+	}
+}
+
+func TestParamNameFromKind_WithContext(t *testing.T) {
+	// Direct table-driven coverage for the contextual path of
+	// paramNameFromKind: singularize(prev) + suffixForKind(kind). This
+	// isolates the suffix selection from path splitting, so a regression
+	// that maps kindBase64 to "Slug" or kindSlug to "Token" fails here
+	// instead of in a far-removed full-path test.
+	cases := []struct {
+		name string
+		prev string
+		kind paramKind
+		want string
+	}{
+		{"users + UUID", "users", kindUUID, "userId"},
+		{"users + ObjectID", "users", kindObjectID, "userId"},
+		{"users + numeric", "users", kindNumeric, "userId"},
+		{"users + shortHex", "users", kindShortHex, "userId"},
+		{"sessions + base64", "sessions", kindBase64, "sessionToken"},
+		{"articles + slug", "articles", kindSlug, "articleSlug"},
+		{"categories + slug", "categories", kindSlug, "categorySlug"},
+		{"addresses + UUID", "addresses", kindUUID, "addressId"},
+		{"data + UUID (no plural)", "data", kindUUID, "dataId"},
+		{"hyphen-context + slug", "my-resource", kindSlug, "myResourceSlug"},
+		{"dot-context + slug", "v2.foo", kindSlug, "v2FooSlug"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := paramNameFromKind(c.prev, c.kind); got != c.want {
+				t.Errorf("paramNameFromKind(%q, %v) = %q, want %q", c.prev, c.kind, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeParamName_HyphenAndDotConversion(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain alphanumeric unchanged", "userId", "userId"},
+		{"underscore preserved", "user_id", "user_id"},
+		{"hyphen becomes camelCase", "my-service", "myService"},
+		{"dot becomes camelCase", "v2.foo.bar", "v2FooBar"},
+		{"trailing hyphen swallowed", "user-", "user"},
+		{"leading hyphen swallowed", "-user", "User"},
+		{"unsafe characters dropped", "us%er!", "user"},
+		{"empty input becomes id", "", "id"},
+		{"only-unsafe becomes id", "!?", "id"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sanitizeParamName(c.in); got != c.want {
+				t.Errorf("sanitizeParamName(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestNormalizePathsWithNames_DepthFiveMultiVarying(t *testing.T) {
+	// Depth-5 paths with overlap at multiple positions exercise the
+	// fixed-point iteration of promoteVaryingPositions across more than
+	// two adjacent literal positions. A regression that artificially caps
+	// iteration at one extra round will not promote the deepest position
+	// and therefore fails this test.
+	paths := []string{
+		"/repos/alice/proj1/issues/1",
+		"/repos/alice/proj1/issues/2",
+		"/repos/alice/proj2/issues/1",
+		"/repos/bob/proj1/issues/1",
+		"/repos/bob/proj2/issues/2",
+	}
+	got := NormalizePathsWithNames(paths)
+	// Owner (position 2) and project (position 3) are slug-shaped and
+	// vary across observations — they are promoted to kindSlug by the
+	// fixed-point iteration. The trailing numeric segments at position 5
+	// are regex-classified as kindNumeric on the first pass and rendered
+	// with the conventional `Id` suffix; they don't go through the
+	// observation pass at all. All three positions are parameterized.
+	const want = "/repos/{repoSlug}/{repoSlug2}/issues/{issueId}"
+	for _, p := range paths {
+		if got[p] != want {
+			t.Errorf("path %q normalized to %q, want %q", p, got[p], want)
 		}
 	}
 }

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -312,6 +312,34 @@ func TestNormalizePathWithNames_NewKinds(t *testing.T) {
 	}
 }
 
+func TestNormalizePathWithNames_NoFalsePositiveOnHexWords(t *testing.T) {
+	// Pure-lowercase English words composed entirely of [a-f] characters
+	// have the right length to match the short-hex regex but are not
+	// hashes. classifyParamSegment must reject them (isShortHexHash
+	// requires at least one digit or uppercase letter).
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"facade is six lowercase hex chars", "/commits/facade"},
+		{"decade is six lowercase hex chars", "/users/decade"},
+		{"defaced is seven lowercase hex chars", "/items/defaced"},
+		{"beaded is six lowercase hex chars", "/state/beaded"},
+		{"deface is six lowercase hex chars", "/actions/deface"},
+		{"accede is six lowercase hex chars", "/votes/accede"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NormalizePathWithNames(c.path); got != c.path {
+				t.Errorf("NormalizePathWithNames(%q) = %q, want unchanged literal", c.path, got)
+			}
+			if got := NormalizePath(c.path); got != c.path {
+				t.Errorf("NormalizePath(%q) = %q, want unchanged literal", c.path, got)
+			}
+		})
+	}
+}
+
 func TestNormalizePathWithNames_NoFalsePositiveOnDictionaryWords(t *testing.T) {
 	// Dictionary words and slugs must not be parameterized by the single-path
 	// pass — only the observation-based pass may promote them to parameters.
@@ -477,6 +505,84 @@ func TestNormalizePathsWithNames_RootResourceNeverPromoted(t *testing.T) {
 	for _, p := range paths {
 		if got[p] != p {
 			t.Errorf("root resource %q was promoted: got %q", p, got[p])
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_ResourceTypeBehindPathPrefixNeverPromoted(t *testing.T) {
+	// /api/<resource> and /v1/<resource> are common API shapes. The first
+	// resource segment after a known scaffold (api, rest, v1, v2, ...) must
+	// not be promoted to a slug parameter, because the only preceding
+	// "literal context" is the scaffold itself — which is not a resource.
+	groups := [][]string{
+		{"/api/users", "/api/posts", "/api/articles"},
+		{"/v1/users", "/v1/posts", "/v1/articles"},
+		{"/v2/products", "/v2/orders", "/v2/customers"},
+		{"/api/v1/users", "/api/v1/posts", "/api/v1/articles"},
+		{"/rest/users", "/rest/posts"},
+	}
+	for _, paths := range groups {
+		got := NormalizePathsWithNames(paths)
+		for _, p := range paths {
+			if got[p] != p {
+				t.Errorf("scaffold-prefixed resource %q was promoted: got %q", p, got[p])
+			}
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_PromotesAfterPathPrefix(t *testing.T) {
+	// The segment AFTER the resource type — even when a scaffold prefix is
+	// present — should still be promoted when it varies. /api/users/<id> is
+	// a parameter; the bug fix for scaffold protection must not over-correct.
+	paths := []string{
+		"/api/users/alice",
+		"/api/users/bob",
+		"/api/users/carol",
+	}
+	got := NormalizePathsWithNames(paths)
+	for _, p := range paths {
+		if got[p] != "/api/users/{userSlug}" {
+			t.Errorf("path %q normalized to %q, want /api/users/{userSlug}", p, got[p])
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_MultiVaryingPositionsWithOverlap(t *testing.T) {
+	// When observations overlap (the same owner appears with multiple repos
+	// AND the same repo name appears with multiple owners), strict
+	// prefix+suffix bucketing has anchors at both positions and the
+	// fixed-point iteration promotes both.
+	paths := []string{
+		"/repos/alice/proj1",
+		"/repos/alice/proj2",
+		"/repos/bob/proj1",
+		"/repos/bob/proj2",
+	}
+	got := NormalizePathsWithNames(paths)
+	for _, p := range paths {
+		want := "/repos/{repoSlug}/{repoSlug2}"
+		if got[p] != want {
+			t.Errorf("path %q normalized to %q, want %q", p, got[p], want)
+		}
+	}
+}
+
+func TestNormalizePathsWithNames_DiagonalObservationsLimitation(t *testing.T) {
+	// Pure-diagonal observations — every (owner, repo) pair unique, no
+	// overlapping prefix/suffix — cannot be promoted by strict bucketing.
+	// Each position's bucket is a singleton, so no variation is observable.
+	// This test documents the current behavior; users with this shape need
+	// to wait for additional observations to anchor the inference.
+	paths := []string{
+		"/repos/alice/proj1",
+		"/repos/bob/proj2",
+		"/repos/carol/proj3",
+	}
+	got := NormalizePathsWithNames(paths)
+	for _, p := range paths {
+		if got[p] != p {
+			t.Errorf("diagonal-only observation %q unexpectedly promoted to %q (algorithm limitation expected)", p, got[p])
 		}
 	}
 }

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -476,6 +476,9 @@ func TestNormalizePathsWithNames_SlugObservation(t *testing.T) {
 		"/articles/my-second-post":   "/articles/{articleSlug}",
 		"/articles/yet-another-post": "/articles/{articleSlug}",
 	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %#v", len(got), len(want), got)
+	}
 	for k, v := range want {
 		if got[k] != v {
 			t.Errorf("path %q normalized to %q, want %q", k, got[k], v)
@@ -718,6 +721,9 @@ func TestNormalizePathsWithNames_RegressionUUIDAndNumeric(t *testing.T) {
 		"/posts/1": "/posts/{postId}",
 		"/posts/2": "/posts/{postId}",
 	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %#v", len(got), len(want), got)
+	}
 	for k, v := range want {
 		if got[k] != v {
 			t.Errorf("path %q normalized to %q, want %q", k, got[k], v)
@@ -743,6 +749,9 @@ func TestNormalizePathsWithNames_MixedKinds(t *testing.T) {
 		"/articles/507f1f77bcf86cd799439011": "/articles/{articleSlug}",
 		"/articles/another-post":             "/articles/{articleSlug}",
 	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %#v", len(got), len(want), got)
+	}
 	for k, v := range want {
 		if got[k] != v {
 			t.Errorf("path %q normalized to %q, want %q", k, got[k], v)
@@ -763,6 +772,9 @@ func TestNormalizePathsWithNames_MixedKindsWithoutSlugObservation(t *testing.T) 
 	want := map[string]string{
 		"/articles/my-only-post":             "/articles/my-only-post",
 		"/articles/507f1f77bcf86cd799439011": "/articles/{articleId}",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %#v", len(got), len(want), got)
 	}
 	for k, v := range want {
 		if got[k] != v {
@@ -964,6 +976,34 @@ func TestNormalizePathsWithNames_FixedPointIterationRequired(t *testing.T) {
 	}
 }
 
+func TestNormalizePathsWithNames_IntraRoundAdjacentPositionPromotion(t *testing.T) {
+	// Pin down the exact failure mode of the pre-fix in-place algorithm:
+	// two positions in the SAME path promoted in the SAME round via
+	// different bucket keys. With four overlapping observations, round 1
+	// finds varying buckets at BOTH position 2 (prefix=/x, suffix=/y/{b|c})
+	// and position 4 (prefix=/x/{a|d}/y, suffix=) of every path. The
+	// atomic two-pass strategy in promoteVaryingPositions promotes both
+	// in the same call. An in-place implementation would mutate position 2
+	// first, change the shape used to compute position 4's posKey, and
+	// silently skip position 4's promotion in this round.
+	paths := []string{
+		"/x/a/y/b",
+		"/x/a/y/c", // anchors position 4's /x/a/y prefix bucket
+		"/x/d/y/b", // anchors position 2's /y/b suffix bucket
+		"/x/d/y/c", // anchors position 2's /y/c suffix bucket and position 4's /x/d/y prefix bucket
+	}
+	got := NormalizePathsWithNames(paths)
+	const want = "/x/{xSlug}/y/{ySlug}"
+	if len(got) != len(paths) {
+		t.Fatalf("got %d entries, want %d: %#v", len(got), len(paths), got)
+	}
+	for _, p := range paths {
+		if got[p] != want {
+			t.Errorf("path %q normalized to %q, want %q", p, got[p], want)
+		}
+	}
+}
+
 func TestIsBase64Token(t *testing.T) {
 	cases := []struct {
 		segment string
@@ -978,6 +1018,7 @@ func TestIsBase64Token(t *testing.T) {
 		{"Aa1Bb2Cc3Dd4Ee5Ff6", true},                 // mixed case + digits, length >= 16
 		{"AaaaaaaaaaaaaaaaaaaaB", false},             // missing digit -> reject
 		{"012345678901234567890123", false},          // pure digits handled by numeric kind, base64 alone false (no upper/lower)
+		{"ABCDEF0123456789XY", false},                // all-uppercase + digits, no lowercase -> false (documented trade-off; rare in URL paths, accepted asymmetry vs isShortHexHash)
 	}
 	for _, c := range cases {
 		if got := isBase64Token(c.segment); got != c.want {

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -1029,37 +1029,150 @@ func TestIsBase64Token(t *testing.T) {
 	}
 }
 
+// withMaxPromotionRounds temporarily overrides the package-level
+// maxPromotionRounds for the duration of t. Restores the original value via
+// t.Cleanup. Production code MUST NOT mutate maxPromotionRounds; this helper
+// is only for tests that need to verify cap behavior under controlled
+// conditions.
+func withMaxPromotionRounds(t *testing.T, n int) {
+	t.Helper()
+	prev := maxPromotionRounds
+	maxPromotionRounds = n
+	t.Cleanup(func() { maxPromotionRounds = prev })
+}
+
 func TestNormalizePathsWithNames_MaxPromotionRoundsCap(t *testing.T) {
-	// Locks in the saturation contract for the maxPromotionRounds = 8 cap
-	// (normalize.go around `const maxPromotionRounds = 8`), the SEC-BE-001
-	// defense against CPU-DoS on pathological inputs. The cap MUST guarantee
-	// that NormalizePathsWithNames terminates with a well-formed result for
-	// any input, regardless of how many rounds the algorithm would otherwise
+	// Locks in the saturation contract for the maxPromotionRounds cap
+	// (normalize.go: `var maxPromotionRounds = 8`), the SEC-BE-001 defense
+	// against CPU-DoS on pathological inputs. The cap MUST guarantee that
+	// NormalizePathsWithNames terminates with a well-formed result for any
+	// input, regardless of how many rounds the algorithm would otherwise
 	// require to fully converge.
 	//
-	// We assert two properties:
-	//
-	//   (a) Saturation safety — even on a deliberately complex fixture
-	//       the function returns without panicking, every input path
-	//       appears in the output map (no silent drops), and every output
-	//       is a non-empty string that begins with `/` (a valid path
-	//       template). Some segments may remain literal at saturation —
-	//       that is the documented best-effort contract.
-	//
-	//   (b) Cap-not-silently-lowered — the cap value MUST be at least 2.
-	//       The fixture below is one that requires exactly 2 rounds to
-	//       fully converge (every path resolves to /repos/{repoSlug}/{repoSlug2}).
-	//       If a future refactor silently lowers the cap to 1, the
-	//       expected templates will not appear and the assertion fails.
-	//       This sub-property is also implicitly covered by
-	//       TestNormalizePathsWithNames_FixedPointIterationRequired but is
-	//       repeated here so the cap-monitor test is self-contained.
+	// We use the test-only helper withMaxPromotionRounds to lower the cap
+	// to a small value and observe the documented best-effort contract:
+	// the function returns, every input path appears in the output map,
+	// every output is a non-empty path string, and segments that did not
+	// converge at saturation remain as their literal input values
+	// (passing through unchanged).
+
+	t.Run("cap_at_one_forces_saturation_with_unconverged_literals", func(t *testing.T) {
+		// Fixture from TestNormalizePathsWithNames_FixedPointIterationRequired
+		// genuinely needs round 2 to fully converge. Lowering the cap to 1
+		// forces saturation: alice/proj-a and bob/proj-a participate in
+		// round 1's varying buckets at both position 2 (suffix /proj-a)
+		// and position 3 (prefix /repos/{owner}), so they fully converge
+		// to /repos/{repoSlug}/{repoSlug2} in a single round. alice/proj-b
+		// and bob/proj-c each have one position promoted in round 1
+		// (their position-3 literal varies within /repos/alice and
+		// /repos/bob respectively); their position-2 literals are
+		// singleton-bucketed in round 1 and would only promote in round 2.
+		// With the cap at 1 those position-2 literals MUST stay literal —
+		// that is the documented saturation contract.
+		withMaxPromotionRounds(t, 1)
+		paths := []string{
+			"/repos/alice/proj-a",
+			"/repos/alice/proj-b",
+			"/repos/bob/proj-a",
+			"/repos/bob/proj-c",
+		}
+		got := NormalizePathsWithNames(paths)
+
+		// Invariant: every input path appears as a key.
+		if len(got) != len(paths) {
+			t.Fatalf("got %d entries, want %d: %#v", len(got), len(paths), got)
+		}
+		for _, p := range paths {
+			if _, ok := got[p]; !ok {
+				t.Errorf("input path %q missing from output map", p)
+			}
+		}
+
+		// Invariant: paths that participated in both buckets in round 1
+		// are fully promoted; paths whose position-2 needed round 2 retain
+		// their literal owner segment.
+		if got["/repos/alice/proj-a"] != "/repos/{repoSlug}/{repoSlug2}" {
+			t.Errorf("alice/proj-a got %q, want /repos/{repoSlug}/{repoSlug2}", got["/repos/alice/proj-a"])
+		}
+		if got["/repos/bob/proj-a"] != "/repos/{repoSlug}/{repoSlug2}" {
+			t.Errorf("bob/proj-a got %q, want /repos/{repoSlug}/{repoSlug2}", got["/repos/bob/proj-a"])
+		}
+		// At cap=1, the owner segment of alice/proj-b and bob/proj-c stays
+		// literal. contextualParamName then walks back from position 3 and
+		// finds the un-promoted owner as the nearest preceding literal, so
+		// the parameter name is {aliceSlug} / {bobSlug} rather than the
+		// fully-converged {repoSlug2} produced when the cap permits round 2.
+		// This is exactly what "best-effort detection on saturation" means:
+		// the output is a valid OpenAPI template, just not the fully-merged
+		// one. The default cap test below verifies the full convergence.
+		if got["/repos/alice/proj-b"] != "/repos/alice/{aliceSlug}" {
+			t.Errorf("alice/proj-b at cap=1 got %q, want /repos/alice/{aliceSlug} (owner stays literal at saturation)", got["/repos/alice/proj-b"])
+		}
+		if got["/repos/bob/proj-c"] != "/repos/bob/{bobSlug}" {
+			t.Errorf("bob/proj-c at cap=1 got %q, want /repos/bob/{bobSlug} (owner stays literal at saturation)", got["/repos/bob/proj-c"])
+		}
+	})
+
+	t.Run("cap_at_zero_returns_input_with_only_regex_kinds_promoted", func(t *testing.T) {
+		// Lowering the cap to 0 disables the observation pass entirely.
+		// Regex-detected kinds (UUID, ObjectID, numeric, etc.) still
+		// classify and render via classifyPaths + renderNormalizedPaths;
+		// only kindSlug promotion is suppressed because the loop body
+		// never runs.
+		withMaxPromotionRounds(t, 0)
+		paths := []string{
+			"/users/42",                       // numeric → {userId} (regex)
+			"/articles/my-first-post",         // slug-shaped, would observe-promote → stays literal
+			"/articles/my-second-post",        // ditto
+			"/posts/507f1f77bcf86cd799439011", // ObjectID → {postId} (regex)
+		}
+		got := NormalizePathsWithNames(paths)
+
+		want := map[string]string{
+			"/users/42":                       "/users/{userId}",
+			"/articles/my-first-post":         "/articles/my-first-post",
+			"/articles/my-second-post":        "/articles/my-second-post",
+			"/posts/507f1f77bcf86cd799439011": "/posts/{postId}",
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %d entries, want %d: %#v", len(got), len(want), got)
+		}
+		for k, v := range want {
+			if got[k] != v {
+				t.Errorf("path %q at cap=0 got %q, want %q", k, got[k], v)
+			}
+		}
+	})
+
+	t.Run("cap_at_default_supports_full_two_round_convergence", func(t *testing.T) {
+		// Sanity-check that the production cap (default 8) actually permits
+		// the 2-round convergence pattern. If maxPromotionRounds is silently
+		// lowered to 1 in production code (e.g., a bad refactor), this test
+		// fails alongside cap_at_one_forces_saturation_with_unconverged_literals
+		// and points at the same root cause.
+		paths := []string{
+			"/repos/alice/proj-a",
+			"/repos/alice/proj-b",
+			"/repos/bob/proj-a",
+			"/repos/bob/proj-c",
+		}
+		got := NormalizePathsWithNames(paths)
+		const want = "/repos/{repoSlug}/{repoSlug2}"
+		for _, p := range paths {
+			if got[p] != want {
+				t.Errorf("path %q normalized to %q, want %q — production cap may be silently below 2", p, got[p], want)
+			}
+		}
+	})
 
 	t.Run("saturation_safety_on_deep_overlap_fixture", func(t *testing.T) {
-		// Construct a deeply-nested fixture with multiple varying positions
-		// and partial overlap. Realistic inputs like this converge in
-		// 2-3 rounds; the test does not depend on hitting the cap, only
-		// on the saturation invariants holding.
+		// Constructs a deep-overlap fixture and asserts the saturation
+		// invariants hold under the production cap (no panic, every input
+		// path is preserved as a key, every output is a non-empty path
+		// string). Realistic inputs converge well below the cap; this is
+		// a smoke test for the well-formedness contract under load rather
+		// than a cap-firing test (the cap-firing path is exercised by the
+		// cap_at_one_… subtest above).
 		var paths []string
 		owners := []string{"alice", "bob", "carol", "dave", "eve"}
 		repos := []string{"proj-a", "proj-b", "proj-c"}
@@ -1074,11 +1187,10 @@ func TestNormalizePathsWithNames_MaxPromotionRoundsCap(t *testing.T) {
 
 		got := NormalizePathsWithNames(paths)
 
-		// Saturation invariant 1: every input path is preserved as a key.
 		for _, p := range paths {
 			out, ok := got[p]
 			if !ok {
-				t.Errorf("input path %q missing from output map (cap may have dropped paths)", p)
+				t.Errorf("input path %q missing from output map", p)
 				continue
 			}
 			if out == "" {
@@ -1086,32 +1198,6 @@ func TestNormalizePathsWithNames_MaxPromotionRoundsCap(t *testing.T) {
 			}
 			if !strings.HasPrefix(out, "/") {
 				t.Errorf("path %q produced non-path output %q", p, out)
-			}
-		}
-
-		// Saturation invariant 2: output map size never exceeds input size
-		// (deduplication is the only path that reduces it).
-		if len(got) > len(paths) {
-			t.Errorf("got %d output entries, want at most %d", len(got), len(paths))
-		}
-	})
-
-	t.Run("cap_supports_at_least_two_rounds", func(t *testing.T) {
-		// Fixture mirrors TestNormalizePathsWithNames_FixedPointIterationRequired:
-		// genuinely needs round 2 to converge. If the cap is silently
-		// lowered to 1, alice/proj-b and bob/proj-c stay literal at
-		// position 2.
-		paths := []string{
-			"/repos/alice/proj-a",
-			"/repos/alice/proj-b",
-			"/repos/bob/proj-a",
-			"/repos/bob/proj-c",
-		}
-		got := NormalizePathsWithNames(paths)
-		const want = "/repos/{repoSlug}/{repoSlug2}"
-		for _, p := range paths {
-			if got[p] != want {
-				t.Errorf("path %q normalized to %q, want %q — maxPromotionRounds may have been silently lowered below 2", p, got[p], want)
 			}
 		}
 	})

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -102,23 +102,35 @@ func extractServers(endpoints []classify.ClassifiedRequest) (openapi3.Servers, s
 }
 
 // groupEndpoints groups and sorts endpoints by normalized path and HTTP method.
+//
+// Path normalization runs in two passes so that slug-style identifiers can be
+// detected from the population of observed paths. The first pass parses URLs
+// and collects their paths; the second pass calls NormalizePathsWithNames
+// once, which performs both regex-based and observation-based detection.
 func groupEndpoints(endpoints []classify.ClassifiedRequest) map[endpointKey][]classify.ClassifiedRequest {
-	endpointGroups := make(map[endpointKey][]classify.ClassifiedRequest)
-
+	type parsedEndpoint struct {
+		path     string
+		endpoint classify.ClassifiedRequest
+	}
+	parsed := make([]parsedEndpoint, 0, len(endpoints))
+	rawPaths := make([]string, 0, len(endpoints))
 	for _, endpoint := range endpoints {
 		parsedURL, err := url.Parse(endpoint.URL)
 		if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
 			// Skip malformed URLs or non-HTTP/HTTPS schemes
 			continue
 		}
-
-		normalizedPath := NormalizePathWithNames(parsedURL.Path)
-		method := strings.ToLower(endpoint.Method)
-
-		key := endpointKey{normalizedPath, method}
-		endpointGroups[key] = append(endpointGroups[key], endpoint)
+		parsed = append(parsed, parsedEndpoint{path: parsedURL.Path, endpoint: endpoint})
+		rawPaths = append(rawPaths, parsedURL.Path)
 	}
 
+	normalized := NormalizePathsWithNames(rawPaths)
+
+	endpointGroups := make(map[endpointKey][]classify.ClassifiedRequest)
+	for _, p := range parsed {
+		key := endpointKey{normalized[p.path], strings.ToLower(p.endpoint.Method)}
+		endpointGroups[key] = append(endpointGroups[key], p.endpoint)
+	}
 	return endpointGroups
 }
 

--- a/pkg/generate/rest/openapi_test.go
+++ b/pkg/generate/rest/openapi_test.go
@@ -523,6 +523,91 @@ func TestP0Fixes_ContextAwarePathParams(t *testing.T) {
 	}
 }
 
+func TestOpenAPIGenerator_SlugObservation(t *testing.T) {
+	// Three slug-shaped observations under a common prefix must be grouped
+	// into a single parameterized path by Generate(). This locks in the
+	// contract that observation-based slug detection (NormalizePathsWithNames)
+	// is wired into groupEndpoints; a regression that reverts the wiring to
+	// per-endpoint normalization would produce three distinct paths and fail
+	// this test.
+	gen := &OpenAPIGenerator{}
+
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://api.example.com/articles/my-first-post",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+					Body:       []byte(`{"title": "first"}`),
+				},
+			},
+			IsAPI: true,
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://api.example.com/articles/another-post",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+					Body:       []byte(`{"title": "another"}`),
+				},
+			},
+			IsAPI: true,
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method: "GET",
+				URL:    "https://api.example.com/articles/yet-another-post",
+				Response: crawl.ObservedResponse{
+					StatusCode: 200,
+					Body:       []byte(`{"title": "yet another"}`),
+				},
+			},
+			IsAPI: true,
+		},
+	}
+
+	spec, err := gen.Generate(endpoints)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData(spec)
+	if err != nil {
+		t.Fatalf("Generated spec failed validation: %v", err)
+	}
+
+	// Exactly one path should exist; observation-based detection collapses
+	// the three slug observations onto /articles/{articleSlug}.
+	if doc.Paths.Len() != 1 {
+		paths := append([]string{}, doc.Paths.InMatchingOrder()...)
+		t.Fatalf("expected 1 path in spec, got %d: %v", doc.Paths.Len(), paths)
+	}
+
+	expectedPath := "/articles/{articleSlug}"
+	pathItem := doc.Paths.Find(expectedPath)
+	if pathItem == nil {
+		paths := append([]string{}, doc.Paths.InMatchingOrder()...)
+		t.Fatalf("expected path %q not found in spec; got: %v", expectedPath, paths)
+	}
+	if pathItem.Get == nil {
+		t.Fatal("GET operation not found on /articles/{articleSlug}")
+	}
+
+	// Verify the path parameter is present and correctly named.
+	var pathParamNames []string
+	for _, paramRef := range pathItem.Get.Parameters {
+		if paramRef.Value.In == "path" {
+			pathParamNames = append(pathParamNames, paramRef.Value.Name)
+		}
+	}
+	if len(pathParamNames) != 1 || pathParamNames[0] != "articleSlug" {
+		t.Errorf("path parameters = %v, want exactly [articleSlug]", pathParamNames)
+	}
+}
+
 func TestP0Fixes_ActualStatusCodes(t *testing.T) {
 	gen := &OpenAPIGenerator{}
 


### PR DESCRIPTION
## Summary

Extends `NormalizePathWithNames` in `pkg/generate/rest/normalize.go` to recognize dynamic path segments beyond UUIDs and numeric IDs, and adds observation-based slug detection across the full set of observed paths.

- New regex-based kinds: **MongoDB ObjectID** (24 hex), **short hex hash** (6–12 hex), **base64 / base64url token** (≥16 chars with mixed case + digits, or with base64 punctuation).
- New multi-path entry point `NormalizePathsWithNames(paths []string)` that performs **observation-based detection**: a literal path position whose value varies across observations sharing the same prefix and suffix shape is promoted to a slug parameter (`/articles/my-first-post` + `/articles/another-post` → `/articles/{articleSlug}`).
- Explicit **known-literal allowlist** (`me`, `current`, `self`, `new`, `list`, `search`) protects literals against all forms of parameterization.
- Parameter names are now kind-aware: `Token` for base64 tokens, `Slug` for observation-promoted segments, `Id` for everything else.
- `groupEndpoints` in `openapi.go` switched to a two-pass strategy that calls the multi-path normalizer once over the full endpoint set so slug detection sees the full population.
- Root-level resource segments are protected: a position is only eligible for slug promotion if it has at least one preceding non-empty literal segment, so `/users` and `/posts` are never collapsed to a single varying parameter. Path-scaffold prefixes (`api`, `apis`, `rest`, `v1`, `v2`, …) are protected by the same mechanism — `/api/users` and `/api/posts` do not collapse.
- **Mixed-kind unification**: when an observation-promoted slug shares a path position with a regex-classified kind (e.g., `/articles/<slug>` alongside `/articles/<ObjectID>`), `unifyMixedKindsAtSamePosition` collapses both onto `{articleSlug}` so a single OpenAPI template emerges instead of two ambiguous ones.
- **Bounded fixed-point iteration**: the multi-path normalizer iterates promotion to a fixed point (so promoting one position can unblock another) with a `maxPromotionRounds = 8` cap to prevent O(N·S³) CPU-DoS on adversarial input. Cap saturation is documented best-effort behavior — unconverged segments pass through as literals.

Closes LAB-2107.

## Reviewer hint — where to start

Read in this order; the diff makes more sense top-down once you have these:

1. **`pkg/generate/rest/normalize.go`** — the algorithm. Skim `classifyParamSegment`, then `NormalizePathsWithNames` (the fixed-point loop), then `promoteVaryingPositions` (atomic two-pass — see the long doc comment), then `unifyMixedKindsAtSamePosition`.
2. **`pkg/generate/rest/normalize_test.go`** — `TestNormalizePathsWithNames_MaxPromotionRoundsCap` is the most illustrative: its four sub-tests (`cap_at_zero…`, `cap_at_one…`, `cap_at_default…`, `saturation_safety…`) demonstrate the design choices and the saturation contract by changing the cap via the test-only `withMaxPromotionRounds` helper. `TestNormalizePathsWithNames_FixedPointIterationRequired` and `_IntraRoundAdjacentPositionPromotion` document the two non-trivial correctness invariants.
3. **`pkg/generate/rest/openapi.go`** — only `groupEndpoints` changed; that change is the call-site wiring for the new multi-path normalizer.

## Changes since first push

The PR ships as 7 commits; CI is green at the tip. Reviewers who want to follow the conversation can read commit-by-commit, but the squashed history is the canonical artifact.

| Commit | Purpose |
|---|---|
| [`162ccfb`](https://github.com/praetorian-inc/vespasian/pull/117/commits/162ccfb) | **feat**: initial implementation — new regex kinds, observation-based detection, `NormalizePathsWithNames`, scaffold protection, two-pass `groupEndpoints` wiring. |
| [`92ac68d`](https://github.com/praetorian-inc/vespasian/pull/117/commits/92ac68d) | **fix**: round-1 review — `pathPrefixes` allowlist so `/api/<r>` and `/v1/<r>` no longer collapse; `isShortHexHash` digit/uppercase guard (`facade`/`decade` stay literal); fixed-point iteration of `promoteVaryingPositions`; integration test through `Generate()`. |
| [`8845676`](https://github.com/praetorian-inc/vespasian/pull/117/commits/8845676) | **fix**: round-2 review — `unifyMixedKindsAtSamePosition` to merge `{articleSlug}` and `{articleId}` templates at the same position; `sanitizeParamName` converts hyphens/dots to camelCase; `versionPrefixRegex` tightened to exclude `v0`/`v01`. |
| [`f4cc7cd`](https://github.com/praetorian-inc/vespasian/pull/117/commits/f4cc7cd) | **fix**: round-3 review **+ real bug fix** — `promoteVaryingPositions` switched to atomic two-pass strategy. The previous in-place mutation changed `shapeKey` for subsequent positions in the same path and silently suppressed their promotion. `TestNormalizePathsWithNames_FixedPointIterationRequired` is the regression that fails on the old algorithm. (This was Gemini's critical issue #3 on the bot review.) |
| [`a5b1732`](https://github.com/praetorian-inc/vespasian/pull/117/commits/a5b1732) | **fix**: round-4 review — `maxPromotionRounds = 8` cap (CPU-DoS defense for adversarial capture files); polish on doc comments, regex docs, and `isBase64Token` trade-off. |
| [`64e754c`](https://github.com/praetorian-inc/vespasian/pull/117/commits/64e754c) | **test**: cap regression test — initial fixture for the new cap. |
| [`af554ca`](https://github.com/praetorian-inc/vespasian/pull/117/commits/af554ca) | **fix**: round-6 review — make the cap genuinely testable (`var` instead of `const`, plus `withMaxPromotionRounds` helper that uses `t.Cleanup`). Documents the safe in-place mutation in `applyKindsToSegments`. Extracts `type segLoc` to remove the duplicate-struct DRY violation. |

Suggested merge strategy: **Squash and merge** — the cumulative diff is the meaningful artifact; the round-by-round commit history is review process noise.

## Test plan

- [x] `make check` passes (gofmt, go vet, golangci-lint v2 with 0 issues, `go test -race ./...`)
- [x] Coverage on `pkg/generate/rest`: **93.2%** (CI gate is 80%)
- [x] CI: 11/11 green at `af554ca` (build, lint, test, gosec, govulncheck, module integrity, CodeRabbit)
- [x] Manual smoke test on a hand-crafted 18-observation capture: 11 distinct paths emitted (38% compression), every LAB-2107 behavior verified by inspection.
- [x] All ticket acceptance criteria covered by tests in `pkg/generate/rest/normalize_test.go`:
  - Short hex hashes detected — `TestNormalizePath_DynamicSegmentExpansion`, `TestNormalizePathWithNames_NewKinds`
  - MongoDB ObjectIDs detected — same suites
  - Base64 / base64url tokens detected — same suites
  - Observation-based slug detection — `TestNormalizePathsWithNames_SlugObservation`, `TestNormalizePathsWithNames_LiteralNotPromotedAcrossPositions`, `TestNormalizePathsWithNames_DifferentShapesNotConflated`, `TestNormalizePathsWithNames_MixedKinds`, `TestNormalizePathsWithNames_MultiVaryingPositionsWithOverlap`, `TestNormalizePathsWithNames_FixedPointIterationRequired`, `TestNormalizePathsWithNames_IntraRoundAdjacentPositionPromotion`
  - Mixed-kind unification — `TestNormalizePathsWithNames_MixedKindsUnifyAcrossAllRegexKinds`, `TestNormalizePathsWithNames_SlugOnlyNoOpUnification`
  - Scaffold protection (`api`, `v1`, `v0` boundary) — `TestNormalizePathsWithNames_ResourceTypeBehindPathPrefixNeverPromoted`, `TestNormalizePathsWithNames_VersionPrefixBoundary`, `TestNormalizePathsWithNames_PromotesAfterPathPrefix`
  - Known literals preserved — `TestNormalizePath_LiteralPreservation`, `TestNormalizePathsWithNames_LiteralNotPromotedAcrossPositions`, `TestNormalizePathsWithNames_RootResourceNeverPromoted`
  - Single observation must not promote — `TestNormalizePathsWithNames_SinglePathNoSlug`
  - Cap saturation contract — `TestNormalizePathsWithNames_MaxPromotionRoundsCap` (four sub-tests)
  - End-to-end through `Generate()` — `TestOpenAPIGenerator_SlugObservation` in `openapi_test.go`
  - No regression on UUID / numeric — `TestNormalizePathsWithNames_RegressionUUIDAndNumeric`, existing `TestNormalizePath_UUID`, `TestNormalizePath_NumericID`, `TestNormalizePathWithNames_ConsecutiveIDs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LAB-2107](https://linear.app/praetorianlabs/issue/LAB-2107/expand-path-parameter-detection-beyond-uuids-and-numeric-ids)