### PR TITLE
feat(rest): make slug path-merging opt-in (to avoid aggressive path normalization) (LAB-4107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,10 @@ The `query_params` field is `map[string][]string` (multi-value). Capture files g
 
 | Command   | Purpose |
 |-----------|---------|
-| `scan`    | Full pipeline: crawl + classify + probe + generate. Flags: `--analyze-js` (default true), `--fetch-sourcemaps` (default true) |
+| `scan`    | Full pipeline: crawl + classify + probe + generate. Flags: `--analyze-js` (default true), `--fetch-sourcemaps` (default true), `--merge-slugs` (default false), `--slug-threshold` (default 2) |
 | `crawl`   | Capture traffic via headless browser → capture.json. Flags: `--analyze-js` (default true), `--fetch-sourcemaps` (default true) |
 | `import`  | Convert Burp XML / HAR / mitmproxy → capture.json |
-| `generate` | Produce spec from capture.json (REST→OpenAPI, GraphQL→SDL, WSDL→WSDL). Flags: `--analyze-js` (default true), `--fetch-sourcemaps` (default false) |
+| `generate` | Produce spec from capture.json (REST→OpenAPI, GraphQL→SDL, WSDL→WSDL). Flags: `--analyze-js` (default true), `--fetch-sourcemaps` (default false), `--merge-slugs` (default false), `--slug-threshold` (default 2) |
 | `version` | Show version information |
 
 ## Test Infrastructure

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ IDs (numeric, UUID, hashes like `/users/42`) are always normalized to parameters
 - For Blog/CMS content, you should use `--merge-slugs`, which will produce: `/posts/hello-world`, `/posts/my-trip` → `/posts/{postSlug}`
 
 
-Optionally, when using `--merge-slug`, you can also configure `--slug-threshold` (default 2) to set how many distinct values must appear at a position before merging paths into a slug; higher is more conservative.
+Optionally, when using `--merge-slugs`, you can also configure `--slug-threshold` (default 2) to set how many distinct values must appear at a position before merging paths into a slug; higher is more conservative.
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,8 @@ vespasian --no-banner scan https://app.example.com -o api.yaml
 
 IDs (numeric, UUID, hashes like `/users/42`) are always normalized to parameters regardless of flags. Observation-based "slug" merging is opt-in via `--merge-slugs` (off by default):
 
-- Feature routes (default, kept separate): `/feature/login`, `/feature/export` stay distinct (default behavior)
-- For Blog/CMS content, you should use `--merge-slugs`, which will produce: `/posts/hello-world`, `/posts/my-trip` → `/posts/{postSlug}`
-
+- Feature routes (default): `/feature/login`, `/feature/export` stay distinct.
+- Blog/CMS content (use `--merge-slugs`): `/posts/hello-world`, `/posts/my-trip` → `/posts/{postSlug}`
 
 Optionally, when using `--merge-slugs`, you can also configure `--slug-threshold` (default 2) to set how many distinct values must appear at a position before merging paths into a slug; higher is more conservative.
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ vespasian scan https://app.example.com -v -o api.yaml
 vespasian --no-banner scan https://app.example.com -o api.yaml
 ```
 
+#### Path normalization & `--merge-slugs`
+
+IDs (numeric, UUID, hashes like `/users/42`) are always normalized to parameters regardless of flags. Observation-based "slug" merging is opt-in via `--merge-slugs` (off by default):
+
+- Feature routes (default, kept separate): `/feature/login`, `/feature/export` stay distinct (default behavior)
+- For Blog/CMS content, you should use `--merge-slugs`, which will produce: `/posts/hello-world`, `/posts/my-trip` → `/posts/{postSlug}`
+
+
+Optionally, when using `--merge-slug`, you can also configure `--slug-threshold` (default 2) to set how many distinct values must appear at a position before merging paths into a slug; higher is more conservative.
+
 ## Use Cases
 
 ### Penetration Testing without API Documentation

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -287,7 +287,7 @@ type CrawlOptions struct {
 // SlugOptions holds the path-normalization flags shared by GenerateCmd and ScanCmd.
 type SlugOptions struct {
 	MergeSlugs    bool `name:"merge-slugs" help:"Enable slug-based path merging (off by default). See README for when to use this vs. distinct endpoint preservation."`
-	SlugThreshold int  `name:"slug-threshold" default:"2" help:"How many distinct values must appear at a path position before --merge-slugs collapses it into a {slug} parameter. Higher = more conservative (needs more samples before merging), which helps on sparse captures. Ignored unless --merge-slugs is set. Minimum 2."`
+	SlugThreshold int  `name:"slug-threshold" default:"2" help:"Distinct values required at a path position before --merge-slugs collapses it; higher is more conservative (minimum 2). See README."`
 }
 
 // setupForceExitHandler spawns a goroutine that waits for the first signal

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -286,7 +286,7 @@ type CrawlOptions struct {
 
 // SlugOptions holds the path-normalization flags shared by GenerateCmd and ScanCmd.
 type SlugOptions struct {
-	MergeSlugs    bool `name:"merge-slugs" help:"Collapse sibling paths whose varying segment looks like content (a \"slug\") into one {slug} parameter. Off by default. USE IT when scanning slug-driven content where each path is the same endpoint with different data (e.g. a blog or CMS): /posts/hello-world,/posts/my-trip -> /posts/{postSlug}. LEAVE IT OFF when distinct path segments are distinct endpoints you don't want to lose (e.g. /feature/login,/feature/export stay separate). Note: numeric/UUID/hash IDs (/users/42) are always normalized regardless of this flag."`
+	MergeSlugs    bool `name:"merge-slugs" help:"Enable slug-based path merging (off by default). See README for when to use this vs. distinct endpoint preservation."`
 	SlugThreshold int  `name:"slug-threshold" default:"2" help:"How many distinct values must appear at a path position before --merge-slugs collapses it into a {slug} parameter. Higher = more conservative (needs more samples before merging), which helps on sparse captures. Ignored unless --merge-slugs is set. Minimum 2."`
 }
 
@@ -526,6 +526,10 @@ const maxCaptureSize = 100 * 1024 * 1024
 
 // Run executes the generate command.
 func (c *GenerateCmd) Run() (err error) {
+	if err := validateSlugThreshold(c.APIType, c.MergeSlugs, c.SlugThreshold); err != nil {
+		return err
+	}
+
 	f, err := os.Open(c.Capture)
 	if err != nil {
 		return fmt.Errorf("open capture file: %w", err)
@@ -604,6 +608,10 @@ type ScanCmd struct {
 // Run executes the scan command (crawl + generate pipeline).
 func (c *ScanCmd) Run() error { //nolint:gocyclo // top-level orchestration
 	if err := validateURL(c.URL); err != nil {
+		return err
+	}
+
+	if err := validateSlugThreshold(c.APIType, c.MergeSlugs, c.SlugThreshold); err != nil {
 		return err
 	}
 
@@ -785,6 +793,21 @@ func augmentAll(ctx context.Context, requests []crawl.ObservedRequest, js jsAnal
 	return requests
 }
 
+// validateSlugThreshold rejects --slug-threshold < 2 when --merge-slugs is on.
+// wsdl/graphql ignore slug options, so they are exempt to avoid a misleading
+// error. Called early in GenerateCmd.Run and ScanCmd.Run so the crawl/file I/O
+// never starts on an invalid flag combination, and again inside generateSpec to
+// cover direct callers.
+func validateSlugThreshold(apiType string, mergeSlugs bool, slugThreshold int) error {
+	if apiType == apiTypeWSDL || apiType == apiTypeGraphQL {
+		return nil
+	}
+	if mergeSlugs && slugThreshold < 2 {
+		return fmt.Errorf("--slug-threshold must be >= 2")
+	}
+	return nil
+}
+
 // generateSpec runs the classify → probe → generate pipeline. It trusts its
 // caller to have already augmented requests with static-HTML form
 // observations AND JS-bundle static analysis — both ScanCmd and GenerateCmd
@@ -795,10 +818,10 @@ func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, opts ge
 	if classifiers == nil {
 		return nil, fmt.Errorf("unsupported API type: %q", opts.APIType)
 	}
-	// Reject <2 loudly at the CLI boundary; the rest package additionally
-	// clamps <2 to 2 defensively for non-CLI callers of NormalizeOptions.
-	if opts.MergeSlugs && opts.SlugThreshold < 2 {
-		return nil, fmt.Errorf("--slug-threshold must be >= 2")
+	// REST-scoped: wsdl/graphql ignore slug options (see validateSlugThreshold).
+	// The rest package additionally clamps <2 to 2 for non-CLI callers.
+	if err := validateSlugThreshold(opts.APIType, opts.MergeSlugs, opts.SlugThreshold); err != nil {
+		return nil, err
 	}
 	classified := classify.RunClassifiers(classifiers, requests, opts.Confidence)
 	if opts.Deduplicate {

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -503,6 +503,8 @@ type GenerateCmd struct {
 	Verbose               bool    `short:"v" help:"Enable verbose logging"`
 	AnalyzeJS             bool    `name:"analyze-js"       default:"true"  help:"Statically analyze JS bundles in the imported capture (when present)."`
 	FetchSourcemaps       bool    `name:"fetch-sourcemaps" default:"false" help:"When --analyze-js is set, fetch .js.map sourcemaps referenced via //# sourceMappingURL= comments. Default false on generate (offline-friendly)."`
+	MergeSlugs            bool    `name:"merge-slugs" help:"Collapse sibling paths whose varying segment looks like content (a \"slug\") into one {slug} parameter. Off by default. USE IT when scanning slug-driven content where each path is the same endpoint with different data (e.g. a blog or CMS): /posts/hello-world,/posts/my-trip -> /posts/{postSlug}. LEAVE IT OFF when distinct path segments are distinct endpoints you don't want to lose (e.g. /feature/login,/feature/export stay separate). Note: numeric/UUID/hash IDs (/users/42) are always normalized regardless of this flag."`
+	SlugThreshold         int     `name:"slug-threshold" default:"2" help:"How many distinct values must appear at a path position before --merge-slugs collapses it into a {slug} parameter. Higher = more conservative (needs more samples before merging), which helps on sparse captures. Ignored unless --merge-slugs is set. Minimum 2."`
 }
 
 // API type constants used for classification routing and generation.
@@ -561,12 +563,14 @@ func (c *GenerateCmd) Run() (err error) {
 	})
 
 	spec, err := generateSpec(ctx, requests, generateSpecOptions{
-		APIType:      c.APIType,
-		Confidence:   c.Confidence,
-		Probe:        c.Probe,
-		Deduplicate:  c.Deduplicate,
-		AllowPrivate: c.DangerousAllowPrivate,
-		Verbose:      c.Verbose,
+		APIType:       c.APIType,
+		Confidence:    c.Confidence,
+		Probe:         c.Probe,
+		Deduplicate:   c.Deduplicate,
+		AllowPrivate:  c.DangerousAllowPrivate,
+		Verbose:       c.Verbose,
+		MergeSlugs:    c.MergeSlugs,
+		SlugThreshold: c.SlugThreshold,
 	})
 	if err != nil {
 		return err
@@ -586,6 +590,8 @@ type ScanCmd struct {
 	Probe                 bool    `default:"true" help:"Enable endpoint probing"`
 	Deduplicate           bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
 	DangerousAllowPrivate bool    `help:"Disable SSRF protection for crawling and probes, allowing private/localhost targets (localhost, 127.0.0.1, RFC1918, link-local). Required when the seed URL is a private host, otherwise the crawl exits with an error and captures nothing. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
+	MergeSlugs            bool    `name:"merge-slugs" help:"Collapse sibling paths whose varying segment looks like content (a \"slug\") into one {slug} parameter. Off by default. USE IT when scanning slug-driven content where each path is the same endpoint with different data (e.g. a blog or CMS): /posts/hello-world,/posts/my-trip -> /posts/{postSlug}. LEAVE IT OFF when distinct path segments are distinct endpoints you don't want to lose (e.g. /feature/login,/feature/export stay separate). Note: numeric/UUID/hash IDs (/users/42) are always normalized regardless of this flag."`
+	SlugThreshold         int     `name:"slug-threshold" default:"2" help:"How many distinct values must appear at a path position before --merge-slugs collapses it into a {slug} parameter. Higher = more conservative (needs more samples before merging), which helps on sparse captures. Ignored unless --merge-slugs is set. Minimum 2."`
 
 	CrawlOptions
 }
@@ -684,12 +690,14 @@ func (c *ScanCmd) Run() error { //nolint:gocyclo // top-level orchestration
 	defer genStop()
 
 	spec, err := generateSpec(genCtx, requests, generateSpecOptions{
-		APIType:      apiType,
-		Confidence:   c.Confidence,
-		Probe:        c.Probe,
-		Deduplicate:  c.Deduplicate,
-		AllowPrivate: c.DangerousAllowPrivate,
-		Verbose:      c.Verbose,
+		APIType:       apiType,
+		Confidence:    c.Confidence,
+		Probe:         c.Probe,
+		Deduplicate:   c.Deduplicate,
+		AllowPrivate:  c.DangerousAllowPrivate,
+		Verbose:       c.Verbose,
+		MergeSlugs:    c.MergeSlugs,
+		SlugThreshold: c.SlugThreshold,
 	})
 	if err != nil {
 		return err
@@ -726,12 +734,14 @@ func main() {
 // generateSpecOptions holds parameters for generateSpec, avoiding consecutive
 // bool arguments that are easy to transpose at call sites.
 type generateSpecOptions struct {
-	APIType      string
-	Confidence   float64
-	Probe        bool
-	Deduplicate  bool
-	AllowPrivate bool
-	Verbose      bool
+	APIType       string
+	Confidence    float64
+	Probe         bool
+	Deduplicate   bool
+	AllowPrivate  bool
+	Verbose       bool
+	MergeSlugs    bool
+	SlugThreshold int
 }
 
 // augmentWithStaticForms appends synthetic ObservedRequests parsed from HTML
@@ -775,10 +785,13 @@ func augmentAll(ctx context.Context, requests []crawl.ObservedRequest, js jsAnal
 // observations AND JS-bundle static analysis — both ScanCmd and GenerateCmd
 // call augmentAll (which performs both stages in order) before invoking this
 // function.
-func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, opts generateSpecOptions) ([]byte, error) {
+func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, opts generateSpecOptions) ([]byte, error) { //nolint:gocyclo // classify → probe → generate orchestration
 	classifiers := classifiersForType(opts.APIType)
 	if classifiers == nil {
 		return nil, fmt.Errorf("unsupported API type: %q", opts.APIType)
+	}
+	if opts.MergeSlugs && opts.SlugThreshold < 2 {
+		return nil, fmt.Errorf("--slug-threshold must be >= 2")
 	}
 	classified := classify.RunClassifiers(classifiers, requests, opts.Confidence)
 	if opts.Deduplicate {
@@ -828,7 +841,7 @@ func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, opts ge
 		classified = enriched
 	}
 
-	gen, err := generate.Get(opts.APIType)
+	gen, err := generate.Get(opts.APIType, generate.Options{MergeSlugs: opts.MergeSlugs, SlugThreshold: opts.SlugThreshold})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -841,7 +841,7 @@ func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, opts ge
 		classified = enriched
 	}
 
-	gen, err := generate.Get(opts.APIType, generate.Options{MergeSlugs: opts.MergeSlugs, SlugThreshold: opts.SlugThreshold})
+	gen, err := generate.GetWithOptions(opts.APIType, generate.Options{MergeSlugs: opts.MergeSlugs, SlugThreshold: opts.SlugThreshold})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -284,6 +284,12 @@ type CrawlOptions struct {
 	FetchSourcemaps bool          `name:"fetch-sourcemaps" default:"true"  help:"When --analyze-js is set, fetch .js.map sourcemaps referenced via //# sourceMappingURL= comments to recover original sources."`
 }
 
+// SlugOptions holds the path-normalization flags shared by GenerateCmd and ScanCmd.
+type SlugOptions struct {
+	MergeSlugs    bool `name:"merge-slugs" help:"Collapse sibling paths whose varying segment looks like content (a \"slug\") into one {slug} parameter. Off by default. USE IT when scanning slug-driven content where each path is the same endpoint with different data (e.g. a blog or CMS): /posts/hello-world,/posts/my-trip -> /posts/{postSlug}. LEAVE IT OFF when distinct path segments are distinct endpoints you don't want to lose (e.g. /feature/login,/feature/export stay separate). Note: numeric/UUID/hash IDs (/users/42) are always normalized regardless of this flag."`
+	SlugThreshold int  `name:"slug-threshold" default:"2" help:"How many distinct values must appear at a path position before --merge-slugs collapses it into a {slug} parameter. Higher = more conservative (needs more samples before merging), which helps on sparse captures. Ignored unless --merge-slugs is set. Minimum 2."`
+}
+
 // setupForceExitHandler spawns a goroutine that waits for the first signal
 // to be handled (ctx.Done), then registers for a second SIGINT/SIGTERM and
 // force-exits the process. This avoids a race where both the graceful handler
@@ -503,8 +509,8 @@ type GenerateCmd struct {
 	Verbose               bool    `short:"v" help:"Enable verbose logging"`
 	AnalyzeJS             bool    `name:"analyze-js"       default:"true"  help:"Statically analyze JS bundles in the imported capture (when present)."`
 	FetchSourcemaps       bool    `name:"fetch-sourcemaps" default:"false" help:"When --analyze-js is set, fetch .js.map sourcemaps referenced via //# sourceMappingURL= comments. Default false on generate (offline-friendly)."`
-	MergeSlugs            bool    `name:"merge-slugs" help:"Collapse sibling paths whose varying segment looks like content (a \"slug\") into one {slug} parameter. Off by default. USE IT when scanning slug-driven content where each path is the same endpoint with different data (e.g. a blog or CMS): /posts/hello-world,/posts/my-trip -> /posts/{postSlug}. LEAVE IT OFF when distinct path segments are distinct endpoints you don't want to lose (e.g. /feature/login,/feature/export stay separate). Note: numeric/UUID/hash IDs (/users/42) are always normalized regardless of this flag."`
-	SlugThreshold         int     `name:"slug-threshold" default:"2" help:"How many distinct values must appear at a path position before --merge-slugs collapses it into a {slug} parameter. Higher = more conservative (needs more samples before merging), which helps on sparse captures. Ignored unless --merge-slugs is set. Minimum 2."`
+
+	SlugOptions
 }
 
 // API type constants used for classification routing and generation.
@@ -590,10 +596,9 @@ type ScanCmd struct {
 	Probe                 bool    `default:"true" help:"Enable endpoint probing"`
 	Deduplicate           bool    `default:"true" help:"Deduplicate classified endpoints before probing"`
 	DangerousAllowPrivate bool    `help:"Disable SSRF protection for crawling and probes, allowing private/localhost targets (localhost, 127.0.0.1, RFC1918, link-local). Required when the seed URL is a private host, otherwise the crawl exits with an error and captures nothing. WARNING: Do not use on production systems." name:"dangerous-allow-private"`
-	MergeSlugs            bool    `name:"merge-slugs" help:"Collapse sibling paths whose varying segment looks like content (a \"slug\") into one {slug} parameter. Off by default. USE IT when scanning slug-driven content where each path is the same endpoint with different data (e.g. a blog or CMS): /posts/hello-world,/posts/my-trip -> /posts/{postSlug}. LEAVE IT OFF when distinct path segments are distinct endpoints you don't want to lose (e.g. /feature/login,/feature/export stay separate). Note: numeric/UUID/hash IDs (/users/42) are always normalized regardless of this flag."`
-	SlugThreshold         int     `name:"slug-threshold" default:"2" help:"How many distinct values must appear at a path position before --merge-slugs collapses it into a {slug} parameter. Higher = more conservative (needs more samples before merging), which helps on sparse captures. Ignored unless --merge-slugs is set. Minimum 2."`
 
 	CrawlOptions
+	SlugOptions
 }
 
 // Run executes the scan command (crawl + generate pipeline).
@@ -790,6 +795,8 @@ func generateSpec(ctx context.Context, requests []crawl.ObservedRequest, opts ge
 	if classifiers == nil {
 		return nil, fmt.Errorf("unsupported API type: %q", opts.APIType)
 	}
+	// Reject <2 loudly at the CLI boundary; the rest package additionally
+	// clamps <2 to 2 defensively for non-CLI callers of NormalizeOptions.
 	if opts.MergeSlugs && opts.SlugThreshold < 2 {
 		return nil, fmt.Errorf("--slug-threshold must be >= 2")
 	}

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -731,6 +731,19 @@ func TestCrawlOptions_Embedded(t *testing.T) {
 	}
 }
 
+// TestSlugOptions_Embedded verifies GenerateCmd and ScanCmd expose the embedded
+// SlugOptions fields directly, the promotion their Run() methods rely on to
+// forward c.MergeSlugs / c.SlugThreshold into generateSpec.
+func TestSlugOptions_Embedded(t *testing.T) {
+	g := &GenerateCmd{SlugOptions: SlugOptions{MergeSlugs: true, SlugThreshold: 4}}
+	require.True(t, g.MergeSlugs)
+	require.Equal(t, 4, g.SlugThreshold)
+
+	s := &ScanCmd{SlugOptions: SlugOptions{MergeSlugs: true, SlugThreshold: 7}}
+	require.True(t, s.MergeSlugs)
+	require.Equal(t, 7, s.SlugThreshold)
+}
+
 // TestDangerousAllowPrivate_GenerateSpec tests generateSpec with allowPrivate=true.
 func TestDangerousAllowPrivate_GenerateSpec(t *testing.T) {
 	requests := []crawl.ObservedRequest{

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -133,6 +133,68 @@ func TestGenerateSpec_MergeSlugsWiring(t *testing.T) {
 	require.Contains(t, onStr, "/api/users/{userId}")
 }
 
+// TestValidateSlugThreshold covers the wsdl/graphql exemption and the
+// apiType x mergeSlugs x threshold matrix for the slug-threshold guard.
+func TestValidateSlugThreshold(t *testing.T) {
+	tests := []struct {
+		name          string
+		apiType       string
+		mergeSlugs    bool
+		slugThreshold int
+		wantErr       bool
+	}{
+		{"rest merge threshold 1 rejected", apiTypeREST, true, 1, true},
+		{"rest merge threshold 0 rejected", apiTypeREST, true, 0, true},
+		{"rest merge threshold 2 ok", apiTypeREST, true, 2, false},
+		{"rest merge off threshold 1 ignored", apiTypeREST, false, 1, false},
+		{"auto merge threshold 1 rejected (avoids wasted crawl)", apiTypeAuto, true, 1, true},
+		{"wsdl merge threshold 1 exempt", apiTypeWSDL, true, 1, false},
+		{"graphql merge threshold 1 exempt", apiTypeGraphQL, true, 1, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSlugThreshold(tt.apiType, tt.mergeSlugs, tt.slugThreshold)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "--slug-threshold must be >= 2")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestGenerateCmdRun_RejectsSlugThresholdBeforeFileIO proves the slug-threshold
+// guard fires before the capture file is opened: the missing file never
+// produces an open error because validation rejects the flag first.
+func TestGenerateCmdRun_RejectsSlugThresholdBeforeFileIO(t *testing.T) {
+	cmd := &GenerateCmd{
+		APIType:     apiTypeREST,
+		Capture:     filepath.Join(t.TempDir(), "does-not-exist.json"),
+		SlugOptions: SlugOptions{MergeSlugs: true, SlugThreshold: 1},
+	}
+	err := cmd.Run()
+	require.Error(t, err)
+	// Early-validation contract: fail on the flag before touching the (missing) file.
+	require.Contains(t, err.Error(), "--slug-threshold must be >= 2")
+	require.NotContains(t, err.Error(), "open capture file")
+}
+
+// TestScanCmdRun_RejectsSlugThresholdBeforeCrawl proves the slug-threshold
+// guard fires before any browser/crawl. The URL is valid, so validateURL
+// passes; a valid URL ordered after the crawl would attempt a real crawl
+// instead of returning the slug error fast.
+func TestScanCmdRun_RejectsSlugThresholdBeforeCrawl(t *testing.T) {
+	cmd := &ScanCmd{
+		URL:         "https://example.com",
+		APIType:     apiTypeAuto,
+		SlugOptions: SlugOptions{MergeSlugs: true, SlugThreshold: 1},
+	}
+	err := cmd.Run()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--slug-threshold must be >= 2")
+}
+
 func TestValidateURL(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -38,21 +38,22 @@ import (
 // siblingSlugRequests returns two sibling REST requests whose only varying
 // path segment looks like a content slug. Default normalization keeps both
 // paths; --merge-slugs collapses them to /api/posts/{postSlug}.
-func siblingSlugRequests() []crawl.ObservedRequest {
-	mk := func(url string) crawl.ObservedRequest {
-		return crawl.ObservedRequest{
-			Method:  "GET",
-			URL:     url,
-			Headers: map[string]string{"Content-Type": "application/json"},
-			Response: crawl.ObservedResponse{
-				StatusCode:  200,
-				ContentType: "application/json",
-			},
-		}
+func jsonGetRequest(url string) crawl.ObservedRequest {
+	return crawl.ObservedRequest{
+		Method:  "GET",
+		URL:     url,
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Response: crawl.ObservedResponse{
+			StatusCode:  200,
+			ContentType: "application/json",
+		},
 	}
+}
+
+func siblingSlugRequests() []crawl.ObservedRequest {
 	return []crawl.ObservedRequest{
-		mk("https://example.com/api/posts/hello-world"),
-		mk("https://example.com/api/posts/my-trip"),
+		jsonGetRequest("https://example.com/api/posts/hello-world"),
+		jsonGetRequest("https://example.com/api/posts/my-trip"),
 	}
 }
 
@@ -87,8 +88,14 @@ func TestGenerateSpec_SlugThresholdValidation(t *testing.T) {
 // TestGenerateSpec_MergeSlugsWiring proves the --merge-slugs flag flows
 // cmd -> generateSpec -> GetWithOptions -> generator and changes the output.
 func TestGenerateSpec_MergeSlugsWiring(t *testing.T) {
-	requests := siblingSlugRequests()
+	// Include numeric-ID siblings to prove regex ID normalization is always
+	// on, independent of --merge-slugs, through the full CLI wiring.
+	requests := append(siblingSlugRequests(),
+		jsonGetRequest("https://example.com/api/users/42"),
+		jsonGetRequest("https://example.com/api/users/99"),
+	)
 
+	// SlugThreshold intentionally omitted: it is ignored when MergeSlugs is false.
 	off, err := generateSpec(context.Background(), requests, generateSpecOptions{
 		APIType:     "rest",
 		Confidence:  0.5,
@@ -101,6 +108,7 @@ func TestGenerateSpec_MergeSlugsWiring(t *testing.T) {
 	require.Contains(t, offStr, "/api/posts/hello-world")
 	require.Contains(t, offStr, "/api/posts/my-trip")
 	require.NotContains(t, offStr, "{postSlug}")
+	require.Contains(t, offStr, "/api/users/{userId}")
 
 	on, err := generateSpec(context.Background(), requests, generateSpecOptions{
 		APIType:       "rest",

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -181,18 +181,20 @@ func TestGenerateCmdRun_RejectsSlugThresholdBeforeFileIO(t *testing.T) {
 }
 
 // TestScanCmdRun_RejectsSlugThresholdBeforeCrawl proves the slug-threshold
-// guard fires before any browser/crawl. The URL is valid, so validateURL
-// passes; a valid URL ordered after the crawl would attempt a real crawl
-// instead of returning the slug error fast.
+// guard fires before any browser/crawl. A malformed header would make
+// setupBrowserAndSignals (which runs AFTER the guard, before the crawl) fail
+// with a distinct "invalid header" error; asserting the error is EXACTLY the
+// slug error proves the guard short-circuited first. If the early guard were
+// removed, the header error would surface instead. No network/Chrome needed.
 func TestScanCmdRun_RejectsSlugThresholdBeforeCrawl(t *testing.T) {
 	cmd := &ScanCmd{
-		URL:         "https://example.com",
-		APIType:     apiTypeAuto,
-		SlugOptions: SlugOptions{MergeSlugs: true, SlugThreshold: 1},
+		URL:          "https://example.com",
+		APIType:      apiTypeAuto,
+		CrawlOptions: CrawlOptions{Header: []string{"no-colon-header"}},
+		SlugOptions:  SlugOptions{MergeSlugs: true, SlugThreshold: 1},
 	}
 	err := cmd.Run()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "--slug-threshold must be >= 2")
+	require.EqualError(t, err, "--slug-threshold must be >= 2")
 }
 
 func TestValidateURL(t *testing.T) {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -35,9 +35,8 @@ import (
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
 )
 
-// siblingSlugRequests returns two sibling REST requests whose only varying
-// path segment looks like a content slug. Default normalization keeps both
-// paths; --merge-slugs collapses them to /api/posts/{postSlug}.
+// jsonGetRequest builds a minimal GET ObservedRequest for the given URL with a
+// JSON response.
 func jsonGetRequest(url string) crawl.ObservedRequest {
 	return crawl.ObservedRequest{
 		Method:  "GET",
@@ -50,6 +49,9 @@ func jsonGetRequest(url string) crawl.ObservedRequest {
 	}
 }
 
+// siblingSlugRequests returns two sibling REST requests whose only varying
+// path segment looks like a content slug. Default normalization keeps both
+// paths; --merge-slugs collapses them to /api/posts/{postSlug}.
 func siblingSlugRequests() []crawl.ObservedRequest {
 	return []crawl.ObservedRequest{
 		jsonGetRequest("https://example.com/api/posts/hello-world"),
@@ -74,7 +76,7 @@ func TestGenerateSpec_SlugThresholdValidation(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "--slug-threshold must be >= 2")
 
-	_, err = generateSpec(context.Background(), requests, generateSpecOptions{
+	off, err := generateSpec(context.Background(), requests, generateSpecOptions{
 		APIType:       "rest",
 		Confidence:    0.5,
 		Probe:         false,
@@ -83,6 +85,11 @@ func TestGenerateSpec_SlugThresholdValidation(t *testing.T) {
 		SlugThreshold: 1,
 	})
 	require.NoError(t, err)
+	// threshold=1 is ignored when merging is off: both siblings survive, no collapse.
+	offStr := string(off)
+	require.Contains(t, offStr, "/api/posts/hello-world")
+	require.Contains(t, offStr, "/api/posts/my-trip")
+	require.NotContains(t, offStr, "{postSlug}")
 }
 
 // TestGenerateSpec_MergeSlugsWiring proves the --merge-slugs flag flows
@@ -123,6 +130,7 @@ func TestGenerateSpec_MergeSlugsWiring(t *testing.T) {
 	require.Contains(t, onStr, "/api/posts/{postSlug}")
 	require.NotContains(t, onStr, "/api/posts/hello-world")
 	require.NotContains(t, onStr, "/api/posts/my-trip")
+	require.Contains(t, onStr, "/api/users/{userId}")
 }
 
 func TestValidateURL(t *testing.T) {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -28,11 +28,93 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/praetorian-inc/vespasian/pkg/analyze"
 	"github.com/praetorian-inc/vespasian/pkg/crawl"
 )
+
+// siblingSlugRequests returns two sibling REST requests whose only varying
+// path segment looks like a content slug. Default normalization keeps both
+// paths; --merge-slugs collapses them to /api/posts/{postSlug}.
+func siblingSlugRequests() []crawl.ObservedRequest {
+	mk := func(url string) crawl.ObservedRequest {
+		return crawl.ObservedRequest{
+			Method:  "GET",
+			URL:     url,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Response: crawl.ObservedResponse{
+				StatusCode:  200,
+				ContentType: "application/json",
+			},
+		}
+	}
+	return []crawl.ObservedRequest{
+		mk("https://example.com/api/posts/hello-world"),
+		mk("https://example.com/api/posts/my-trip"),
+	}
+}
+
+// TestGenerateSpec_SlugThresholdValidation covers the CLI-boundary guard in
+// generateSpec: --slug-threshold < 2 is rejected when merging is on, and
+// ignored when merging is off.
+func TestGenerateSpec_SlugThresholdValidation(t *testing.T) {
+	requests := siblingSlugRequests()
+
+	_, err := generateSpec(context.Background(), requests, generateSpecOptions{
+		APIType:       "rest",
+		Confidence:    0.5,
+		Probe:         false,
+		Deduplicate:   true,
+		MergeSlugs:    true,
+		SlugThreshold: 1,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--slug-threshold must be >= 2")
+
+	_, err = generateSpec(context.Background(), requests, generateSpecOptions{
+		APIType:       "rest",
+		Confidence:    0.5,
+		Probe:         false,
+		Deduplicate:   true,
+		MergeSlugs:    false,
+		SlugThreshold: 1,
+	})
+	require.NoError(t, err)
+}
+
+// TestGenerateSpec_MergeSlugsWiring proves the --merge-slugs flag flows
+// cmd -> generateSpec -> GetWithOptions -> generator and changes the output.
+func TestGenerateSpec_MergeSlugsWiring(t *testing.T) {
+	requests := siblingSlugRequests()
+
+	off, err := generateSpec(context.Background(), requests, generateSpecOptions{
+		APIType:     "rest",
+		Confidence:  0.5,
+		Probe:       false,
+		Deduplicate: true,
+		MergeSlugs:  false,
+	})
+	require.NoError(t, err)
+	offStr := string(off)
+	require.Contains(t, offStr, "/api/posts/hello-world")
+	require.Contains(t, offStr, "/api/posts/my-trip")
+	require.NotContains(t, offStr, "{postSlug}")
+
+	on, err := generateSpec(context.Background(), requests, generateSpecOptions{
+		APIType:       "rest",
+		Confidence:    0.5,
+		Probe:         false,
+		Deduplicate:   true,
+		MergeSlugs:    true,
+		SlugThreshold: 2,
+	})
+	require.NoError(t, err)
+	onStr := string(on)
+	require.Contains(t, onStr, "/api/posts/{postSlug}")
+	require.NotContains(t, onStr, "/api/posts/hello-world")
+}
 
 func TestValidateURL(t *testing.T) {
 	tests := []struct {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -114,6 +114,7 @@ func TestGenerateSpec_MergeSlugsWiring(t *testing.T) {
 	onStr := string(on)
 	require.Contains(t, onStr, "/api/posts/{postSlug}")
 	require.NotContains(t, onStr, "/api/posts/hello-world")
+	require.NotContains(t, onStr, "/api/posts/my-trip")
 }
 
 func TestValidateURL(t *testing.T) {

--- a/pkg/generate/doc.go
+++ b/pkg/generate/doc.go
@@ -21,5 +21,6 @@
 //   - [graphql]: GraphQL SDL from introspection or traffic inference
 //   - [wsdl]: WSDL XML from SOAP traffic
 //
-// Use [Get] to retrieve a generator by API type name.
+// Use [Get] to retrieve a generator by API type name, or [GetWithOptions] to
+// pass [Options] (e.g. REST slug-merging configuration) to the generator.
 package generate

--- a/pkg/generate/registry.go
+++ b/pkg/generate/registry.go
@@ -22,11 +22,21 @@ import (
 	"github.com/praetorian-inc/vespasian/pkg/generate/wsdl"
 )
 
+// Options configures spec generation. Only the REST/OpenAPI generator
+// consumes these today; wsdl and graphql ignore them.
+type Options struct {
+	// MergeSlugs enables observation-based slug merging in REST path normalization.
+	MergeSlugs bool
+	// SlugThreshold is the minimum distinct values at a path position before
+	// merging; clamped to >=2 downstream. Ignored unless MergeSlugs is set.
+	SlugThreshold int
+}
+
 // Get returns a SpecGenerator for the given API type.
-func Get(apiType string) (SpecGenerator, error) {
+func Get(apiType string, opts Options) (SpecGenerator, error) {
 	switch apiType {
 	case "rest":
-		return &rest.OpenAPIGenerator{}, nil
+		return &rest.OpenAPIGenerator{MergeSlugs: opts.MergeSlugs, SlugThreshold: opts.SlugThreshold}, nil
 	case "wsdl":
 		return &wsdl.Generator{}, nil
 	case "graphql":

--- a/pkg/generate/registry.go
+++ b/pkg/generate/registry.go
@@ -32,8 +32,14 @@ type Options struct {
 	SlugThreshold int
 }
 
-// Get returns a SpecGenerator for the given API type.
-func Get(apiType string, opts Options) (SpecGenerator, error) {
+// Get returns a SpecGenerator for the given API type using default options.
+func Get(apiType string) (SpecGenerator, error) {
+	return GetWithOptions(apiType, Options{})
+}
+
+// GetWithOptions returns a SpecGenerator for the given API type configured
+// with the supplied options.
+func GetWithOptions(apiType string, opts Options) (SpecGenerator, error) {
 	switch apiType {
 	case "rest":
 		return &rest.OpenAPIGenerator{MergeSlugs: opts.MergeSlugs, SlugThreshold: opts.SlugThreshold}, nil

--- a/pkg/generate/registry_test.go
+++ b/pkg/generate/registry_test.go
@@ -17,7 +17,21 @@ package generate
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/vespasian/pkg/generate/rest"
 )
+
+func TestGetWithOptions_PropagatesToREST(t *testing.T) {
+	gen, err := GetWithOptions("rest", Options{MergeSlugs: true, SlugThreshold: 5})
+	require.NoError(t, err)
+
+	rg, ok := gen.(*rest.OpenAPIGenerator)
+	require.True(t, ok)
+	require.True(t, rg.MergeSlugs)
+	require.Equal(t, 5, rg.SlugThreshold)
+}
 
 func TestGet(t *testing.T) {
 	tests := []struct {

--- a/pkg/generate/registry_test.go
+++ b/pkg/generate/registry_test.go
@@ -34,7 +34,7 @@ func TestGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gen, err := Get(tt.apiType, Options{})
+			gen, err := Get(tt.apiType)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Get(%q) error = %v, wantErr %v", tt.apiType, err, tt.wantErr)
 				return

--- a/pkg/generate/registry_test.go
+++ b/pkg/generate/registry_test.go
@@ -34,7 +34,7 @@ func TestGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gen, err := Get(tt.apiType)
+			gen, err := Get(tt.apiType, Options{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Get(%q) error = %v, wantErr %v", tt.apiType, err, tt.wantErr)
 				return

--- a/pkg/generate/rest/doc.go
+++ b/pkg/generate/rest/doc.go
@@ -23,7 +23,8 @@
 //     accepts a population of observed paths and returns a map of input path
 //     to template path, performing both single-path regex detection (UUIDs,
 //     MongoDB ObjectIDs, numeric IDs, short hex hashes, base64/base64url
-//     tokens) and observation-based slug detection across the population.
+//     tokens) and, when opt-in slug detection is enabled via options
+//     (mergeSlugs), observation-based slug detection across the population.
 //     Known literals (`me`, `current`, `self`, `new`, `list`, `search`) are
 //     preserved against all forms of parameterization.
 //   - [NormalizePathWithNames] is a single-path convenience that performs

--- a/pkg/generate/rest/normalize.go
+++ b/pkg/generate/rest/normalize.go
@@ -267,11 +267,26 @@ type segLoc struct {
 	pathIdx, segIdx int
 }
 
+// normalizeOptions controls observation-based slug promotion in
+// NormalizePathsWithNames. Regex-based ID detection (UUID, numeric, ObjectID,
+// short hex, base64) always runs and is NOT affected by these options.
+type normalizeOptions struct {
+	// mergeSlugs enables observation-based promotion of varying literal
+	// segments to {slug} parameters. Off by default so distinct endpoints
+	// that merely share a path prefix are not collapsed.
+	mergeSlugs bool
+	// slugThreshold is the minimum number of distinct values that must be
+	// observed at a position before it is promoted to a slug. Values < 2 are
+	// clamped to 2 — a threshold of 1 would merge every sibling segment.
+	slugThreshold int
+}
+
 // NormalizePathsWithNames classifies each input path's segments by regex /
-// literal kind, then performs observation-based detection: a position whose
-// literal segment value varies across paths sharing the same prefix and
-// suffix shape (and same path length) is promoted to a slug-style
-// parameter. Promotion runs to a fixed point — promoting one position can
+// literal kind, then — when opts.mergeSlugs is set — performs
+// observation-based detection: a position whose literal segment value varies
+// across paths sharing the same prefix and suffix shape (and same path
+// length), across at least opts.slugThreshold distinct values, is promoted to
+// a slug-style parameter. Promotion runs to a fixed point — promoting one position can
 // change the shape of a sibling position, exposing additional varying
 // buckets — so the function iterates until no further promotions occur.
 //
@@ -294,25 +309,30 @@ type segLoc struct {
 // today; downstream consumers receive a partially-normalized result. A
 // debug logging hook for cap-saturation events is a reasonable future
 // addition but is not in scope for LAB-2107.
-func NormalizePathsWithNames(paths []string) map[string]string {
+func NormalizePathsWithNames(paths []string, opts normalizeOptions) map[string]string {
 	if len(paths) == 0 {
 		return map[string]string{}
 	}
+	if opts.slugThreshold < 2 {
+		opts.slugThreshold = 2
+	}
 
 	infos := classifyPaths(paths)
-	for i := 0; i < maxPromotionRounds; i++ {
-		varying := findVaryingPositions(infos)
-		if len(varying) == 0 {
-			break
-		}
-		// Defensive guard: if findVaryingPositions returned a non-empty
-		// set, promoteVaryingPositions is expected to convert at least one
-		// segment (the find phase only surfaces literal candidates).
-		// promoteVaryingPositions returning false here would indicate an
-		// internal contract break; we exit the loop safely rather than
-		// spin.
-		if !promoteVaryingPositions(infos, varying) {
-			break
+	if opts.mergeSlugs {
+		for i := 0; i < maxPromotionRounds; i++ {
+			varying := findVaryingPositions(infos, opts.slugThreshold)
+			if len(varying) == 0 {
+				break
+			}
+			// Defensive guard: if findVaryingPositions returned a non-empty
+			// set, promoteVaryingPositions is expected to convert at least one
+			// segment (the find phase only surfaces literal candidates).
+			// promoteVaryingPositions returning false here would indicate an
+			// internal contract break; we exit the loop safely rather than
+			// spin.
+			if !promoteVaryingPositions(infos, varying) {
+				break
+			}
 		}
 	}
 	unifyMixedKindsAtSamePosition(infos)
@@ -399,8 +419,9 @@ func classifyPaths(paths []string) []pathInfo {
 
 // findVaryingPositions returns the set of position buckets whose literal
 // segments vary across observations and therefore qualify for slug-style
-// parameter promotion.
-func findVaryingPositions(infos []pathInfo) map[posKey]struct{} {
+// parameter promotion. A bucket qualifies only when it holds at least
+// threshold distinct values.
+func findVaryingPositions(infos []pathInfo, threshold int) map[posKey]struct{} {
 	values := make(map[posKey]map[string]struct{})
 	for _, info := range infos {
 		for i, seg := range info.segments {
@@ -418,7 +439,7 @@ func findVaryingPositions(infos []pathInfo) map[posKey]struct{} {
 	}
 	varying := make(map[posKey]struct{})
 	for key, set := range values {
-		if len(set) >= 2 {
+		if len(set) >= threshold {
 			varying[key] = struct{}{}
 		}
 	}

--- a/pkg/generate/rest/normalize.go
+++ b/pkg/generate/rest/normalize.go
@@ -267,25 +267,25 @@ type segLoc struct {
 	pathIdx, segIdx int
 }
 
-// normalizeOptions controls observation-based slug promotion in
+// NormalizeOptions controls observation-based slug promotion in
 // NormalizePathsWithNames. Regex-based ID detection (UUID, numeric, ObjectID,
 // short hex, base64) always runs and is NOT affected by these options.
-type normalizeOptions struct {
-	// mergeSlugs enables observation-based promotion of varying literal
+type NormalizeOptions struct {
+	// MergeSlugs enables observation-based promotion of varying literal
 	// segments to {slug} parameters. Off by default so distinct endpoints
 	// that merely share a path prefix are not collapsed.
-	mergeSlugs bool
-	// slugThreshold is the minimum number of distinct values that must be
+	MergeSlugs bool
+	// SlugThreshold is the minimum number of distinct values that must be
 	// observed at a position before it is promoted to a slug. Values < 2 are
 	// clamped to 2 — a threshold of 1 would merge every sibling segment.
-	slugThreshold int
+	SlugThreshold int
 }
 
 // NormalizePathsWithNames classifies each input path's segments by regex /
-// literal kind, then — when opts.mergeSlugs is set — performs
+// literal kind, then — when opts.MergeSlugs is set — performs
 // observation-based detection: a position whose literal segment value varies
 // across paths sharing the same prefix and suffix shape (and same path
-// length), across at least opts.slugThreshold distinct values, is promoted to
+// length), across at least opts.SlugThreshold distinct values, is promoted to
 // a slug-style parameter. Promotion runs to a fixed point — promoting one position can
 // change the shape of a sibling position, exposing additional varying
 // buckets — so the function iterates until no further promotions occur.
@@ -309,18 +309,18 @@ type normalizeOptions struct {
 // today; downstream consumers receive a partially-normalized result. A
 // debug logging hook for cap-saturation events is a reasonable future
 // addition but is not in scope for LAB-2107.
-func NormalizePathsWithNames(paths []string, opts normalizeOptions) map[string]string {
+func NormalizePathsWithNames(paths []string, opts NormalizeOptions) map[string]string {
 	if len(paths) == 0 {
 		return map[string]string{}
 	}
-	if opts.slugThreshold < 2 {
-		opts.slugThreshold = 2
+	if opts.SlugThreshold < 2 {
+		opts.SlugThreshold = 2
 	}
 
 	infos := classifyPaths(paths)
-	if opts.mergeSlugs {
+	if opts.MergeSlugs {
 		for i := 0; i < maxPromotionRounds; i++ {
-			varying := findVaryingPositions(infos, opts.slugThreshold)
+			varying := findVaryingPositions(infos, opts.SlugThreshold)
 			if len(varying) == 0 {
 				break
 			}

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -19,7 +19,11 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func mergeOpts() normalizeOptions { return normalizeOptions{mergeSlugs: true} }
 
 func TestNormalizePath_UUID(t *testing.T) {
 	tests := []struct {
@@ -469,7 +473,7 @@ func TestNormalizePathsWithNames_SlugObservation(t *testing.T) {
 		"/articles/my-second-post",
 		"/articles/yet-another-post",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 
 	// All three slug-style observations should collapse to a single
 	// parameterized path because the position varies across observations.
@@ -494,7 +498,7 @@ func TestNormalizePathsWithNames_LiteralNotPromotedAcrossPositions(t *testing.T)
 		"/users/jane/profile",
 		"/users/bob/profile",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 
 	// `me` is a known literal and must not be parameterized even though
 	// `jane` and `bob` vary at the same position. The two non-literal
@@ -520,7 +524,7 @@ func TestNormalizePathsWithNames_RootResourceNeverPromoted(t *testing.T) {
 		"/articles",
 		"/sessions",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	for _, p := range paths {
 		if got[p] != p {
 			t.Errorf("root resource %q was promoted: got %q", p, got[p])
@@ -542,7 +546,7 @@ func TestNormalizePathsWithNames_ResourceTypeBehindPathPrefixNeverPromoted(t *te
 		{"/rest/users", "/rest/posts"},
 	}
 	for _, paths := range groups {
-		got := NormalizePathsWithNames(paths)
+		got := NormalizePathsWithNames(paths, mergeOpts())
 		for _, p := range paths {
 			if got[p] != p {
 				t.Errorf("scaffold-prefixed resource %q was promoted: got %q", p, got[p])
@@ -559,7 +563,7 @@ func TestNormalizePathsWithNames_VersionPrefixBoundary(t *testing.T) {
 	// still suppress promotion of the immediately-following resource segment.
 	t.Run("v0 is not a scaffold so users segment is observable", func(t *testing.T) {
 		paths := []string{"/v0/users/alice", "/v0/users/bob", "/v0/users/carol"}
-		got := NormalizePathsWithNames(paths)
+		got := NormalizePathsWithNames(paths, mergeOpts())
 		for _, p := range paths {
 			if got[p] != "/v0/users/{userSlug}" {
 				t.Errorf("path %q normalized to %q, want /v0/users/{userSlug}", p, got[p])
@@ -568,7 +572,7 @@ func TestNormalizePathsWithNames_VersionPrefixBoundary(t *testing.T) {
 	})
 	t.Run("v01 with leading zero is not a scaffold", func(t *testing.T) {
 		paths := []string{"/v01/users/alice", "/v01/users/bob", "/v01/users/carol"}
-		got := NormalizePathsWithNames(paths)
+		got := NormalizePathsWithNames(paths, mergeOpts())
 		for _, p := range paths {
 			if got[p] != "/v01/users/{userSlug}" {
 				t.Errorf("path %q normalized to %q, want /v01/users/{userSlug}", p, got[p])
@@ -577,7 +581,7 @@ func TestNormalizePathsWithNames_VersionPrefixBoundary(t *testing.T) {
 	})
 	t.Run("v001 with multiple leading zeros is not a scaffold", func(t *testing.T) {
 		paths := []string{"/v001/items/foo", "/v001/items/bar", "/v001/items/baz"}
-		got := NormalizePathsWithNames(paths)
+		got := NormalizePathsWithNames(paths, mergeOpts())
 		for _, p := range paths {
 			if got[p] != "/v001/items/{itemSlug}" {
 				t.Errorf("path %q normalized to %q, want /v001/items/{itemSlug}", p, got[p])
@@ -589,7 +593,7 @@ func TestNormalizePathsWithNames_VersionPrefixBoundary(t *testing.T) {
 		// ResourceTypeBehindPathPrefixNeverPromoted, but worth a direct
 		// contrast against the v0 case to make the boundary explicit).
 		paths := []string{"/v1/users", "/v1/posts", "/v1/articles"}
-		got := NormalizePathsWithNames(paths)
+		got := NormalizePathsWithNames(paths, mergeOpts())
 		for _, p := range paths {
 			if got[p] != p {
 				t.Errorf("v1 scaffold path %q was promoted: got %q", p, got[p])
@@ -607,7 +611,7 @@ func TestNormalizePathsWithNames_PromotesAfterPathPrefix(t *testing.T) {
 		"/api/users/bob",
 		"/api/users/carol",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	for _, p := range paths {
 		if got[p] != "/api/users/{userSlug}" {
 			t.Errorf("path %q normalized to %q, want /api/users/{userSlug}", p, got[p])
@@ -626,7 +630,7 @@ func TestNormalizePathsWithNames_MultiVaryingPositionsWithOverlap(t *testing.T) 
 		"/repos/bob/proj1",
 		"/repos/bob/proj2",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	for _, p := range paths {
 		want := "/repos/{repoSlug}/{repoSlug2}"
 		if got[p] != want {
@@ -646,7 +650,7 @@ func TestNormalizePathsWithNames_DiagonalObservationsLimitation(t *testing.T) {
 		"/repos/bob/proj2",
 		"/repos/carol/proj3",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	for _, p := range paths {
 		if got[p] != p {
 			t.Errorf("diagonal-only observation %q unexpectedly promoted to %q (algorithm limitation expected)", p, got[p])
@@ -658,7 +662,7 @@ func TestNormalizePathsWithNames_SinglePathNoSlug(t *testing.T) {
 	// One observation cannot demonstrate variation, so the literal segment
 	// must be preserved.
 	paths := []string{"/articles/my-only-post"}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	if got["/articles/my-only-post"] != "/articles/my-only-post" {
 		t.Errorf("single observation parameterized: %v", got)
 	}
@@ -679,7 +683,7 @@ func TestNormalizePathsWithNames_MixedKindsUnifyAcrossAllRegexKinds(t *testing.T
 		"/articles/AbCdEf12",                             // short hex (uppercase + digit)
 		"/articles/42",                                   // numeric
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	const want = "/articles/{articleSlug}"
 	for _, p := range paths {
 		if got[p] != want {
@@ -699,7 +703,7 @@ func TestNormalizePathsWithNames_SlugOnlyNoOpUnification(t *testing.T) {
 		"/items/bar-2",
 		"/items/baz-3",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	for _, p := range paths {
 		if got[p] != "/items/{itemSlug}" {
 			t.Errorf("path %q normalized to %q, want /items/{itemSlug}", p, got[p])
@@ -715,7 +719,7 @@ func TestNormalizePathsWithNames_RegressionUUIDAndNumeric(t *testing.T) {
 		"/posts/1",
 		"/posts/2",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	want := map[string]string{
 		"/users/42": "/users/{userId}",
 		"/users/43": "/users/{userId}",
@@ -745,7 +749,7 @@ func TestNormalizePathsWithNames_MixedKinds(t *testing.T) {
 		"/articles/507f1f77bcf86cd799439011", // ObjectID
 		"/articles/another-post",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	want := map[string]string{
 		"/articles/my-first-post":            "/articles/{articleSlug}",
 		"/articles/507f1f77bcf86cd799439011": "/articles/{articleSlug}",
@@ -770,7 +774,7 @@ func TestNormalizePathsWithNames_MixedKindsWithoutSlugObservation(t *testing.T) 
 		"/articles/my-only-post",             // 1 literal observation, not promoted
 		"/articles/507f1f77bcf86cd799439011", // ObjectID, regex-classified
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	want := map[string]string{
 		"/articles/my-only-post":             "/articles/my-only-post",
 		"/articles/507f1f77bcf86cd799439011": "/articles/{articleId}",
@@ -795,7 +799,7 @@ func TestNormalizePathsWithNames_DifferentShapesNotConflated(t *testing.T) {
 		"/users/me",
 		"/users/baz",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 
 	// /articles position has two distinct values -> slug.
 	if got["/articles/foo"] != "/articles/{articleSlug}" {
@@ -815,12 +819,12 @@ func TestNormalizePathsWithNames_DifferentShapesNotConflated(t *testing.T) {
 }
 
 func TestNormalizePathsWithNames_EmptyAndDuplicateInputs(t *testing.T) {
-	if got := NormalizePathsWithNames(nil); len(got) != 0 {
-		t.Errorf("NormalizePathsWithNames(nil) = %v, want empty map", got)
+	if got := NormalizePathsWithNames(nil, mergeOpts()); len(got) != 0 {
+		t.Errorf("NormalizePathsWithNames(nil, mergeOpts()) = %v, want empty map", got)
 	}
 
 	dupPaths := []string{"/users/42", "/users/42", "/users/43"}
-	got := NormalizePathsWithNames(dupPaths)
+	got := NormalizePathsWithNames(dupPaths, mergeOpts())
 	if len(got) != 2 {
 		// Sort for stable error output
 		keys := make([]string, 0, len(got))
@@ -932,7 +936,7 @@ func TestNormalizePathsWithNames_DeepPathsAcrossPositions(t *testing.T) {
 		"/repos/bob/proj1/issues/1",
 		"/repos/bob/proj2/issues/2",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	const want = "/repos/{repoSlug}/{repoSlug2}/issues/{issueId}"
 	for _, p := range paths {
 		if got[p] != want {
@@ -969,7 +973,7 @@ func TestNormalizePathsWithNames_FixedPointIterationRequired(t *testing.T) {
 		"/repos/bob/proj-a",
 		"/repos/bob/proj-c",
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	const want = "/repos/{repoSlug}/{repoSlug2}"
 	for _, p := range paths {
 		if got[p] != want {
@@ -994,7 +998,7 @@ func TestNormalizePathsWithNames_IntraRoundAdjacentPositionPromotion(t *testing.
 		"/x/d/y/b", // anchors position 2's /y/b suffix bucket
 		"/x/d/y/c", // anchors position 2's /y/c suffix bucket and position 4's /x/d/y prefix bucket
 	}
-	got := NormalizePathsWithNames(paths)
+	got := NormalizePathsWithNames(paths, mergeOpts())
 	const want = "/x/{xSlug}/y/{ySlug}"
 	if len(got) != len(paths) {
 		t.Fatalf("got %d entries, want %d: %#v", len(got), len(paths), got)
@@ -1076,7 +1080,7 @@ func TestNormalizePathsWithNames_MaxPromotionRoundsCap(t *testing.T) {
 			"/repos/bob/proj-a",
 			"/repos/bob/proj-c",
 		}
-		got := NormalizePathsWithNames(paths)
+		got := NormalizePathsWithNames(paths, mergeOpts())
 
 		// Invariant: every input path appears as a key.
 		if len(got) != len(paths) {
@@ -1126,7 +1130,7 @@ func TestNormalizePathsWithNames_MaxPromotionRoundsCap(t *testing.T) {
 			"/articles/my-second-post",        // ditto
 			"/posts/507f1f77bcf86cd799439011", // ObjectID → {postId} (regex)
 		}
-		got := NormalizePathsWithNames(paths)
+		got := NormalizePathsWithNames(paths, mergeOpts())
 
 		want := map[string]string{
 			"/users/42":                       "/users/{userId}",
@@ -1156,7 +1160,7 @@ func TestNormalizePathsWithNames_MaxPromotionRoundsCap(t *testing.T) {
 			"/repos/bob/proj-a",
 			"/repos/bob/proj-c",
 		}
-		got := NormalizePathsWithNames(paths)
+		got := NormalizePathsWithNames(paths, mergeOpts())
 		const want = "/repos/{repoSlug}/{repoSlug2}"
 		for _, p := range paths {
 			if got[p] != want {
@@ -1185,7 +1189,7 @@ func TestNormalizePathsWithNames_MaxPromotionRoundsCap(t *testing.T) {
 			}
 		}
 
-		got := NormalizePathsWithNames(paths)
+		got := NormalizePathsWithNames(paths, mergeOpts())
 
 		for _, p := range paths {
 			out, ok := got[p]
@@ -1201,4 +1205,35 @@ func TestNormalizePathsWithNames_MaxPromotionRoundsCap(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestNormalizePathsWithNames_MergeDisabledByDefault verifies that with
+// mergeSlugs off, distinct sibling pages are preserved (no slug collapse),
+// while regex-based ID normalization still applies. Reproduces LAB-4107.
+func TestNormalizePathsWithNames_MergeDisabledByDefault(t *testing.T) {
+	paths := []string{
+		"/navigation/source/info.php",
+		"/navigation/source/low.php",
+	}
+	got := NormalizePathsWithNames(paths, normalizeOptions{})
+	require.Equal(t, "/navigation/source/info.php", got["/navigation/source/info.php"])
+	require.Equal(t, "/navigation/source/low.php", got["/navigation/source/low.php"])
+
+	// Regex ID detection is unaffected by mergeSlugs.
+	ids := NormalizePathsWithNames([]string{"/users/42", "/users/99"}, normalizeOptions{})
+	require.Equal(t, "/users/{userId}", ids["/users/42"])
+	require.Equal(t, "/users/{userId}", ids["/users/99"])
+}
+
+// TestNormalizePathsWithNames_SlugThreshold verifies the threshold gates how
+// many distinct values are needed before a position is promoted to a slug.
+func TestNormalizePathsWithNames_SlugThreshold(t *testing.T) {
+	twoVals := []string{"/posts/a", "/posts/b"}
+	got := NormalizePathsWithNames(twoVals, normalizeOptions{mergeSlugs: true, slugThreshold: 3})
+	require.Equal(t, "/posts/a", got["/posts/a"], "2 values must not merge at threshold 3")
+	require.Equal(t, "/posts/b", got["/posts/b"])
+
+	threeVals := []string{"/posts/a", "/posts/b", "/posts/c"}
+	got = NormalizePathsWithNames(threeVals, normalizeOptions{mergeSlugs: true, slugThreshold: 3})
+	require.Equal(t, "/posts/{postSlug}", got["/posts/a"], "3 values must merge at threshold 3")
 }

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -1237,3 +1237,12 @@ func TestNormalizePathsWithNames_SlugThreshold(t *testing.T) {
 	got = NormalizePathsWithNames(threeVals, NormalizeOptions{MergeSlugs: true, SlugThreshold: 3})
 	require.Equal(t, "/posts/{postSlug}", got["/posts/a"], "3 values must merge at threshold 3")
 }
+
+// TestNormalizePathsWithNames_SlugThresholdClamped verifies the defensive
+// SlugThreshold < 2 clamp inside NormalizePathsWithNames: a threshold of 1
+// must behave as 2, so two distinct values still merge.
+func TestNormalizePathsWithNames_SlugThresholdClamped(t *testing.T) {
+	got := NormalizePathsWithNames([]string{"/posts/a", "/posts/b"}, NormalizeOptions{MergeSlugs: true, SlugThreshold: 1})
+	require.Equal(t, "/posts/{postSlug}", got["/posts/a"])
+	require.Equal(t, "/posts/{postSlug}", got["/posts/b"])
+}

--- a/pkg/generate/rest/normalize_test.go
+++ b/pkg/generate/rest/normalize_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mergeOpts() normalizeOptions { return normalizeOptions{mergeSlugs: true} }
+func mergeOpts() NormalizeOptions { return NormalizeOptions{MergeSlugs: true} }
 
 func TestNormalizePath_UUID(t *testing.T) {
 	tests := []struct {
@@ -1215,12 +1215,12 @@ func TestNormalizePathsWithNames_MergeDisabledByDefault(t *testing.T) {
 		"/navigation/source/info.php",
 		"/navigation/source/low.php",
 	}
-	got := NormalizePathsWithNames(paths, normalizeOptions{})
+	got := NormalizePathsWithNames(paths, NormalizeOptions{})
 	require.Equal(t, "/navigation/source/info.php", got["/navigation/source/info.php"])
 	require.Equal(t, "/navigation/source/low.php", got["/navigation/source/low.php"])
 
 	// Regex ID detection is unaffected by mergeSlugs.
-	ids := NormalizePathsWithNames([]string{"/users/42", "/users/99"}, normalizeOptions{})
+	ids := NormalizePathsWithNames([]string{"/users/42", "/users/99"}, NormalizeOptions{})
 	require.Equal(t, "/users/{userId}", ids["/users/42"])
 	require.Equal(t, "/users/{userId}", ids["/users/99"])
 }
@@ -1229,11 +1229,11 @@ func TestNormalizePathsWithNames_MergeDisabledByDefault(t *testing.T) {
 // many distinct values are needed before a position is promoted to a slug.
 func TestNormalizePathsWithNames_SlugThreshold(t *testing.T) {
 	twoVals := []string{"/posts/a", "/posts/b"}
-	got := NormalizePathsWithNames(twoVals, normalizeOptions{mergeSlugs: true, slugThreshold: 3})
+	got := NormalizePathsWithNames(twoVals, NormalizeOptions{MergeSlugs: true, SlugThreshold: 3})
 	require.Equal(t, "/posts/a", got["/posts/a"], "2 values must not merge at threshold 3")
 	require.Equal(t, "/posts/b", got["/posts/b"])
 
 	threeVals := []string{"/posts/a", "/posts/b", "/posts/c"}
-	got = NormalizePathsWithNames(threeVals, normalizeOptions{mergeSlugs: true, slugThreshold: 3})
+	got = NormalizePathsWithNames(threeVals, NormalizeOptions{MergeSlugs: true, SlugThreshold: 3})
 	require.Equal(t, "/posts/{postSlug}", got["/posts/a"], "3 values must merge at threshold 3")
 }

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -92,6 +92,12 @@ func inferQueryParamType(value string) string {
 type OpenAPIGenerator struct {
 	// Format specifies the output format: "json" or "yaml" (default: "yaml")
 	Format string
+	// MergeSlugs enables observation-based slug promotion during path
+	// normalization (see normalizeOptions). Off by default.
+	MergeSlugs bool
+	// SlugThreshold is the minimum distinct values at a path position before
+	// promotion; clamped to >=2 downstream. Ignored unless MergeSlugs is set.
+	SlugThreshold int
 }
 
 // explodeTrue is a singleton pointer target for setting the Explode field on
@@ -145,7 +151,7 @@ func extractServers(endpoints []classify.ClassifiedRequest) (openapi3.Servers, s
 // detected from the population of observed paths. The first pass parses URLs
 // and collects their paths; the second pass calls NormalizePathsWithNames
 // once, which performs both regex-based and observation-based detection.
-func groupEndpoints(endpoints []classify.ClassifiedRequest) map[endpointKey][]classify.ClassifiedRequest {
+func groupEndpoints(endpoints []classify.ClassifiedRequest, opts normalizeOptions) map[endpointKey][]classify.ClassifiedRequest {
 	type parsedEndpoint struct {
 		path     string
 		endpoint classify.ClassifiedRequest
@@ -162,7 +168,7 @@ func groupEndpoints(endpoints []classify.ClassifiedRequest) map[endpointKey][]cl
 		rawPaths = append(rawPaths, parsedURL.Path)
 	}
 
-	normalized := NormalizePathsWithNames(rawPaths)
+	normalized := NormalizePathsWithNames(rawPaths, opts)
 
 	endpointGroups := make(map[endpointKey][]classify.ClassifiedRequest)
 	for _, p := range parsed {
@@ -549,7 +555,7 @@ func (g *OpenAPIGenerator) Generate(endpoints []classify.ClassifiedRequest) ([]b
 	}
 
 	// Group and sort endpoints
-	endpointGroups := groupEndpoints(endpoints)
+	endpointGroups := groupEndpoints(endpoints, normalizeOptions{mergeSlugs: g.MergeSlugs, slugThreshold: g.SlugThreshold})
 
 	// Determine whether to emit x-vespasian-source extensions.
 	// Only emitted when at least one input request has a "static:" Source so that

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -96,7 +96,8 @@ type OpenAPIGenerator struct {
 	// normalization (see NormalizeOptions). Off by default.
 	MergeSlugs bool
 	// SlugThreshold is the minimum distinct values at a path position before
-	// promotion; clamped to >=2 downstream. Ignored unless MergeSlugs is set.
+	// promotion. The zero value (0) is treated as 2: NormalizePathsWithNames
+	// clamps any value < 2 up to 2. Ignored unless MergeSlugs is set.
 	SlugThreshold int
 }
 

--- a/pkg/generate/rest/openapi.go
+++ b/pkg/generate/rest/openapi.go
@@ -93,7 +93,7 @@ type OpenAPIGenerator struct {
 	// Format specifies the output format: "json" or "yaml" (default: "yaml")
 	Format string
 	// MergeSlugs enables observation-based slug promotion during path
-	// normalization (see normalizeOptions). Off by default.
+	// normalization (see NormalizeOptions). Off by default.
 	MergeSlugs bool
 	// SlugThreshold is the minimum distinct values at a path position before
 	// promotion; clamped to >=2 downstream. Ignored unless MergeSlugs is set.
@@ -151,7 +151,7 @@ func extractServers(endpoints []classify.ClassifiedRequest) (openapi3.Servers, s
 // detected from the population of observed paths. The first pass parses URLs
 // and collects their paths; the second pass calls NormalizePathsWithNames
 // once, which performs both regex-based and observation-based detection.
-func groupEndpoints(endpoints []classify.ClassifiedRequest, opts normalizeOptions) map[endpointKey][]classify.ClassifiedRequest {
+func groupEndpoints(endpoints []classify.ClassifiedRequest, opts NormalizeOptions) map[endpointKey][]classify.ClassifiedRequest {
 	type parsedEndpoint struct {
 		path     string
 		endpoint classify.ClassifiedRequest
@@ -555,7 +555,7 @@ func (g *OpenAPIGenerator) Generate(endpoints []classify.ClassifiedRequest) ([]b
 	}
 
 	// Group and sort endpoints
-	endpointGroups := groupEndpoints(endpoints, normalizeOptions{mergeSlugs: g.MergeSlugs, slugThreshold: g.SlugThreshold})
+	endpointGroups := groupEndpoints(endpoints, NormalizeOptions{MergeSlugs: g.MergeSlugs, SlugThreshold: g.SlugThreshold})
 
 	// Determine whether to emit x-vespasian-source extensions.
 	// Only emitted when at least one input request has a "static:" Source so that

--- a/pkg/generate/rest/openapi_test.go
+++ b/pkg/generate/rest/openapi_test.go
@@ -609,6 +609,56 @@ func TestOpenAPIGenerator_SlugObservation(t *testing.T) {
 	}
 }
 
+// TestOpenAPIGenerator_DefaultPreservesDistinctSiblings locks in the LAB-4107
+// default at the Generate() seam: a zero-value generator (MergeSlugs unset)
+// must keep slug-shaped siblings as distinct paths. A wiring bug that ignored
+// g.MergeSlugs, or a default flip to merge-on, would collapse them and fail
+// here even though the cmd/unit/E2E layers pass. Mirrors
+// TestOpenAPIGenerator_SlugObservation with merging off.
+func TestOpenAPIGenerator_DefaultPreservesDistinctSiblings(t *testing.T) {
+	gen := &OpenAPIGenerator{} // MergeSlugs defaults off
+
+	endpoints := []classify.ClassifiedRequest{
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:   "GET",
+				URL:      "https://api.example.com/articles/my-first-post",
+				Response: crawl.ObservedResponse{StatusCode: 200, Body: []byte(`{"title": "first"}`)},
+			},
+			IsAPI: true,
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:   "GET",
+				URL:      "https://api.example.com/articles/another-post",
+				Response: crawl.ObservedResponse{StatusCode: 200, Body: []byte(`{"title": "another"}`)},
+			},
+			IsAPI: true,
+		},
+		{
+			ObservedRequest: crawl.ObservedRequest{
+				Method:   "GET",
+				URL:      "https://api.example.com/articles/yet-another-post",
+				Response: crawl.ObservedResponse{StatusCode: 200, Body: []byte(`{"title": "yet another"}`)},
+			},
+			IsAPI: true,
+		},
+	}
+
+	spec, err := gen.Generate(endpoints)
+	require.NoError(t, err)
+
+	doc, err := openapi3.NewLoader().LoadFromData(spec)
+	require.NoError(t, err)
+
+	// Merge off: all three siblings survive as distinct paths, none collapsed.
+	require.Equal(t, 3, doc.Paths.Len(), "distinct siblings must be preserved; got %v", doc.Paths.InMatchingOrder())
+	for _, p := range []string{"/articles/my-first-post", "/articles/another-post", "/articles/yet-another-post"} {
+		assert.NotNil(t, doc.Paths.Find(p), "expected preserved path %q", p)
+	}
+	assert.Nil(t, doc.Paths.Find("/articles/{articleSlug}"), "must not collapse into a slug param when merge is off")
+}
+
 func TestP0Fixes_ActualStatusCodes(t *testing.T) {
 	gen := &OpenAPIGenerator{}
 

--- a/pkg/generate/rest/openapi_test.go
+++ b/pkg/generate/rest/openapi_test.go
@@ -531,7 +531,7 @@ func TestOpenAPIGenerator_SlugObservation(t *testing.T) {
 	// is wired into groupEndpoints; a regression that reverts the wiring to
 	// per-endpoint normalization would produce three distinct paths and fail
 	// this test.
-	gen := &OpenAPIGenerator{}
+	gen := &OpenAPIGenerator{MergeSlugs: true}
 
 	endpoints := []classify.ClassifiedRequest{
 		{

--- a/test/README.md
+++ b/test/README.md
@@ -62,6 +62,12 @@ For the JS bundle static-analysis test (`generate-js-static`, offline — no ser
 2. **Assert** the recovered path count matches `js-static/expected-paths.json` and every operation carries `x-vespasian-source: js-bundle`
 3. **Assert opt-out** — re-generating with `--analyze-js=false` yields zero `/api` paths and no `x-vespasian-source` extension
 
+For the slug-merging test (`generate-merge-slugs`, offline — no server or browser):
+
+1. **Generate** an OpenAPI spec from `fixtures/merge-slugs-capture.json` (two slug siblings `/api/posts/hello-world`, `/api/posts/my-trip` plus numeric-ID siblings `/api/users/42`, `/api/users/99`) with `--probe=false`
+2. **Assert default (off)** — both `/api/posts/*` siblings survive as distinct paths (the LAB-4107 regression guard) while `/api/users/{userId}` is still ID-normalized
+3. **Assert `--merge-slugs`** — the slug siblings collapse to `/api/posts/{postSlug}` and `/api/users/{userId}` normalization is unaffected
+
 For importer tests:
 
 1. **Import** — `vespasian import burp fixtures/sample-burp-export.xml -o imported.json`
@@ -93,7 +99,7 @@ Options:
                           Live:       rest-api, soap-service, graphql-server
                           Generate:   generate-rest, generate-wsdl, generate-wsdl-matrix,
                                       generate-graphql, generate-graphql-imports,
-                                      generate-js-static
+                                      generate-js-static, generate-merge-slugs
                           Import:     import-burp, import-har, import-base64,
                                       import-mitmproxy, import-mitmproxy-native,
                                       import-unicode, import-duplicates,
@@ -173,6 +179,9 @@ Results are saved to `test/.results/` with one subdirectory per test:
 ├── generate-js-static/
 │   ├── spec-on.yaml        # OpenAPI from a JS bundle (--analyze-js)
 │   └── spec-off.yaml       # Same capture with --analyze-js=false (opt-out)
+├── generate-merge-slugs/
+│   ├── spec-default.yaml   # Slug siblings preserved (merge off, LAB-4107 default)
+│   └── spec-merge.yaml     # Same capture with --merge-slugs (collapsed to {postSlug})
 ├── import-burp/
 │   └── imported.json       # Imported from Burp XML
 ├── import-har/
@@ -207,7 +216,7 @@ Results are saved to `test/.results/` with one subdirectory per test:
 
 ## Expected Results
 
-All 22 tests should pass. Order is non-deterministic and durations vary by machine (live crawl tests take the longest).
+All 23 tests should pass. Order is non-deterministic and durations vary by machine (live crawl tests take the longest).
 
 ```
   TARGET                      STATUS    ENDPOINTS   EXPECTED   DURATION
@@ -219,6 +228,7 @@ All 22 tests should pass. Order is non-deterministic and durations vary by machi
   generate-graphql            PASS      8           8          0s
   generate-graphql-imports    PASS      2           2          0s
   generate-js-static          PASS      3           3          1s
+  generate-merge-slugs        PASS      3           3          0s
   generate-rest               PASS      8           8          0s
   generate-wsdl               PASS      3           3          1s
   graphql-server              PASS      8           8          1s

--- a/test/fixtures/merge-slugs-capture.json
+++ b/test/fixtures/merge-slugs-capture.json
@@ -1,0 +1,30 @@
+[
+  {
+    "method": "GET",
+    "url": "https://app.example.com/api/posts/hello-world",
+    "headers": {"Content-Type": "application/json"},
+    "source": "import:merge-slugs-fixture",
+    "response": {"status_code": 200, "content_type": "application/json"}
+  },
+  {
+    "method": "GET",
+    "url": "https://app.example.com/api/posts/my-trip",
+    "headers": {"Content-Type": "application/json"},
+    "source": "import:merge-slugs-fixture",
+    "response": {"status_code": 200, "content_type": "application/json"}
+  },
+  {
+    "method": "GET",
+    "url": "https://app.example.com/api/users/42",
+    "headers": {"Content-Type": "application/json"},
+    "source": "import:merge-slugs-fixture",
+    "response": {"status_code": 200, "content_type": "application/json"}
+  },
+  {
+    "method": "GET",
+    "url": "https://app.example.com/api/users/99",
+    "headers": {"Content-Type": "application/json"},
+    "source": "import:merge-slugs-fixture",
+    "response": {"status_code": 200, "content_type": "application/json"}
+  }
+]

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -1233,6 +1233,109 @@ test_generate_js_static() {
     fi
 }
 
+# test_generate_merge_slugs guards the LAB-4107 regression end-to-end: the
+# --merge-slugs CLI flag, threaded through generate.GetWithOptions ->
+# OpenAPIGenerator -> path normalization, must collapse slug siblings ONLY when
+# requested, while numeric-ID siblings normalize regardless. Offline: no
+# server/browser, --probe=false.
+test_generate_merge_slugs() {
+    local target_dir="${RESULTS_DIR}/generate-merge-slugs"
+    local input_capture="${SCRIPT_DIR}/fixtures/merge-slugs-capture.json"
+    local spec_default="${target_dir}/spec-default.yaml"
+    local spec_merge="${target_dir}/spec-merge.yaml"
+    local verbose_flag=""
+
+    [ "${VERBOSE:-false}" = true ] && verbose_flag="-v"
+
+    mkdir -p "$target_dir"
+    init_test_status "generate-merge-slugs"
+
+    local start=$SECONDS
+    local failures=0
+
+    log_header "Testing: generate-merge-slugs (LAB-4107 opt-in slug merging)"
+
+    if [ ! -f "$input_capture" ]; then
+        log_fail "Input capture not found: ${input_capture}"
+        set_test_result "generate-merge-slugs" "FAIL" "?" "3" "$((SECONDS - start))"
+        return 1
+    fi
+
+    # ── default (merge OFF): distinct slug siblings must BOTH survive ──
+    log_info "Generating with defaults (merge off)..."
+    if ! "$VESPASIAN" generate rest "$input_capture" \
+        -o "$spec_default" \
+        --probe=false \
+        $verbose_flag 2>&1; then
+        log_fail "Generate (default) failed"
+        set_test_result "generate-merge-slugs" "FAIL" "?" "3" "$((SECONDS - start))"
+        return 1
+    fi
+
+    validate_openapi_structure "$spec_default" || failures=$((failures + 1))
+
+    local stem
+    for stem in "/api/posts/hello-world" "/api/posts/my-trip"; do
+        if grep -qE "^[[:space:]]+${stem}:" "$spec_default"; then
+            log_ok "default preserved ${stem}"
+        else
+            log_fail "default dropped ${stem} (regression: distinct endpoint lost)"
+            failures=$((failures + 1))
+        fi
+    done
+    if grep -qE "^[[:space:]]+/api/posts/\{[A-Za-z]+\}:" "$spec_default"; then
+        log_fail "default collapsed /api/posts into a {slug} param (merge must be opt-in)"
+        failures=$((failures + 1))
+    fi
+    if grep -qE "^[[:space:]]+/api/users/\{[A-Za-z]+\}:" "$spec_default"; then
+        log_ok "default normalized numeric IDs to /api/users/{param}"
+    else
+        log_fail "default did not normalize /api/users numeric IDs"
+        failures=$((failures + 1))
+    fi
+
+    # ── --merge-slugs (opt-in): slug siblings collapse to one {slug} ──
+    log_info "Generating with --merge-slugs..."
+    if ! "$VESPASIAN" generate rest "$input_capture" \
+        -o "$spec_merge" \
+        --merge-slugs \
+        --probe=false \
+        $verbose_flag 2>&1; then
+        log_fail "Generate (--merge-slugs) failed"
+        failures=$((failures + 1))
+    else
+        if grep -qE "^[[:space:]]+/api/posts/\{[A-Za-z]+\}:" "$spec_merge"; then
+            log_ok "--merge-slugs collapsed /api/posts siblings to a {slug} param"
+        else
+            log_fail "--merge-slugs did not collapse /api/posts siblings"
+            failures=$((failures + 1))
+        fi
+        for stem in "/api/posts/hello-world" "/api/posts/my-trip"; do
+            if grep -qE "^[[:space:]]+${stem}:" "$spec_merge"; then
+                log_fail "--merge-slugs left ${stem} uncollapsed"
+                failures=$((failures + 1))
+            fi
+        done
+        if grep -qE "^[[:space:]]+/api/users/\{[A-Za-z]+\}:" "$spec_merge"; then
+            log_ok "--merge-slugs kept numeric-ID normalization for /api/users"
+        else
+            log_fail "--merge-slugs lost /api/users numeric-ID normalization"
+            failures=$((failures + 1))
+        fi
+    fi
+
+    local endpoint_count
+    endpoint_count=$(count_spec_endpoints "$spec_default")
+    local duration=$((SECONDS - start))
+    if [ $failures -eq 0 ]; then
+        set_test_result "generate-merge-slugs" "PASS" "$endpoint_count" "3" "$duration"
+        log_ok "generate-merge-slugs: PASSED (${duration}s)"
+    else
+        set_test_result "generate-merge-slugs" "FAIL" "$endpoint_count" "3" "$duration"
+        log_fail "generate-merge-slugs: ${failures} check(s) failed (${duration}s)"
+    fi
+}
+
 # ──────────────────────────────────────────────────────────────
 # Edge case tests
 # ──────────────────────────────────────────────────────────────
@@ -2360,7 +2463,7 @@ usage() {
     echo "                          Live:       rest-api, soap-service, graphql-server"
     echo "                          Generate:   generate-rest, generate-wsdl, generate-wsdl-matrix,"
     echo "                                      generate-graphql, generate-graphql-imports,"
-    echo "                                      generate-js-static"
+    echo "                                      generate-js-static, generate-merge-slugs"
     echo "                          Import:     import-burp, import-har, import-base64,"
     echo "                                      import-mitmproxy, import-mitmproxy-native,"
     echo "                                      import-unicode, import-duplicates,"
@@ -2425,7 +2528,7 @@ main() {
         targets="${TARGETS_SETUP:-rest-api,soap-service,graphql-server}"
         # Always include importer tests
         targets="${targets},import-burp,import-har,import-base64,import-mitmproxy,import-mitmproxy-native,import-unicode,import-duplicates,import-malformed,import-empty"
-        targets="${targets},generate-rest,generate-wsdl,generate-wsdl-matrix,generate-graphql,generate-graphql-imports,generate-js-static"
+        targets="${targets},generate-rest,generate-wsdl,generate-wsdl-matrix,generate-graphql,generate-graphql-imports,generate-js-static,generate-merge-slugs"
         targets="${targets},edge-cases,crawl-depth,crawl-unreachable"
         targets="${targets},classifier-edge,spec-edge"
     fi
@@ -2473,6 +2576,7 @@ main() {
             generate-graphql)   test_generate_graphql ;;
             generate-graphql-imports) test_generate_graphql_imports ;;
             generate-js-static) test_generate_js_static ;;
+            generate-merge-slugs) test_generate_merge_slugs ;;
             edge-cases)         test_edge_cases ;;
             crawl-depth)        test_crawl_depth ;;
             crawl-unreachable)  test_crawl_unreachable ;;


### PR DESCRIPTION
## Initial problem

Path normalization always ran observation-based "slug" merging: any literal segment that varied across sibling paths was collapsed into a single `{...Slug}` parameter. On assessments this silently **dropped distinct endpoints** sharing a prefix (e.g. `/feature/login`, `/feature/export` → `/feature/{featureSlug}`).

Against DVWA, two genuinely-distinct pages collapsed into one:

```
/navigation/source/info.php  ┐
/navigation/source/low.php   ┘→  /navigation/source/{sourceSlug}   # endpoint lost
```

## Proposed solution

Make the fuzzy merge **opt-in** and keep deterministic ID detection always-on:

- Regex ID normalization (UUID / numeric / ObjectID / hex / base64, e.g. `/users/42` → `/users/{userId}`) stays **always on**.
- `--merge-slugs` (default **off**) — re-enables observation-based slug merging. Use it for slug-driven content (blog/CMS); leave off when distinct segments are distinct endpoints.
- `--slug-threshold` (default **2**, min 2) — how many distinct values a position must show before merging. Higher = more conservative on sparse captures. No-op unless `--merge-slugs` is set.

Both flags are available on `generate` and `scan`.

## Implementation structure

- `pkg/generate/rest/normalize.go` — new `normalizeOptions{mergeSlugs, slugThreshold}`; the promotion loop is gated on `mergeSlugs`, threshold clamped to ≥2.
- `pkg/generate/rest/openapi.go` — `OpenAPIGenerator` carries the options through to normalization.
- `pkg/generate/registry.go` — `Get(apiType, Options)` threads the config from the CLI.
- `cmd/vespasian/main.go` — the two flags + `--slug-threshold >= 2` validation, wired into both commands.
- Tests + README/doc updates. `make check` green.

## E2E testing

Run against DVWA (`--confidence 0` to surface the GET pages that contain the collapse case):

```
$ vespasian generate rest dvwa.json --confidence 0          # default
    /navigation/source/info.php:
    /navigation/source/low.php:          # both endpoints preserved

$ vespasian generate rest dvwa.json --confidence 0 --merge-slugs
    /navigation/source/{sourceSlug}:     # opt-in collapse (old behavior)
```

Default run keeps all 25 paths (no endpoint loss); `--merge-slugs` reproduces the old grouping on demand.