### PR TITLE
fix(ci): bump claude-md-drift to v2.3.1, remove invalid timeout-minutes

### DIFF
--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -10,11 +10,9 @@ concurrency:
 
 jobs:
   drift-check:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@87c0808aa16862a7ffef0cd94c516a02eb48242b  # v2.3.0
-    timeout-minutes: 15
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@25c08fbd15a931e275f207ecee1758c931f89ea5  # v2.3.1
     permissions:
       contents: read
       pull-requests: write
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-


### PR DESCRIPTION
## Summary
- Remove invalid `timeout-minutes: 15` from the `drift-check` caller job (`timeout-minutes` is not a valid key on reusable-workflow `uses:` jobs — GitHub silently ignores or rejects it)
- Bump pinned SHA from `v2.3.0` (`87c0808`) to `v2.3.1` (`25c08fb`), which includes the upstream template fix (public-workflows PR #60)

Matches the working configuration already deployed in [chariot](https://github.com/praetorian-inc/chariot).

## Test plan
- [ ] Verify workflow parses correctly (no "invalid workflow file" errors)
- [ ] Open a test PR to confirm drift detection runs