### PR TITLE
test(crawl): backend parity matrix, benchmarks, SPA capture (LAB-2787)

### DIFF
--- a/docs/benchmarks/crawler-comparison.md
+++ b/docs/benchmarks/crawler-comparison.md
@@ -1,0 +1,100 @@
+# Crawler Backend Comparison: RodCrawler vs HTTPCrawler
+
+## Summary
+
+Vespasian exposes a single `Crawler` interface with two implementations: `HTTPCrawler`
+(stdlib `net/http` engine) for fast, Chrome-free crawling of static and REST targets, and
+`RodCrawler` (go-rod / Chromium) for JavaScript-heavy or SPA targets that issue runtime
+`fetch`/XHR requests. Use `RodCrawler` (via `--headless=true`, the default) when you need
+SPA coverage; use `HTTPCrawler` (`--headless=false`) when you need speed or a Chrome-free
+environment.
+
+## Methodology
+
+- **Fixture:** `pkg/crawl/bench_test.go` — deterministic linked static HTML (`benchPages=20`
+  pages), no randomness or time-based content. Index page links to 20 leaf pages; each leaf
+  links to the next (ring) and back to the index.
+- **Command:**
+  ```
+  go test -run '^$' -bench 'Benchmark.*Crawl' -benchmem ./pkg/crawl/
+  ```
+- **Environment:** linux/arm64 (12-core), Go runtime benchmarking framework (`testing.B`).
+- **Caveats:**
+  - Chrome cold-start (≈ 1–3 s per `b.N` iteration) dominates `BenchmarkRodCrawl` wall
+    time. Rod numbers measure end-to-end throughput with Chrome launch cost included, not
+    raw crawl throughput.
+  - `heapbytes/op` uses `runtime.MemStats.TotalAlloc` delta (monotonically increasing
+    allocation counter, stable under GC scheduling) rather than `HeapInuse` peak (which is
+    non-deterministic). Both metrics are comparable across backends but `TotalAlloc` is more
+    reproducible.
+  - `BenchmarkRodCrawl` is run without `-race` when Chrome CDP goroutines cause race
+    instrumentation false positives; `BenchmarkHTTPCrawl` always runs with `-race`.
+
+## Results
+
+Benchmark run on 2026-06-05. Raw output:
+
+```
+goos: linux
+goarch: arm64
+pkg: github.com/praetorian-inc/vespasian/pkg/crawl
+BenchmarkHTTPCrawl-12    542   2390080 ns/op   21.00 captured/op   786142 heapbytes/op   786142 B/op   4997 allocs/op
+BenchmarkHTTPCrawl-12    493   2367137 ns/op   21.00 captured/op   784550 heapbytes/op   784549 B/op   4993 allocs/op
+BenchmarkRodCrawl-12       1   11301201505 ns/op   42.00 captured/op   7041496 heapbytes/op   7041496 B/op   116148 allocs/op
+BenchmarkRodCrawl-12       1   11220377755 ns/op   42.00 captured/op   6550600 heapbytes/op   6550600 B/op   111666 allocs/op
+```
+
+### 1. Request Count (`captured/op`)
+
+| Backend     | captured/op | Notes                                                           |
+|-------------|-------------|----------------------------------------------------------------|
+| HTTPCrawler | 21          | Deterministic: 1 index + 20 leaf pages                        |
+| RodCrawler  | 42          | Chrome captures additional browser-internal requests (favicon, etc.) |
+
+### 2. Wall-Clock Time (`ns/op`)
+
+| Backend     | ns/op (approx)  | Notes                                      |
+|-------------|-----------------|---------------------------------------------|
+| HTTPCrawler | ~2.4 ms         | Pure Go stdlib; no process spawn            |
+| RodCrawler  | ~11,000 ms      | Chrome cold-start (~1–3 s) per iteration dominates |
+
+The ~4,600× wall-time difference on this fixture is almost entirely Chrome
+cold-start cost. Rod's per-page crawl latency is not captured separately here.
+
+### 3. Peak Memory (`heapbytes/op`, `B/op`, `allocs/op`)
+
+| Backend     | heapbytes/op | B/op    | allocs/op |
+|-------------|--------------|---------|-----------|
+| HTTPCrawler | ~786 KB      | ~786 KB | ~4,995    |
+| RodCrawler  | ~6.8 MB      | ~6.8 MB | ~113,907  |
+
+`heapbytes/op` = `TotalAlloc` delta / `b.N`. Rod's higher allocation count
+reflects Chrome subprocess I/O, CDP protocol parsing, and network event handling.
+
+### 4. Race Safety
+
+| Backend     | `-race` |
+|-------------|---------|
+| HTTPCrawler | Passes cleanly (`go test -race ./pkg/crawl/`) |
+| RodCrawler  | Not guaranteed with `-race` (go-rod CDP goroutines may trigger false positives on some platforms) |
+
+## Capability Gap
+
+| Capability                              | HTTPCrawler | RodCrawler |
+|-----------------------------------------|-------------|------------|
+| Static HTML link following              | Yes         | Yes        |
+| Scope confinement (cross-origin links)  | Yes         | Yes        |
+| Depth and max-pages limiting            | Yes         | Yes        |
+| Custom request headers                  | Yes         | Yes        |
+| Relative-link resolution (post-redirect)| Yes         | Yes        |
+| SSRF redirect guard (Go dial)           | Yes         | N/A (Chrome network layer) |
+| JavaScript execution                    | No          | Yes        |
+| Inline-script literal extraction        | Yes (jsluice static scan) | Yes (+ runtime execution) |
+| SPA runtime `fetch`/XHR capture         | **No**      | **Yes**    |
+| Cookie propagation across redirects     | Yes (stdlib) | Yes (Chrome) |
+
+The critical gap is **SPA runtime `fetch`/XHR capture**: `HTTPCrawler` performs
+no JavaScript execution and cannot observe requests issued dynamically at runtime.
+`RodCrawler` hooks Chrome's network layer and captures all requests regardless of
+how they are initiated. This gap is verified by `pkg/crawl/spa_integration_test.go`
+(`TestRodCrawler_CapturesSPAFetch`), which closes LAB-1535.

--- a/docs/benchmarks/crawler-comparison.md
+++ b/docs/benchmarks/crawler-comparison.md
@@ -15,7 +15,7 @@ environment.
   pages), no randomness or time-based content. Index page links to 20 leaf pages; each leaf
   links to the next (ring) and back to the index.
 - **Command:**
-  ```
+  ```text
   go test -run '^$' -bench 'Benchmark.*Crawl' -benchmem ./pkg/crawl/
   ```
 - **Environment:** linux/arm64 (12-core), Go runtime benchmarking framework (`testing.B`).
@@ -34,7 +34,7 @@ environment.
 
 Benchmark run on 2026-06-05. Raw output:
 
-```
+```text
 goos: linux
 goarch: arm64
 pkg: github.com/praetorian-inc/vespasian/pkg/crawl
@@ -69,7 +69,9 @@ cold-start cost. Rod's per-page crawl latency is not captured separately here.
 | RodCrawler  | ~6.8 MB      | ~6.8 MB | ~113,907  |
 
 `heapbytes/op` = `TotalAlloc` delta / `b.N`. Rod's higher allocation count
-reflects Chrome subprocess I/O, CDP protocol parsing, and network event handling.
+reflects CDP protocol parsing and go-rod library allocations within the Go process.
+`TotalAlloc` measures only Go heap allocations; Chrome subprocess memory and I/O
+are not included in this metric.
 
 ### 4. Race Safety
 

--- a/docs/benchmarks/crawler-comparison.md
+++ b/docs/benchmarks/crawler-comparison.md
@@ -15,7 +15,7 @@ environment.
   pages), no randomness or time-based content. Index page links to 20 leaf pages; each leaf
   links to the next (ring) and back to the index.
 - **Command:**
-  ```text
+  ```shell
   go test -run '^$' -bench 'Benchmark.*Crawl' -benchmem ./pkg/crawl/
   ```
 - **Environment:** linux/arm64 (12-core), Go runtime benchmarking framework (`testing.B`).

--- a/pkg/crawl/bench_test.go
+++ b/pkg/crawl/bench_test.go
@@ -77,9 +77,12 @@ func BenchmarkHTTPCrawl(b *testing.B) {
 }
 
 // BenchmarkRodCrawl measures the go-rod headless crawler against the same
-// deterministic fixture. Skips when Chrome is unavailable. Chrome cold-start
-// (~1-3 s/op) dominates wall time; treat rod numbers as relative to HTTP, not
-// as micro-optimization targets.
+// deterministic fixture. Skips when Chrome is unavailable.
+//
+// Each iteration relaunches Chrome, so b.N effectively stays at 1 and ns/op is
+// a single cold-start sample (~1-3 s) dominated by Chrome launch overhead. Use
+// these numbers for RELATIVE comparison vs BenchmarkHTTPCrawl, not as absolute
+// per-page latency measurements. A shared BrowserMgr optimisation is deferred.
 //
 // Note: run without -race when Chrome+race proves flaky in your environment
 // (go-rod spawns CDP goroutines; race instrumentation can cause false positives

--- a/pkg/crawl/bench_test.go
+++ b/pkg/crawl/bench_test.go
@@ -44,7 +44,6 @@ func newBenchFixture(pages int) *httptest.Server {
 		fmt.Fprintf(w, "<html><body>%s</body></html>", b.String())
 	})
 	for i := range pages {
-		i := i // capture range variable
 		mux.HandleFunc(fmt.Sprintf("/p%d", i), func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/html")
 			fmt.Fprintf(w, `<html><body><a href="/p%d">next</a></body></html>`, (i+1)%pages)
@@ -86,7 +85,7 @@ func BenchmarkHTTPCrawl(b *testing.B) {
 //
 // Note: run without -race when Chrome+race proves flaky in your environment
 // (go-rod spawns CDP goroutines; race instrumentation can cause false positives
-// on the Chrome subprocess I/O pipes). HTTP benchmark always runs with -race.
+// on the CDP goroutines communicating with Chrome). HTTP benchmark always runs with -race.
 func BenchmarkRodCrawl(b *testing.B) {
 	if err := probeChromeForBench(); err != nil {
 		b.Skipf("Chrome unavailable: %v", err)
@@ -138,6 +137,8 @@ func benchCrawl(b *testing.B, srv *httptest.Server, headless bool) {
 	b.StopTimer()
 	runtime.ReadMemStats(&m1)
 
+	// lastCount == every-iteration count: fixture is deterministic, so the
+	// per-iteration captured count is constant (using last is equivalent to first).
 	b.ReportMetric(float64(lastCount), "captured/op")
 	b.ReportMetric(float64(m1.TotalAlloc-m0.TotalAlloc)/float64(b.N), "heapbytes/op")
 }

--- a/pkg/crawl/bench_test.go
+++ b/pkg/crawl/bench_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// benchPages is the fixed page count for the deterministic benchmark fixture.
+// Kept small to bound Chrome cold-start cost for BenchmarkRodCrawl.
+const benchPages = 20
+
+// newBenchFixture serves a fixed tree of inter-linked static pages: an index
+// page linking to pages /p0../p(N-1), each page linking to the next (modulo N)
+// and back to the index. Counts are deterministic (no time/random content) so
+// captured-request counts match across runs and backends.
+func newBenchFixture(pages int) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		var b strings.Builder
+		for i := range pages {
+			fmt.Fprintf(&b, `<a href="/p%d">p%d</a>`, i, i)
+		}
+		fmt.Fprintf(w, "<html><body>%s</body></html>", b.String())
+	})
+	for i := range pages {
+		i := i // capture range variable
+		mux.HandleFunc(fmt.Sprintf("/p%d", i), func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, `<html><body><a href="/p%d">next</a></body></html>`, (i+1)%pages)
+		})
+	}
+	return httptest.NewServer(mux)
+}
+
+// probeChromeForBench performs a one-shot Chrome availability check for use
+// by BenchmarkRodCrawl. It reuses the same NewBrowserManager launch probe as
+// the contract gate (skipIfNoChrome) but returns an error rather than calling
+// t.Skip so benchmark callers can use b.Skip.
+func probeChromeForBench() error {
+	bm, err := NewBrowserManager(BrowserOptions{Headless: true})
+	if err != nil {
+		return err
+	}
+	bm.Close()
+	return nil
+}
+
+// BenchmarkHTTPCrawl measures the stdlib net/http crawler against the
+// deterministic linked-HTML fixture. Reports ns/op, B/op, allocs/op (standard
+// -benchmem), captured/op (request count), and heapbytes/op (TotalAlloc delta
+// via runtime.MemStats — a stable, GC-independent allocation signal).
+func BenchmarkHTTPCrawl(b *testing.B) {
+	srv := newBenchFixture(benchPages)
+	defer srv.Close()
+	benchCrawl(b, srv, false)
+}
+
+// BenchmarkRodCrawl measures the go-rod headless crawler against the same
+// deterministic fixture. Skips when Chrome is unavailable. Chrome cold-start
+// (~1-3 s/op) dominates wall time; treat rod numbers as relative to HTTP, not
+// as micro-optimization targets.
+//
+// Note: run without -race when Chrome+race proves flaky in your environment
+// (go-rod spawns CDP goroutines; race instrumentation can cause false positives
+// on the Chrome subprocess I/O pipes). HTTP benchmark always runs with -race.
+func BenchmarkRodCrawl(b *testing.B) {
+	if err := probeChromeForBench(); err != nil {
+		b.Skipf("Chrome unavailable: %v", err)
+	}
+	srv := newBenchFixture(benchPages)
+	defer srv.Close()
+	benchCrawl(b, srv, true)
+}
+
+// benchCrawl is the shared benchmark body. It measures wall-clock (b.N loop),
+// allocations (b.ReportAllocs), captured-request count (captured/op custom
+// metric), and total heap allocations (heapbytes/op via runtime.MemStats
+// TotalAlloc delta).
+//
+// Race-free: each iteration builds a fresh NewCrawler; Crawl is internally
+// synchronized (http_crawler.go mu; engine.go mu) and returns a snapshot copy.
+// The fixture handlers are stateless — no shared mutable state across
+// iterations.
+//
+// TotalAlloc is used (not HeapInuse peak) because HeapInuse is non-deterministic
+// under GC scheduling. TotalAlloc is a monotonically increasing counter giving a
+// stable, comparable allocation signal across runs and backends.
+func benchCrawl(b *testing.B, srv *httptest.Server, headless bool) {
+	b.Helper()
+	b.ReportAllocs()
+	opts := CrawlerOptions{
+		Depth:        3,
+		MaxPages:     1000,
+		Timeout:      60 * time.Second,
+		Scope:        "same-origin",
+		AllowPrivate: true,
+		Headless:     headless,
+	}
+
+	var lastCount int
+	var m0, m1 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m0)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		got, err := NewCrawler(opts).Crawl(context.Background(), srv.URL)
+		if err != nil {
+			b.Fatalf("crawl: %v", err)
+		}
+		lastCount = len(got)
+	}
+
+	b.StopTimer()
+	runtime.ReadMemStats(&m1)
+
+	b.ReportMetric(float64(lastCount), "captured/op")
+	b.ReportMetric(float64(m1.TotalAlloc-m0.TotalAlloc)/float64(b.N), "heapbytes/op")
+}

--- a/pkg/crawl/contract_test.go
+++ b/pkg/crawl/contract_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -103,7 +104,6 @@ func runCrawlerContract(
 ) {
 	t.Helper()
 	for _, bc := range crawlerBackends() {
-		bc := bc // capture range variable
 		t.Run(bc.name, func(t *testing.T) {
 			if bc.headless {
 				skipIfNoChrome(t)
@@ -159,16 +159,37 @@ func TestCrawlerContract_FollowsLinks(t *testing.T) {
 	)
 }
 
-// TestCrawlerContract_RespectsMaxPages asserts that both backends stop after
-// crawling at most MaxPages pages. The fixture serves 50 inter-linked pages;
-// limiting to 5 must cap results well below 50.
+// TestCrawlerContract_RespectsMaxPages asserts that both backends stop actual
+// crawl WORK after at most MaxPages pages. The fixture serves 50 inter-linked
+// pages; with MaxPages=5 the server must receive at most maxPages+2 page-path
+// requests (a small margin accounts for in-flight requests that were already
+// dispatched before the cap triggers with Concurrency:1).
+//
+// The server-side counter is the critical assertion: counting URLs in the
+// result slice only tests capping of stored results, not actual fetch work
+// (both backends already cap the result slice by construction). The counter
+// verifies that the crawler stops dispatching requests after the limit, not
+// just stops storing them.
 func TestCrawlerContract_RespectsMaxPages(t *testing.T) {
 	const totalPages = 50
 	const maxPages = 5
+	// margin: with Concurrency=1 there is at most 1 in-flight request beyond
+	// the cap trigger. Allow 2 to accommodate any final in-flight request that
+	// completes after cancel() is called but before the worker loop exits.
+	const fetchMargin = 2
+
+	var serverPageFetches atomic.Int64
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Count server-side page hits: "/" (seed) and "/p<digits>" (leaves).
+		// Sub-resources (favicon, about:blank, CDP internal) are excluded so
+		// the counter is comparable across both http and rod backends.
+		p := r.URL.Path
+		if p == "/" || isPagePath(p) {
+			serverPageFetches.Add(1)
+		}
 		w.Header().Set("Content-Type", "text/html")
-		if r.URL.Path == "/" {
+		if p == "/" {
 			var b strings.Builder
 			for i := range totalPages {
 				fmt.Fprintf(&b, `<a href="/p%d">p%d</a>`, i, i)
@@ -177,7 +198,7 @@ func TestCrawlerContract_RespectsMaxPages(t *testing.T) {
 			return
 		}
 		for i := range totalPages {
-			if r.URL.Path == fmt.Sprintf("/p%d", i) {
+			if p == fmt.Sprintf("/p%d", i) {
 				fmt.Fprint(w, `<html><body><p>leaf</p></body></html>`)
 				return
 			}
@@ -185,23 +206,47 @@ func TestCrawlerContract_RespectsMaxPages(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	runCrawlerContract(t, srv,
-		func(headless bool) CrawlerOptions {
-			return CrawlerOptions{
-				Depth: 5, MaxPages: maxPages, Timeout: 30 * time.Second,
-				AllowPrivate: true, Headless: headless,
+	for _, bc := range crawlerBackends() {
+		t.Run(bc.name, func(t *testing.T) {
+			if bc.headless {
+				skipIfNoChrome(t)
 			}
-		},
-		func(t *testing.T, got []ObservedRequest, err error) {
-			t.Helper()
+			// Reset the server counter for each backend sub-test.
+			serverPageFetches.Store(0)
+
+			// Concurrency:1 bounds in-flight overshoot to at most 1 extra
+			// page request beyond the cap trigger, making the margin tight.
+			c := NewCrawler(CrawlerOptions{
+				Depth: 5, MaxPages: maxPages, Timeout: 30 * time.Second,
+				AllowPrivate: true, Headless: bc.headless, Concurrency: 1,
+			})
+			got, err := c.Crawl(context.Background(), srv.URL)
 			if err != nil {
 				t.Fatalf("Crawl error: %v", err)
 			}
-			// Count only distinct page URLs — those whose path is "/" or matches
-			// "/p<digits>" (the fixture's page set). Sub-resource and browser-
-			// internal captures (favicon, about:blank, CDP targets) have paths
-			// that do not match the fixture pattern and are excluded so the bound
-			// holds for both the http and rod backends.
+
+			// Sanity: the seed must have been crawled.
+			if len(got) == 0 {
+				t.Fatal("crawl returned zero results — seed was not crawled")
+			}
+
+			// Primary assertion: the SERVER received at most maxPages+fetchMargin
+			// page requests. This verifies MaxPages bounds actual crawl work, not
+			// just result storage.
+			fetches := int(serverPageFetches.Load())
+			if fetches > maxPages+fetchMargin {
+				t.Errorf("server received %d page fetches, want ≤%d (maxPages=%d + margin=%d) — MaxPages does not bound crawl work",
+					fetches, maxPages+fetchMargin, maxPages, fetchMargin)
+			}
+			// Guard: the crawler stopped far short of totalPages, confirming the
+			// limit is real and not just rounding against a near-totalPages run.
+			if fetches >= totalPages {
+				t.Errorf("server received %d page fetches — as many as totalPages=%d; MaxPages limit had no effect",
+					fetches, totalPages)
+			}
+
+			// Count distinct result page URLs for the result-slice sanity check
+			// (kept as a secondary assertion alongside the server counter).
 			pageURLs := make(map[string]struct{})
 			for _, r := range got {
 				u, err := url.Parse(r.URL)
@@ -209,17 +254,16 @@ func TestCrawlerContract_RespectsMaxPages(t *testing.T) {
 					continue
 				}
 				p := u.Path
-				isPage := p == "/" || isPagePath(p)
-				if isPage {
+				if p == "/" || isPagePath(p) {
 					pageURLs[r.URL] = struct{}{}
 				}
 			}
 			if len(pageURLs) > maxPages {
-				t.Errorf("got %d distinct page URLs, want ≤%d — MaxPages not respected",
+				t.Errorf("result slice has %d distinct page URLs, want ≤%d — MaxPages not respected in results",
 					len(pageURLs), maxPages)
 			}
-		},
-	)
+		})
+	}
 }
 
 // TestCrawlerContract_SendsCustomHeaders asserts that both backends inject
@@ -229,23 +273,35 @@ func TestCrawlerContract_SendsCustomHeaders(t *testing.T) {
 	const headerName = "X-Contract-Test"
 	const headerVal = "hello-from-contract"
 
-	var sawHeader string
+	// sawHeader: header value received on ANY request (seed or followed).
+	// sawHeaderOnP2: header value received specifically on the followed /p2 request.
+	// This ensures the header is injected on followed requests, not only the seed.
+	var sawHeader, sawHeaderOnP2 string
 	var mu sync.Mutex
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		if v := r.Header.Get(headerName); v != "" {
 			sawHeader = v
+			if r.URL.Path == "/p2" {
+				sawHeaderOnP2 = v
+			}
 		}
 		mu.Unlock()
 		w.Header().Set("Content-Type", "text/html")
-		fmt.Fprint(w, `<html><body>ok</body></html>`)
+		switch r.URL.Path {
+		case "/":
+			// Seed links to /p2 so the crawler follows at least one link.
+			fmt.Fprint(w, `<html><body><a href="/p2">page 2</a></body></html>`)
+		default:
+			fmt.Fprint(w, `<html><body>ok</body></html>`)
+		}
 	}))
 	defer srv.Close()
 
 	runCrawlerContract(t, srv,
 		func(headless bool) CrawlerOptions {
 			return CrawlerOptions{
-				Depth: 1, MaxPages: 5, Timeout: 30 * time.Second,
+				Depth: 2, MaxPages: 5, Timeout: 30 * time.Second,
 				AllowPrivate: true, Headless: headless,
 				Headers: map[string]string{headerName: headerVal},
 			}
@@ -257,10 +313,17 @@ func TestCrawlerContract_SendsCustomHeaders(t *testing.T) {
 			}
 			mu.Lock()
 			v := sawHeader
+			v2 := sawHeaderOnP2
 			mu.Unlock()
 			if v != headerVal {
 				t.Errorf("custom header %s not received by server: got %q, want %q",
 					headerName, v, headerVal)
+			}
+			// Assert the header was also received on the followed /p2 request
+			// (not only on the seed), verifying header injection on non-seed pages.
+			if v2 != headerVal {
+				t.Errorf("custom header %s not received on followed /p2 request: got %q, want %q",
+					headerName, v2, headerVal)
 			}
 		},
 	)
@@ -337,9 +400,10 @@ func TestCrawlerContract_RelativeLinksResolvedAgainstFinalURL(t *testing.T) {
 	defer srv.Close()
 
 	// Use a custom server URL with /start suffix so the redirect happens.
+	// runCrawlerContract is not used here because it always seeds with server.URL;
+	// this test requires a non-root seed URL (/start) to exercise redirect resolution.
 	startURL := srv.URL + "/start"
 	for _, bc := range crawlerBackends() {
-		bc := bc
 		t.Run(bc.name, func(t *testing.T) {
 			if bc.headless {
 				skipIfNoChrome(t)
@@ -408,11 +472,34 @@ func TestCrawlerContract_DepthLimit(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Crawl error: %v", err)
 			}
-			// /d3 and /d4 are at depth >2 and must not appear.
+			// Depth semantics: seed "/" is depth 0; each hop increments by 1.
+			// With Depth=2:
+			//   depth 0: /       ← must be visited (seed)
+			//   depth 1: /d1     ← must be visited (one hop from seed)
+			//   depth 2: /d2     ← must be visited (exactly at limit)
+			//   depth 3: /d3     ← must NOT be visited (one beyond limit)
+			//   depth 4: /d4     ← must NOT be visited (two beyond limit)
+			var foundD2, foundD3, foundD4 bool
 			for _, r := range got {
-				if strings.Contains(r.URL, "/d3") || strings.Contains(r.URL, "/d4") {
-					t.Errorf("depth limit breached — URL beyond depth=2 crawled: %s", r.URL)
+				switch {
+				case strings.Contains(r.URL, "/d2"):
+					foundD2 = true
+				case strings.Contains(r.URL, "/d3"):
+					foundD3 = true
+				case strings.Contains(r.URL, "/d4"):
+					foundD4 = true
 				}
+			}
+			// /d2 is exactly at the depth limit and must be reachable.
+			if !foundD2 {
+				t.Error("/d2 (depth=2, at limit) was not crawled — depth limit too aggressive")
+			}
+			// /d3 and /d4 are beyond the depth limit and must not appear.
+			if foundD3 {
+				t.Error("depth limit breached — /d3 (depth=3, beyond limit=2) was crawled")
+			}
+			if foundD4 {
+				t.Error("depth limit breached — /d4 (depth=4, beyond limit=2) was crawled")
 			}
 		},
 	)

--- a/pkg/crawl/contract_test.go
+++ b/pkg/crawl/contract_test.go
@@ -1,0 +1,389 @@
+//go:build integration
+
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// chromeOnce guards a single Chrome availability probe shared across all
+// contract test rows. Probing once avoids launching multiple Chrome processes
+// for the availability check.
+var (
+	chromeOnce sync.Once
+	chromeErr  error
+)
+
+// skipIfNoChrome skips t when a headless Chrome cannot be launched.
+// It uses NewBrowserManager (browser.go:60) as the probe — the same launch
+// path RodCrawler.Crawl uses — so the skip reason matches real runtime
+// behavior. The result is cached in a sync.Once to avoid launching Chrome for
+// every subtest row.
+func skipIfNoChrome(t *testing.T) {
+	t.Helper()
+	chromeOnce.Do(func() {
+		bm, err := NewBrowserManager(BrowserOptions{Headless: true})
+		if err != nil {
+			chromeErr = err
+			return
+		}
+		bm.Close()
+	})
+	if chromeErr != nil {
+		t.Skipf("skipping headless backend: Chrome unavailable: %v", chromeErr)
+	}
+}
+
+// crawlerContractCase is one backend row in the parameterized contract table.
+type crawlerContractCase struct {
+	name     string
+	headless bool
+}
+
+// crawlerBackends returns the two backends to exercise. This whole file is
+// behind `//go:build integration` (matching the repo's Chrome-test convention),
+// so default `make test` never runs it; the rod row additionally self-skips via
+// skipIfNoChrome when Chrome is unavailable under the integration build.
+func crawlerBackends() []crawlerContractCase {
+	return []crawlerContractCase{
+		{name: "http", headless: false},
+		{name: "rod", headless: true},
+	}
+}
+
+// runCrawlerContract runs check against both backends. makeOpts receives the
+// backend's Headless value and returns the full CrawlerOptions for that row.
+// The rod row skips cleanly when Chrome is unavailable.
+func runCrawlerContract(
+	t *testing.T,
+	server *httptest.Server,
+	makeOpts func(headless bool) CrawlerOptions,
+	check func(t *testing.T, got []ObservedRequest, err error),
+) {
+	t.Helper()
+	for _, bc := range crawlerBackends() {
+		bc := bc // capture range variable
+		t.Run(bc.name, func(t *testing.T) {
+			if bc.headless {
+				skipIfNoChrome(t)
+			}
+			c := NewCrawler(makeOpts(bc.headless)) // crawler.go:94 — shared seam
+			got, err := c.Crawl(context.Background(), server.URL)
+			check(t, got, err)
+		})
+	}
+}
+
+// TestCrawlerContract_FollowsLinks asserts that both backends discover and
+// follow <a href> links from an httptest server. This is the most fundamental
+// crawler behavior: the seed page links to /p2 and the crawler must visit it.
+func TestCrawlerContract_FollowsLinks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		switch r.URL.Path {
+		case "/":
+			fmt.Fprint(w, `<html><body><a href="/p2">page 2</a></body></html>`)
+		case "/p2":
+			fmt.Fprint(w, `<html><body><p>page 2</p></body></html>`)
+		}
+	}))
+	defer srv.Close()
+
+	runCrawlerContract(t, srv,
+		func(headless bool) CrawlerOptions {
+			return CrawlerOptions{
+				Depth: 2, MaxPages: 10, Timeout: 30 * time.Second,
+				AllowPrivate: true, Headless: headless,
+			}
+		},
+		func(t *testing.T, got []ObservedRequest, err error) {
+			t.Helper()
+			if err != nil {
+				t.Fatalf("Crawl error: %v", err)
+			}
+			if len(got) < 2 {
+				t.Errorf("got %d requests, want ≥2 (seed + /p2)", len(got))
+			}
+			var foundP2 bool
+			for _, r := range got {
+				if strings.Contains(r.URL, "/p2") {
+					foundP2 = true
+					break
+				}
+			}
+			if !foundP2 {
+				t.Error("/p2 was not crawled — link following broken")
+			}
+		},
+	)
+}
+
+// TestCrawlerContract_RespectsMaxPages asserts that both backends stop after
+// crawling at most MaxPages pages. The fixture serves 50 inter-linked pages;
+// limiting to 5 must cap results well below 50.
+func TestCrawlerContract_RespectsMaxPages(t *testing.T) {
+	const totalPages = 50
+	const maxPages = 5
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		if r.URL.Path == "/" {
+			var b strings.Builder
+			for i := range totalPages {
+				fmt.Fprintf(&b, `<a href="/p%d">p%d</a>`, i, i)
+			}
+			fmt.Fprintf(w, "<html><body>%s</body></html>", b.String())
+			return
+		}
+		for i := range totalPages {
+			if r.URL.Path == fmt.Sprintf("/p%d", i) {
+				fmt.Fprint(w, `<html><body><p>leaf</p></body></html>`)
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	runCrawlerContract(t, srv,
+		func(headless bool) CrawlerOptions {
+			return CrawlerOptions{
+				Depth: 5, MaxPages: maxPages, Timeout: 30 * time.Second,
+				AllowPrivate: true, Headless: headless,
+			}
+		},
+		func(t *testing.T, got []ObservedRequest, err error) {
+			t.Helper()
+			if err != nil {
+				t.Fatalf("Crawl error: %v", err)
+			}
+			// MaxPages bounds the pages crawled, not necessarily each request
+			// (rod may capture sub-resources). The key invariant: far fewer than
+			// totalPages(50) distinct page URLs observed.
+			uniqueURLs := make(map[string]struct{})
+			for _, r := range got {
+				uniqueURLs[r.URL] = struct{}{}
+			}
+			if len(uniqueURLs) > totalPages/2 {
+				t.Errorf("got %d unique URLs, want ≤%d — MaxPages not respected",
+					len(uniqueURLs), totalPages/2)
+			}
+		},
+	)
+}
+
+// TestCrawlerContract_SendsCustomHeaders asserts that both backends inject
+// caller-supplied headers into outbound requests. The fixture records the
+// header value received from the crawler.
+func TestCrawlerContract_SendsCustomHeaders(t *testing.T) {
+	const headerName = "X-Contract-Test"
+	const headerVal = "hello-from-contract"
+
+	var sawHeader string
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		if v := r.Header.Get(headerName); v != "" {
+			sawHeader = v
+		}
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body>ok</body></html>`)
+	}))
+	defer srv.Close()
+
+	runCrawlerContract(t, srv,
+		func(headless bool) CrawlerOptions {
+			return CrawlerOptions{
+				Depth: 1, MaxPages: 5, Timeout: 30 * time.Second,
+				AllowPrivate: true, Headless: headless,
+				Headers: map[string]string{headerName: headerVal},
+			}
+		},
+		func(t *testing.T, got []ObservedRequest, err error) {
+			t.Helper()
+			if err != nil {
+				t.Fatalf("Crawl error: %v", err)
+			}
+			mu.Lock()
+			v := sawHeader
+			mu.Unlock()
+			if v != headerVal {
+				t.Errorf("custom header %s not received by server: got %q, want %q",
+					headerName, v, headerVal)
+			}
+		},
+	)
+}
+
+// TestCrawlerContract_ScopeConfinement asserts the NEGATIVE: neither backend
+// follows cross-origin links. The fixture serves a page linking to an
+// external origin; neither crawler result should contain the off-origin URL.
+//
+// This tests cross-origin LINK confinement enforced at the frontier
+// (scope.go scopeChecker via frontier.Push) — both backends share this guard.
+// It does NOT test redirect-Location SSRF (HTTP-only; see http_crawler_test.go).
+func TestCrawlerContract_ScopeConfinement(t *testing.T) {
+	// A second server plays the role of a different origin.
+	offOrigin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><p>off-origin</p></body></html>`)
+	}))
+	defer offOrigin.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// Page links to both a same-origin page and the off-origin server.
+		fmt.Fprintf(w,
+			`<html><body><a href="/local">local</a><a href="%s/off">off</a></body></html>`,
+			offOrigin.URL,
+		)
+	}))
+	defer srv.Close()
+
+	runCrawlerContract(t, srv,
+		func(headless bool) CrawlerOptions {
+			return CrawlerOptions{
+				Depth: 2, MaxPages: 20, Timeout: 30 * time.Second,
+				Scope: "same-origin", AllowPrivate: true, Headless: headless,
+			}
+		},
+		func(t *testing.T, got []ObservedRequest, err error) {
+			t.Helper()
+			if err != nil {
+				t.Fatalf("Crawl error: %v", err)
+			}
+			// NEGATIVE assertion: no result URL should be on the off-origin server.
+			for _, r := range got {
+				if strings.Contains(r.URL, offOrigin.URL) {
+					t.Errorf("crawler followed cross-origin link — scope confinement broken: %s", r.URL)
+				}
+			}
+		},
+	)
+}
+
+// TestCrawlerContract_RelativeLinksResolvedAgainstFinalURL verifies that
+// relative links are resolved against the post-redirect base URL, not the
+// seed URL. Both backends must fetch /app/next (resolved from /app/ + "next"),
+// not /next (resolved from the seed /start + "next").
+func TestCrawlerContract_RelativeLinksResolvedAgainstFinalURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			http.Redirect(w, r, "/app/", http.StatusFound)
+		case "/app/":
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, `<html><body><a href="next">next</a></body></html>`)
+		case "/app/next":
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, `<html><body><p>correct</p></body></html>`)
+		case "/next":
+			// This path is wrong — relative link resolved against seed, not final URL.
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, `<html><body><p>wrong</p></body></html>`)
+		}
+	}))
+	defer srv.Close()
+
+	// Use a custom server URL with /start suffix so the redirect happens.
+	startURL := srv.URL + "/start"
+	for _, bc := range crawlerBackends() {
+		bc := bc
+		t.Run(bc.name, func(t *testing.T) {
+			if bc.headless {
+				skipIfNoChrome(t)
+			}
+			c := NewCrawler(CrawlerOptions{
+				Depth: 3, MaxPages: 20, Timeout: 30 * time.Second,
+				AllowPrivate: true, Headless: bc.headless,
+			})
+			got, err := c.Crawl(context.Background(), startURL)
+			if err != nil {
+				t.Fatalf("Crawl error: %v", err)
+			}
+			var foundAppNext, foundBadNext bool
+			for _, r := range got {
+				if strings.Contains(r.URL, "/app/next") {
+					foundAppNext = true
+				}
+				if strings.HasSuffix(r.URL, "/next") && !strings.Contains(r.URL, "/app/next") {
+					foundBadNext = true
+				}
+			}
+			if !foundAppNext {
+				t.Error("expected /app/next to be crawled (relative link resolved against final URL)")
+			}
+			if foundBadNext {
+				t.Error("/next was crawled — relative link resolved against seed URL, not post-redirect URL")
+			}
+		})
+	}
+}
+
+// TestCrawlerContract_DepthLimit verifies that both backends respect the Depth
+// limit and do not crawl pages beyond it. The fixture forms a chain of depth-4
+// pages; with Depth=2 only the first two levels should be visited.
+func TestCrawlerContract_DepthLimit(t *testing.T) {
+	// Chain: / → /d1 → /d2 → /d3 → /d4
+	// With Depth:2, /d3 and /d4 must not be visited.
+	const chainLen = 4
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		for i := range chainLen {
+			if r.URL.Path == fmt.Sprintf("/d%d", i) || (i == 0 && r.URL.Path == "/") {
+				next := i + 1
+				if next <= chainLen {
+					fmt.Fprintf(w, `<html><body><a href="/d%d">next</a></body></html>`, next)
+				} else {
+					fmt.Fprint(w, `<html><body><p>end</p></body></html>`)
+				}
+				return
+			}
+		}
+		fmt.Fprint(w, `<html><body><p>leaf</p></body></html>`)
+	}))
+	defer srv.Close()
+
+	runCrawlerContract(t, srv,
+		func(headless bool) CrawlerOptions {
+			return CrawlerOptions{
+				Depth: 2, MaxPages: 100, Timeout: 30 * time.Second,
+				AllowPrivate: true, Headless: headless,
+			}
+		},
+		func(t *testing.T, got []ObservedRequest, err error) {
+			t.Helper()
+			if err != nil {
+				t.Fatalf("Crawl error: %v", err)
+			}
+			// /d3 and /d4 are at depth >2 and must not appear.
+			for _, r := range got {
+				if strings.Contains(r.URL, "/d3") || strings.Contains(r.URL, "/d4") {
+					t.Errorf("depth limit breached — URL beyond depth=2 crawled: %s", r.URL)
+				}
+			}
+		},
+	)
+}

--- a/pkg/crawl/contract_test.go
+++ b/pkg/crawl/contract_test.go
@@ -21,11 +21,31 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+// isPagePath reports whether path matches the fixture's page pattern "/p<digits>".
+// Used by TestCrawlerContract_RespectsMaxPages to distinguish crawled page URLs
+// from sub-resources (favicon, about:blank, CDP targets, etc.).
+func isPagePath(path string) bool {
+	if !strings.HasPrefix(path, "/p") {
+		return false
+	}
+	rest := path[2:]
+	if len(rest) == 0 {
+		return false
+	}
+	for _, c := range rest {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
 
 // chromeOnce guards a single Chrome availability probe shared across all
 // contract test rows. Probing once avoids launching multiple Chrome processes
@@ -177,16 +197,26 @@ func TestCrawlerContract_RespectsMaxPages(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Crawl error: %v", err)
 			}
-			// MaxPages bounds the pages crawled, not necessarily each request
-			// (rod may capture sub-resources). The key invariant: far fewer than
-			// totalPages(50) distinct page URLs observed.
-			uniqueURLs := make(map[string]struct{})
+			// Count only distinct page URLs — those whose path is "/" or matches
+			// "/p<digits>" (the fixture's page set). Sub-resource and browser-
+			// internal captures (favicon, about:blank, CDP targets) have paths
+			// that do not match the fixture pattern and are excluded so the bound
+			// holds for both the http and rod backends.
+			pageURLs := make(map[string]struct{})
 			for _, r := range got {
-				uniqueURLs[r.URL] = struct{}{}
+				u, err := url.Parse(r.URL)
+				if err != nil {
+					continue
+				}
+				p := u.Path
+				isPage := p == "/" || isPagePath(p)
+				if isPage {
+					pageURLs[r.URL] = struct{}{}
+				}
 			}
-			if len(uniqueURLs) > totalPages/2 {
-				t.Errorf("got %d unique URLs, want ≤%d — MaxPages not respected",
-					len(uniqueURLs), totalPages/2)
+			if len(pageURLs) > maxPages {
+				t.Errorf("got %d distinct page URLs, want ≤%d — MaxPages not respected",
+					len(pageURLs), maxPages)
 			}
 		},
 	)

--- a/pkg/crawl/spa_integration_test.go
+++ b/pkg/crawl/spa_integration_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRodCrawler_CapturesSPAFetch regresses LAB-1535: the rod (headless)
+// backend must capture a fetch/XHR POST issued by inline JavaScript at page
+// load. The HTTPCrawler cannot execute JavaScript and is expected to MISS it
+// (documented capability gap).
+//
+// The test serves a minimal SPA from an httptest server — a static HTML page
+// with an inline <script> that calls fetch("/graphql", {method:"POST",...}) on
+// load, mirroring the pattern at test/graphql-server/server.js:213-237 but
+// with zero external dependencies.
+//
+// Closing assertion: hasGraphQLPost(got)==true for the rod backend closes
+// LAB-1535. The negative assertion for the HTTP backend documents the
+// intentional capability gap and fails loudly if the gap assumption ever
+// changes.
+//
+// Chrome must be available; test uses skipIfNoChrome (D1 gate helper) so it
+// skips cleanly when run in Chrome-free CI environments.
+func TestRodCrawler_CapturesSPAFetch(t *testing.T) {
+	skipIfNoChrome(t)
+
+	const spaHTML = `<!DOCTYPE html>
+<html><head></head><body>
+<div id="out"></div>
+<script>
+fetch("/graphql",{
+  method:"POST",
+  headers:{"Content-Type":"application/json"},
+  body:JSON.stringify({query:"{ users { id } }"})
+})
+.then(function(r){return r.json();})
+.then(function(d){document.getElementById("out").textContent="done";});
+</script>
+</body></html>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/graphql" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"data":{"users":[{"id":"1"}]}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, spaHTML)
+	}))
+	defer srv.Close()
+
+	// Rod backend: MUST capture the /graphql POST (LAB-1535).
+	rodCrawler := NewCrawler(CrawlerOptions{
+		Depth:        1,
+		MaxPages:     10,
+		Timeout:      30 * time.Second,
+		Scope:        "same-origin",
+		Headless:     true,
+		AllowPrivate: true,
+	})
+	rodGot, err := rodCrawler.Crawl(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("rod crawl: %v", err)
+	}
+	if !hasGraphQLPost(rodGot) {
+		t.Fatalf("rod backend did not capture the SPA fetch /graphql POST (LAB-1535 not closed); got %d requests: %v",
+			len(rodGot), urlList(rodGot))
+	}
+
+	// HTTP backend: expected to MISS the runtime fetch (no JS execution).
+	// This is a documented capability gap — fail loudly if the assumption changes.
+	httpCrawler := NewCrawler(CrawlerOptions{
+		Depth:        1,
+		MaxPages:     10,
+		Timeout:      30 * time.Second,
+		Scope:        "same-origin",
+		Headless:     false,
+		AllowPrivate: true,
+	})
+	httpGot, _ := httpCrawler.Crawl(context.Background(), srv.URL)
+	if hasGraphQLPost(httpGot) {
+		t.Errorf("HTTPCrawler unexpectedly captured a runtime fetch POST — capability gap assumption changed; update docs/benchmarks/crawler-comparison.md")
+	}
+}
+
+// hasGraphQLPost reports whether any captured request is a POST to a path
+// ending with "/graphql". It is method+path agnostic w.r.t. Source so it
+// works for both "http" and "browser" source values.
+func hasGraphQLPost(reqs []ObservedRequest) bool {
+	for _, r := range reqs {
+		if r.Method == "POST" && strings.HasSuffix(r.URL, "/graphql") {
+			return true
+		}
+	}
+	return false
+}
+
+// urlList returns a human-readable list of URLs in reqs for test failure messages.
+func urlList(reqs []ObservedRequest) []string {
+	out := make([]string, 0, len(reqs))
+	for _, r := range reqs {
+		out = append(out, r.Method+" "+r.URL)
+	}
+	return out
+}

--- a/pkg/crawl/spa_integration_test.go
+++ b/pkg/crawl/spa_integration_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -99,18 +99,32 @@ fetch("/graphql",{
 		Headless:     false,
 		AllowPrivate: true,
 	})
-	httpGot, _ := httpCrawler.Crawl(context.Background(), srv.URL)
+	httpGot, httpErr := httpCrawler.Crawl(context.Background(), srv.URL)
+	if httpErr != nil {
+		t.Fatalf("HTTP crawl error: %v", httpErr)
+	}
+	if len(httpGot) < 1 {
+		t.Fatalf("HTTP crawl returned no results — cannot assert negative (gap assumption test vacuous)")
+	}
 	if hasGraphQLPost(httpGot) {
 		t.Errorf("HTTPCrawler unexpectedly captured a runtime fetch POST — capability gap assumption changed; update docs/benchmarks/crawler-comparison.md")
 	}
 }
 
-// hasGraphQLPost reports whether any captured request is a POST to a path
-// ending with "/graphql". It is method+path agnostic w.r.t. Source so it
-// works for both "http" and "browser" source values.
+// hasGraphQLPost reports whether any captured request is a POST to the path
+// "/graphql". It uses net/url.Parse to match the exact path, avoiding false
+// positives from query strings or trailing slashes (e.g. "/graphql?foo" or
+// "/graphql/"). Works for both "http" and "browser" source values.
 func hasGraphQLPost(reqs []ObservedRequest) bool {
 	for _, r := range reqs {
-		if r.Method == "POST" && strings.HasSuffix(r.URL, "/graphql") {
+		if r.Method != "POST" {
+			continue
+		}
+		u, err := url.Parse(r.URL)
+		if err != nil {
+			continue
+		}
+		if u.Path == "/graphql" {
 			return true
 		}
 	}

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -164,6 +164,29 @@ with open(sys.argv[1]) as f:
 PYEOF
 }
 
+# crawl_backend runs one crawl with an explicit --headless value and writes
+# output to <out>. Only the backend-invariant flags (--headless,
+# --dangerous-allow-private) are fixed here; the caller passes --depth,
+# --max-pages, --timeout, etc. so there are no duplicated/overridden flags.
+# Usage: crawl_backend <base_url> <out_capture> <headless:true|false> <crawl flags...>
+crawl_backend() {
+    local base_url=$1 out=$2 headless=$3; shift 3
+    "$VESPASIAN" crawl "$base_url" -o "$out" \
+        --headless="$headless" \
+        --dangerous-allow-private "$@" 2>&1
+}
+
+# chrome_available returns 0 if Chrome is likely reachable, 1 otherwise.
+# Uses the same heuristics as the Go skipIfNoChrome probe: binary presence or
+# rod's cached Chromium. A non-zero rod-crawl exit is treated as log_warn +
+# skip (not failures++) so unlaunchable-Chrome environments degrade gracefully.
+chrome_available() {
+    command -v google-chrome >/dev/null 2>&1 || \
+    command -v chromium >/dev/null 2>&1 || \
+    command -v chromium-browser >/dev/null 2>&1 || \
+    [ -d "$HOME/.cache/rod/browser" ]
+}
+
 # ──────────────────────────────────────────────────────────────
 # Test functions
 # ──────────────────────────────────────────────────────────────
@@ -187,26 +210,41 @@ test_rest_api() {
 
     log_header "Testing: rest-api (${base_url})"
 
-    # Step 1: Crawl
-    log_info "Crawling ${base_url}..."
-    if ! "$VESPASIAN" crawl "$base_url" \
-        -o "$capture_file" \
-        --depth 2 \
-        --max-pages 50 \
-        --timeout 2m \
-        --dangerous-allow-private \
-        $verbose_flag 2>&1; then
-        log_fail "Crawl failed"
-        set_test_result "rest-api" "FAIL" "?" "?" "$((SECONDS - start))"
-        return 1
+    # Step 1: Crawl — both backends (http and rod).
+    # The http backend (headless=false) is the primary capture used downstream
+    # for spec generation. The rod backend (headless=true) adds a parity check.
+    for hl in false true; do
+        local cap="${target_dir}/capture-${hl}.json"
+        if [ "$hl" = "true" ]; then
+            if ! chrome_available; then
+                log_warn "rest-api[headless=true]: Chrome unavailable, skipping rod backend"
+                continue
+            fi
+        fi
+        log_info "Crawling ${base_url} (headless=${hl})..."
+        if ! crawl_backend "$base_url" "$cap" "$hl" --depth 2 --max-pages 50 --timeout 2m $verbose_flag; then
+            if [ "$hl" = "true" ]; then
+                # Rod crawl failure degrades gracefully — Chrome may be unlaunchable.
+                log_warn "rest-api[headless=true]: crawl failed (Chrome may be unlaunchable), skipping rod backend"
+                continue
+            fi
+            log_fail "Crawl failed (headless=${hl})"
+            set_test_result "rest-api" "FAIL" "?" "?" "$((SECONDS - start))"
+            return 1
+        fi
+        local n; n=$(json_len "$cap")
+        log_info "rest-api[headless=${hl}]: ${n} requests captured"
+        if ! validate_capture "$cap" 3; then
+            failures=$((failures + 1))
+        fi
+    done
+
+    # Use the http capture for spec generation (primary artifact).
+    if [ ! -f "$capture_file" ]; then
+        cp "${target_dir}/capture-false.json" "$capture_file" 2>/dev/null || true
     fi
 
-    # Step 2: Validate capture
-    if ! validate_capture "$capture_file" 3; then
-        failures=$((failures + 1))
-    fi
-
-    # Step 3: Generate OpenAPI spec
+    # Step 2: Generate OpenAPI spec from http capture
     log_info "Generating OpenAPI spec..."
     if ! "$VESPASIAN" generate rest "$capture_file" \
         -o "$spec_file" \
@@ -217,7 +255,7 @@ test_rest_api() {
         return 1
     fi
 
-    # Step 4: Validate spec
+    # Step 3: Validate spec
     if ! validate_openapi_structure "$spec_file"; then
         failures=$((failures + 1))
     fi
@@ -281,16 +319,29 @@ test_soap_service() {
             -o /dev/null 2>/dev/null || true
     done
 
-    # Crawl the service (will capture the WSDL page and index)
-    log_info "Crawling ${base_url}..."
-    if ! "$VESPASIAN" crawl "$base_url" \
-        -o "$capture_file" \
-        --depth 2 \
-        --max-pages 20 \
-        --timeout 1m \
-        --dangerous-allow-private \
-        $verbose_flag 2>&1; then
-        log_warn "Crawl returned non-zero (may still have partial results)"
+    # Crawl the service — both backends for parity.
+    for hl in false true; do
+        local cap="${target_dir}/capture-${hl}.json"
+        if [ "$hl" = "true" ]; then
+            if ! chrome_available; then
+                log_warn "soap-service[headless=true]: Chrome unavailable, skipping rod backend"
+                continue
+            fi
+        fi
+        log_info "Crawling ${base_url} (headless=${hl})..."
+        if ! crawl_backend "$base_url" "$cap" "$hl" --depth 2 --max-pages 20 --timeout 1m $verbose_flag; then
+            if [ "$hl" = "true" ]; then
+                log_warn "soap-service[headless=true]: crawl failed (Chrome may be unlaunchable), skipping rod backend"
+                continue
+            fi
+            log_warn "Crawl returned non-zero (may still have partial results)"
+        fi
+        local n; n=$(json_len "$cap")
+        log_info "soap-service[headless=${hl}]: ${n} requests captured"
+    done
+    # Use http capture as the crawl artifact for subsequent steps.
+    if [ -f "${target_dir}/capture-false.json" ]; then
+        cp "${target_dir}/capture-false.json" "$capture_file"
     fi
 
     # Also import the SOAP traffic directly if crawl didn't capture it.
@@ -782,6 +833,39 @@ PYEOF
         # Not a hard failure — inference fallback is valid behavior
     else
         log_ok "Introspection check: $introspection_check"
+    fi
+
+    # Step 7: Rod crawl of / — assert SPA /graphql POST is captured (LAB-1535).
+    # The http backend is expected to miss runtime fetch() calls; rod captures them.
+    log_info "Rod crawl of ${base_url}/ (SPA fetch capture — LAB-1535)..."
+    if ! chrome_available; then
+        log_warn "graphql-server[rod-spa]: Chrome unavailable, skipping SPA fetch assertion"
+    else
+        local rod_capture="${target_dir}/capture-rod.json"
+        local rod_ok=true
+        if ! crawl_backend "$base_url" "$rod_capture" true --depth 2 --max-pages 20 --timeout 1m $verbose_flag; then
+            log_warn "graphql-server[rod-spa]: crawl failed (Chrome may be unlaunchable), skipping SPA assertion"
+            rod_ok=false
+        fi
+        if [ "$rod_ok" = true ] && [ -f "$rod_capture" ]; then
+            local rod_n; rod_n=$(json_len "$rod_capture")
+            log_info "graphql-server[headless=true]: ${rod_n} requests captured"
+            # Assert /graphql POST is present (SPA fetch captured by rod).
+            local found_graphql; found_graphql=$(python3 - "$rod_capture" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    reqs = json.load(f)
+found = any(r.get("method","").upper()=="POST" and r.get("url","").endswith("/graphql") for r in reqs)
+print("yes" if found else "no")
+PYEOF
+            )
+            if [ "$found_graphql" = "yes" ]; then
+                log_ok "graphql-server[rod-spa]: /graphql POST captured (LAB-1535 confirmed)"
+            else
+                log_warn "graphql-server[rod-spa]: /graphql POST NOT captured in rod crawl (SPA fetch missed)"
+                failures=$((failures + 1))
+            fi
+        fi
     fi
 
     local expected_count

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -177,9 +177,13 @@ crawl_backend() {
 }
 
 # chrome_available returns 0 if Chrome is likely reachable, 1 otherwise.
-# Uses the same heuristics as the Go skipIfNoChrome probe: binary presence or
-# rod's cached Chromium. A non-zero rod-crawl exit is treated as log_warn +
-# skip (not failures++) so unlaunchable-Chrome environments degrade gracefully.
+# This is a best-effort shell heuristic (binary presence or rod's cached
+# Chromium directory) and may diverge from the Go skipIfNoChrome probe, which
+# actually attempts to launch a headless browser via NewBrowserManager. A false
+# positive here (chrome_available returns 0 but Chrome fails to launch) degrades
+# to a log_warn + skip, never a hard failure. A false negative causes the rod
+# backend to be skipped even when Chrome is present; re-run with an explicit
+# Chrome binary on PATH if rod skips unexpectedly.
 chrome_available() {
     command -v google-chrome >/dev/null 2>&1 || \
     command -v chromium >/dev/null 2>&1 || \
@@ -239,10 +243,9 @@ test_rest_api() {
         fi
     done
 
-    # Use the http capture for spec generation (primary artifact).
-    if [ ! -f "$capture_file" ]; then
-        cp "${target_dir}/capture-false.json" "$capture_file" 2>/dev/null || true
-    fi
+    # Use the http capture for spec generation (primary artifact). Copy
+    # unconditionally so a stale capture.json from a prior run is never used.
+    cp "${target_dir}/capture-false.json" "$capture_file" 2>/dev/null || true
 
     # Step 2: Generate OpenAPI spec from http capture
     log_info "Generating OpenAPI spec..."
@@ -847,23 +850,30 @@ PYEOF
             log_warn "graphql-server[rod-spa]: crawl failed (Chrome may be unlaunchable), skipping SPA assertion"
             rod_ok=false
         fi
-        if [ "$rod_ok" = true ] && [ -f "$rod_capture" ]; then
-            local rod_n; rod_n=$(json_len "$rod_capture")
-            log_info "graphql-server[headless=true]: ${rod_n} requests captured"
-            # Assert /graphql POST is present (SPA fetch captured by rod).
-            local found_graphql; found_graphql=$(python3 - "$rod_capture" << 'PYEOF'
+        if [ "$rod_ok" = true ]; then
+            if [ ! -f "$rod_capture" ]; then
+                # Crawl reported success but wrote no capture file — count as failure
+                # so the missing assertion is not silently skipped.
+                log_fail "graphql-server[rod-spa]: rod crawl succeeded but capture file absent: ${rod_capture}"
+                failures=$((failures + 1))
+            else
+                local rod_n; rod_n=$(json_len "$rod_capture")
+                log_info "graphql-server[headless=true]: ${rod_n} requests captured"
+                # Assert /graphql POST is present (SPA fetch captured by rod).
+                local found_graphql; found_graphql=$(python3 - "$rod_capture" << 'PYEOF'
 import json, sys
 with open(sys.argv[1]) as f:
     reqs = json.load(f)
 found = any(r.get("method","").upper()=="POST" and r.get("url","").endswith("/graphql") for r in reqs)
 print("yes" if found else "no")
 PYEOF
-            )
-            if [ "$found_graphql" = "yes" ]; then
-                log_ok "graphql-server[rod-spa]: /graphql POST captured (LAB-1535 confirmed)"
-            else
-                log_warn "graphql-server[rod-spa]: /graphql POST NOT captured in rod crawl (SPA fetch missed)"
-                failures=$((failures + 1))
+                )
+                if [ "$found_graphql" = "yes" ]; then
+                    log_ok "graphql-server[rod-spa]: /graphql POST captured (LAB-1535 confirmed)"
+                else
+                    log_warn "graphql-server[rod-spa]: /graphql POST NOT captured in rod crawl (SPA fetch missed)"
+                    failures=$((failures + 1))
+                fi
             fi
         fi
     fi

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -862,9 +862,11 @@ PYEOF
                 # Assert /graphql POST is present (SPA fetch captured by rod).
                 local found_graphql; found_graphql=$(python3 - "$rod_capture" << 'PYEOF'
 import json, sys
+from urllib.parse import urlparse
 with open(sys.argv[1]) as f:
     reqs = json.load(f)
-found = any(r.get("method","").upper()=="POST" and r.get("url","").endswith("/graphql") for r in reqs)
+# Exact path match (parity with Go hasGraphQLPost) — avoids /api/graphql or query-string variants.
+found = any(r.get("method","").upper()=="POST" and urlparse(r.get("url","")).path=="/graphql" for r in reqs)
 print("yes" if found else "no")
 PYEOF
                 )

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -342,7 +342,9 @@ test_soap_service() {
         local n; n=$(json_len "$cap")
         log_info "soap-service[headless=${hl}]: ${n} requests captured"
     done
-    # Use http capture as the crawl artifact for subsequent steps.
+    # Retain the http capture as this target's crawl artifact (parity with the
+    # other targets / manual inspection). WSDL generation below does NOT use it —
+    # it uses the synthetic $soap_capture built next.
     if [ -f "${target_dir}/capture-false.json" ]; then
         cp "${target_dir}/capture-false.json" "$capture_file"
     fi
@@ -860,7 +862,12 @@ PYEOF
                 local rod_n; rod_n=$(json_len "$rod_capture")
                 log_info "graphql-server[headless=true]: ${rod_n} requests captured"
                 # Assert /graphql POST is present (SPA fetch captured by rod).
-                local found_graphql; found_graphql=$(python3 - "$rod_capture" << 'PYEOF'
+                # `|| echo "error"` keeps this on the file's defensive convention
+                # (cf. json_field/json_len): without it, a python failure (e.g. an
+                # empty capture serialized as JSON `null`, which is not iterable)
+                # would abort the whole suite under `set -e` instead of failing the
+                # assertion.
+                local found_graphql; found_graphql=$(python3 - "$rod_capture" << 'PYEOF' || echo "error"
 import json, sys
 from urllib.parse import urlparse
 with open(sys.argv[1]) as f:
@@ -872,6 +879,9 @@ PYEOF
                 )
                 if [ "$found_graphql" = "yes" ]; then
                     log_ok "graphql-server[rod-spa]: /graphql POST captured (LAB-1535 confirmed)"
+                elif [ "$found_graphql" = "error" ]; then
+                    log_fail "graphql-server[rod-spa]: could not parse rod capture for /graphql POST assertion"
+                    failures=$((failures + 1))
                 else
                     log_warn "graphql-server[rod-spa]: /graphql POST NOT captured in rod crawl (SPA fetch missed)"
                     failures=$((failures + 1))


### PR DESCRIPTION
## Summary

Crawler 4/5 (LAB-2787) — test migration + parity benchmarks. Since #132 removed Katana per ADR LAB-2784, "parity" here is **RodCrawler (headless go-rod) vs HTTPCrawler (stdlib net/http)** — the two retained backends. No Katana baseline (scope interpretation A, confirmed with maintainer).

## What's here
- **Parameterized contract tests** (`pkg/crawl/contract_test.go`, `//go:build integration`): one `runCrawlerContract` helper drives **both** backends via `NewCrawler` — link-following, max-pages, custom headers, scope confinement, relative-URL-vs-final-URL, depth. Integration-tagged to match the repo's existing Chrome-test convention (`engine_integration_test.go`), so default `make test` stays Chrome-free and fast (~2s).
  - Scope-confinement asserts the invariant **both** backends honor (no cross-origin/private URL captured), not the HTTP-specific stderr — Chrome does its own networking and the rod path has no Go dial pin (documented in #132).
- **LAB-1535 closed** (`pkg/crawl/spa_integration_test.go`, `//go:build integration`): rod captures an inline-script runtime `fetch('/graphql', POST)`; HTTP misses it (documented capability gap, asserted loudly).
- **Benchmarks** (`pkg/crawl/bench_test.go`): deterministic `httptest` fixture; `BenchmarkHTTPCrawl` vs `BenchmarkRodCrawl` report `captured/op`, `ns/op`, `heapbytes/op`; race-safe.
- **Live harness** (`test/run-live-tests.sh`): rest-api/soap crawled with both `--headless` backends (rod self-skips without Chrome); rod SPA-XHR assertion for graphql-server.
- **Doc** (`docs/benchmarks/crawler-comparison.md`): factual Rod-vs-HTTP comparison + capability gap.

## Benchmark snapshot (local, deterministic fixture)
| Backend | captured/op | ns/op | mem |
|---|---|---|---|
| HTTPCrawler | 21 | ~2.4 ms | ~786 KB |
| RodCrawler | 42 | ~11.2 s | ~6.8 MB |

Rod captures 2× the requests (Chrome fetches sub-resources / runtime XHR) at ~4500× the wall-clock and ~9× the memory — the fast-static vs full-JS tradeoff.

## Verification
- `make check` green (default, Chrome-free).
- `go test -tags=integration ./pkg/crawl/` — contract (both backends) + SPA suites pass (Chrome via cached Chromium).
- `bash -n test/run-live-tests.sh` clean.

## Notes
- The parity/SPA suites are `//go:build integration` (repo convention). The default CI gate (`make test`) does **not** run integration tests, so a Chrome-equipped integration CI job is needed to make this matrix gate PRs — tracked separately in LAB-4012.
- 3 pre-existing lint findings surface only under `--build-tags=integration` in `engine_integration_test.go` (not this PR's code; not in the default lint gate).

## Tickets
- Closes [LAB-2787](https://linear.app/praetorianlabs/issue/LAB-2787)
- Closes [LAB-1535](https://linear.app/praetorianlabs/issue/LAB-1535) (SPA XHR/fetch captured by rod backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
