### PR TITLE
ci: converge go-sec.yml reusable to v2.6.6

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-sec.yml@c1a6ca690193bc4bbc5ee55d903f8ea17a37cd35  # v2.6.2
+    uses: praetorian-inc/public-workflows/.github/workflows/go-sec.yml@9391f462483f0ca025fbbb57bfb0f9f9561e1b6a  # v2.6.6
     permissions:
       contents: read
       pull-requests: read     # go-sec.yml preflight reads PR files + repo tree


### PR DESCRIPTION
Pin-only convergence of the `go-sec.yml` reusable to **v2.6.6** (`9391f46`), the current canonical public-workflows tag.

**Why safe:** go-sec.yml content is byte-identical v2.6.3→v2.6.6 (blob `d991c6fa`). This pin carries the GHAS-403 visibility guard (auto-skip SARIF upload on non-public repos, `fail-on-findings`, `has_go_sources` skip — PRs #90/#91) plus print-findings-to-log observability (PR #92). **No caller inputs changed**; existing `with:` and `permissions:` blocks are untouched. Pin-only PR → preflight skips lint/scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)