### PR TITLE
ci: add live test suite to GitHub Actions (LAB-4012)

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -5,12 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -20,6 +20,7 @@ jobs:
   # Push-to-main and workflow_dispatch always run.
   check-label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       should-run: ${{ steps.gate.outputs.run }}
     steps:
@@ -43,6 +44,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
@@ -81,8 +84,12 @@ jobs:
     if: needs.check-label.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      VESPASIAN_NO_SANDBOX: "true"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
@@ -103,10 +110,6 @@ jobs:
       - name: Run live tests
         run: ./test/run-live-tests.sh --no-build --targets rest-api,soap-service,graphql-server,concat-spa,edge-cases,crawl-depth
 
-      - name: Teardown
-        if: always()
-        run: ./test/setup-live-targets.sh --teardown
-
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
@@ -114,3 +117,7 @@ jobs:
           name: live-test-results
           path: test/.results/
           retention-days: 7
+
+      - name: Teardown
+        if: always()
+        run: ./test/setup-live-targets.sh --teardown

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -1,0 +1,116 @@
+name: Live Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Gate: skip PR runs unless the 'live-tests' label is present.
+  # Push-to-main and workflow_dispatch always run.
+  check-label:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.gate.outputs.run }}
+    steps:
+      - id: gate
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'live-tests') }}" == "true" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping live tests — add the 'live-tests' label to run them on this PR."
+          fi
+
+  # Offline tests: imports, deterministic generates, classifier/spec edge cases.
+  # No services or Chrome needed — runs fast (~1-2 min).
+  offline-tests:
+    needs: check-label
+    if: needs.check-label.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build vespasian
+        run: go build -o bin/vespasian ./cmd/vespasian
+
+      - name: Write stub config
+        run: |
+          printf '%s\n' \
+            "REST_API_PORT=8990" \
+            "SOAP_SERVICE_PORT=8991" \
+            "GRAPHQL_SERVER_PORT=8992" \
+            "CONCAT_SPA_PORT=8993" \
+            "TARGETS_SETUP=" \
+            > test/.live-test-config
+
+      - name: Run offline tests
+        run: |
+          ./test/run-live-tests.sh --no-start --no-build \
+            --targets import-burp,import-har,import-base64,import-mitmproxy,import-mitmproxy-native,import-unicode,import-duplicates,import-malformed,import-empty,generate-rest,generate-wsdl,generate-wsdl-matrix,generate-graphql,generate-graphql-imports,generate-js-static,generate-merge-slugs,crawl-unreachable,classifier-edge,spec-edge
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: offline-test-results
+          path: test/.results/
+          retention-days: 7
+
+  # Live tests: boots target services, crawls them, generates specs, validates.
+  # Requires Go (targets), Node (GraphQL/Apollo), and Chrome (rod backend).
+  live-tests:
+    needs: check-label
+    if: needs.check-label.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: 20
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd  # v2.1.2
+        with:
+          chrome-version: stable
+
+      - name: Setup live targets
+        run: ./test/setup-live-targets.sh
+
+      - name: Run live tests
+        run: ./test/run-live-tests.sh --no-build --targets rest-api,soap-service,graphql-server,concat-spa,edge-cases,crawl-depth
+
+      - name: Teardown
+        if: always()
+        run: ./test/setup-live-targets.sh --teardown
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: live-test-results
+          path: test/.results/
+          retention-days: 7

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -19,7 +19,7 @@ jobs:
   # Gate: skip PR runs unless the 'live-tests' label is present.
   # Push-to-main and workflow_dispatch always run.
   check-label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       should-run: ${{ steps.gate.outputs.run }}
@@ -40,7 +40,7 @@ jobs:
   offline-tests:
     needs: check-label
     if: needs.check-label.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -82,7 +82,7 @@ jobs:
   live-tests:
     needs: check-label
     if: needs.check-label.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
       VESPASIAN_NO_SANDBOX: "true"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,4 +129,7 @@ See `test/README.md` for how to run the suite, including the `TEST_HOST` overrid
 
 ## CI
 
-GitHub Actions runs on push to main and PRs: build, test (with 80% coverage threshold), lint (golangci-lint v2), and format check.
+GitHub Actions runs on push to main and PRs:
+
+- **ci.yml**: Build, test (`go test -race`, 80% coverage threshold), lint (golangci-lint v2), and format check. Runs on all pushes and PRs.
+- **live-tests.yml**: Two parallel jobs — **offline-tests** (imports, deterministic generates, classifier/spec edge cases; no services or Chrome needed) and **live-tests** (boots REST, SOAP, GraphQL, and concat-SPA target services, installs Chrome, runs crawl-based end-to-end tests). Label-gated on PRs: add the `live-tests` label to trigger. Always runs on push to `main` and `workflow_dispatch`.

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -56,16 +56,13 @@ type BrowserManager struct {
 	cleanupOnce sync.Once
 }
 
-// NewBrowserManager launches a Chrome instance with the given options and
-// returns a manager that owns its lifecycle.
-func NewBrowserManager(opts BrowserOptions) (*BrowserManager, error) {
+// configureLauncher applies BrowserOptions to a new launcher without
+// launching Chrome. Extracted for testability of the CI auto-detection logic.
+func configureLauncher(opts BrowserOptions) (*launcher.Launcher, error) {
 	l := launcher.New().
 		Headless(opts.Headless)
 
-	if opts.NoSandbox {
-		l = l.NoSandbox(true)
-	}
-	if !opts.NoSandbox && os.Getenv("CI") != "" {
+	if opts.NoSandbox || os.Getenv("CI") != "" {
 		l = l.NoSandbox(true)
 	}
 	if opts.ChromePath != "" {
@@ -76,6 +73,17 @@ func NewBrowserManager(opts BrowserOptions) (*BrowserManager, error) {
 			return nil, err
 		}
 		l = l.Set("proxy-server", opts.Proxy)
+	}
+
+	return l, nil
+}
+
+// NewBrowserManager launches a Chrome instance with the given options and
+// returns a manager that owns its lifecycle.
+func NewBrowserManager(opts BrowserOptions) (*BrowserManager, error) {
+	l, err := configureLauncher(opts)
+	if err != nil {
+		return nil, err
 	}
 
 	wsURL, err := l.Launch()

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -57,12 +57,13 @@ type BrowserManager struct {
 }
 
 // configureLauncher applies BrowserOptions to a new launcher without
-// launching Chrome. Extracted for testability of the CI auto-detection logic.
+// launching Chrome. Disables the sandbox when opts.NoSandbox is set or
+// when the VESPASIAN_NO_SANDBOX env var is "true" (set by CI workflows).
 func configureLauncher(opts BrowserOptions) (*launcher.Launcher, error) {
 	l := launcher.New().
 		Headless(opts.Headless)
 
-	if opts.NoSandbox || os.Getenv("CI") != "" {
+	if opts.NoSandbox || os.Getenv("VESPASIAN_NO_SANDBOX") == "true" {
 		l = l.NoSandbox(true)
 	}
 	if opts.ChromePath != "" {

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -32,7 +32,8 @@ type BrowserOptions struct {
 	// NoSandbox disables Chrome's OS-level sandbox. This removes a primary
 	// exploit mitigation barrier and should only be set in containerized or
 	// CI environments where the sandbox cannot be enabled (e.g., Docker
-	// without --cap-add SYS_ADMIN).
+	// without --cap-add SYS_ADMIN). The sandbox is also disabled when the
+	// VESPASIAN_NO_SANDBOX environment variable is set to "true".
 	NoSandbox bool
 
 	// ChromePath overrides the Chrome binary used by the launcher. This value

--- a/pkg/crawl/browser.go
+++ b/pkg/crawl/browser.go
@@ -17,6 +17,7 @@ package crawl
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"sync"
 
 	"github.com/go-rod/rod"
@@ -62,6 +63,9 @@ func NewBrowserManager(opts BrowserOptions) (*BrowserManager, error) {
 		Headless(opts.Headless)
 
 	if opts.NoSandbox {
+		l = l.NoSandbox(true)
+	}
+	if !opts.NoSandbox && os.Getenv("CI") != "" {
 		l = l.NoSandbox(true)
 	}
 	if opts.ChromePath != "" {

--- a/pkg/crawl/browser_test.go
+++ b/pkg/crawl/browser_test.go
@@ -51,3 +51,34 @@ func TestBrowserManager_SetCookies_NilReceiverReturnsError(t *testing.T) {
 		t.Errorf("error message %q should contain 'not connected'", err.Error())
 	}
 }
+
+func TestConfigureLauncher_CIAutoDetectsNoSandbox(t *testing.T) {
+	tests := []struct {
+		name      string
+		noSandbox bool
+		ciEnv     string
+		wantFlag  bool
+	}{
+		{"explicit NoSandbox", true, "", true},
+		{"explicit NoSandbox with CI", true, "true", true},
+		{"no flags no CI", false, "", false},
+		{"CI auto-detects NoSandbox", false, "true", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.ciEnv != "" {
+				t.Setenv("CI", tt.ciEnv)
+			} else {
+				t.Setenv("CI", "")
+			}
+			l, err := configureLauncher(BrowserOptions{NoSandbox: tt.noSandbox})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := l.Has("no-sandbox")
+			if got != tt.wantFlag {
+				t.Errorf("Has(no-sandbox) = %v, want %v", got, tt.wantFlag)
+			}
+		})
+	}
+}

--- a/pkg/crawl/browser_test.go
+++ b/pkg/crawl/browser_test.go
@@ -52,33 +52,61 @@ func TestBrowserManager_SetCookies_NilReceiverReturnsError(t *testing.T) {
 	}
 }
 
-func TestConfigureLauncher_CIAutoDetectsNoSandbox(t *testing.T) {
-	tests := []struct {
-		name      string
-		noSandbox bool
-		ciEnv     string
-		wantFlag  bool
-	}{
-		{"explicit NoSandbox", true, "", true},
-		{"explicit NoSandbox with CI", true, "true", true},
-		{"no flags no CI", false, "", false},
-		{"CI auto-detects NoSandbox", false, "true", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.ciEnv != "" {
-				t.Setenv("CI", tt.ciEnv)
-			} else {
-				t.Setenv("CI", "")
-			}
-			l, err := configureLauncher(BrowserOptions{NoSandbox: tt.noSandbox})
+func TestConfigureLauncher(t *testing.T) {
+	t.Run("sandbox", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			noSandbox bool
+			envVal    string
+			wantFlag  bool
+		}{
+			{"explicit NoSandbox", true, "", true},
+			{"explicit NoSandbox with env", true, "true", true},
+			{"no flags no env", false, "", false},
+			{"env true enables NoSandbox", false, "true", true},
+			{"env false does not enable NoSandbox", false, "false", false},
+			{"env arbitrary value does not enable NoSandbox", false, "1", false},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Setenv("VESPASIAN_NO_SANDBOX", tt.envVal)
+				l, err := configureLauncher(BrowserOptions{NoSandbox: tt.noSandbox})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got := l.Has("no-sandbox")
+				if got != tt.wantFlag {
+					t.Errorf("Has(no-sandbox) = %v, want %v", got, tt.wantFlag)
+				}
+			})
+		}
+	})
+
+	t.Run("proxy", func(t *testing.T) {
+		t.Run("valid proxy sets flag", func(t *testing.T) {
+			l, err := configureLauncher(BrowserOptions{Proxy: "http://127.0.0.1:8080"})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			got := l.Has("no-sandbox")
-			if got != tt.wantFlag {
-				t.Errorf("Has(no-sandbox) = %v, want %v", got, tt.wantFlag)
+			if !l.Has("proxy-server") {
+				t.Error("expected proxy-server flag to be set")
 			}
 		})
-	}
+		t.Run("invalid proxy returns error", func(t *testing.T) {
+			_, err := configureLauncher(BrowserOptions{Proxy: "not a valid proxy"})
+			if err == nil {
+				t.Fatal("expected error for invalid proxy, got nil")
+			}
+		})
+	})
+
+	t.Run("chrome path", func(t *testing.T) {
+		l, err := configureLauncher(BrowserOptions{ChromePath: "/usr/bin/chromium"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !l.Has("rod-bin") {
+			t.Error("expected rod-bin flag to be set after ChromePath")
+		}
+	})
 }

--- a/pkg/crawl/browser_test.go
+++ b/pkg/crawl/browser_test.go
@@ -88,14 +88,17 @@ func TestConfigureLauncher(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if !l.Has("proxy-server") {
-				t.Error("expected proxy-server flag to be set")
+			if got := l.Get("proxy-server"); got != "http://127.0.0.1:8080" {
+				t.Errorf("Get(proxy-server) = %q, want http://127.0.0.1:8080", got)
 			}
 		})
 		t.Run("invalid proxy returns error", func(t *testing.T) {
 			_, err := configureLauncher(BrowserOptions{Proxy: "not a valid proxy"})
 			if err == nil {
 				t.Fatal("expected error for invalid proxy, got nil")
+			}
+			if !strings.Contains(err.Error(), "proxy") {
+				t.Errorf("error %q should mention proxy", err.Error())
 			}
 		})
 	})
@@ -105,8 +108,21 @@ func TestConfigureLauncher(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !l.Has("rod-bin") {
-			t.Error("expected rod-bin flag to be set after ChromePath")
+		if got := l.Get("rod-bin"); got != "/usr/bin/chromium" {
+			t.Errorf("Get(rod-bin) = %q, want /usr/bin/chromium", got)
 		}
 	})
+}
+
+func TestNewBrowserManager_InvalidProxyReturnsError(t *testing.T) {
+	mgr, err := NewBrowserManager(BrowserOptions{Proxy: "not a valid proxy"})
+	if err == nil {
+		t.Fatal("expected error for invalid proxy, got nil")
+	}
+	if mgr != nil {
+		t.Error("expected nil manager on error")
+	}
+	if !strings.Contains(err.Error(), "proxy") {
+		t.Errorf("error %q should mention proxy", err.Error())
+	}
 }

--- a/test/live-test-gaps.md
+++ b/test/live-test-gaps.md
@@ -1,0 +1,50 @@
+# Live Test Coverage Gaps
+
+Documents what the CI live test suite covers versus known gaps.
+Updated as part of LAB-4012 (live tests in GitHub Actions).
+
+## Covered by CI
+
+### Offline tests (no services, no Chrome)
+
+| Target | What it validates |
+|--------|-------------------|
+| import-burp | Burp XML import, JSON golden-file comparison |
+| import-har | HAR import, request count and URL validation |
+| import-base64 | Base64-encoded Burp XML import |
+| import-mitmproxy | mitmproxy JSON export import |
+| import-mitmproxy-native | mitmproxy native tnetstring format import |
+| import-unicode | Unicode/emoji content in Burp XML |
+| import-duplicates | Duplicate headers/params in HAR |
+| import-malformed | Graceful failure on truncated/invalid input |
+| import-empty | Zero-entry imports produce null output |
+| generate-rest | OpenAPI generation, golden-file diff |
+| generate-wsdl | WSDL generation, golden-file diff |
+| generate-wsdl-matrix | SOAP 1.1/1.2, RPC/doc/literal param extraction |
+| generate-graphql | GraphQL SDL generation, golden-file diff |
+| generate-graphql-imports | Import then generate SDL from Burp XML and HAR |
+| generate-js-static | JS bundle static analysis with --analyze-js |
+| generate-merge-slugs | Slug merging opt-in vs default behavior |
+| crawl-unreachable | No crash/panic on unreachable host |
+| classifier-edge | RSS feeds, versioned paths, mismatched content-types |
+| spec-edge | UUID paths, numeric IDs, multi-param paths |
+
+### Live tests (require services + Chrome)
+
+| Target | What it validates |
+|--------|-------------------|
+| rest-api | REST crawl (both backends), OpenAPI path coverage, static asset exclusion |
+| soap-service | SOAP traffic generation, WSDL operation extraction |
+| graphql-server | GraphQL queries/mutations, SDL structure, introspection quality, SPA fetch capture |
+| concat-spa | JS concat/plus-chain extraction, exact path count, forbidden path absence |
+| edge-cases | Large responses, URL encoding, redirects, HTTP errors, binary exclusion |
+| crawl-depth | Depth limiting, max-pages, infinite loop detection |
+
+## Known gaps
+
+- **Path parameterization validation**: `validate_path_coverage` treats `{param}` as a wildcard matching any segment, so parameterization regressions (e.g., literal `/users/1` instead of `/users/{id}`) are invisible to live tests. Only the offline golden-file diffs catch these.
+- **SOAP body-based detection**: All SOAP test traffic includes `SOAPAction` headers; the body-based `hasSoapEnvelope` fallback (Signal 2) is never the primary classifier. See LAB-4698.
+- **Pipeline `IsStaticAssetURL`**: The pipeline's static asset filter is only used in the SDK capability path, not the CLI path the live tests exercise. See LAB-4698.
+- **Static extension list drift**: `internal/pipeline/static_asset.go:staticAssetExtensions` and `pkg/classify/rest.go:staticExtensions` are independent lists with no synchronization test. See LAB-4698.
+- **SDK/capability path**: `pkg/sdk` is not exercised by any live test; only the CLI pipeline is tested.
+- **Sourcemap fetching**: `--fetch-sourcemaps` is not exercised by any live test target.


### PR DESCRIPTION
## Summary

- Adds `live-tests.yml` workflow with two parallel jobs: **offline-tests** (imports, deterministic generates, classifier/spec edge cases — no services needed) and **live-tests** (boots 4 target services, installs Chrome, runs crawl-based tests)
- Label-gated on PRs (`live-tests` label required), always runs on push to `main` and `workflow_dispatch`
- Teardown and artifact upload run unconditionally (`if: always()`)

Closes [LAB-4012](https://linear.app/praetorianlabs/issue/LAB-4012/vespasian-run-the-live-test-suite-in-github-actions-ci)

## Test plan

- [x] Offline tests validated locally via `act` — all 19 tests pass
- [x] Live tests validated locally via `act` — workflow structure correct, Chrome step fails due to `act` slim image limitation (not a real GHA issue)
- [x] Verify both jobs pass on real GHA runner (this PR push triggers the workflow)
- [x] Verify PR label gating works (remove `live-tests` label → jobs should skip)
- [x] Verify deliberate test break fails the job