### PR TITLE
fix(grpc): bound aggregate reflection-descriptor memory across targets (LAB-4693)

### DIFF
--- a/pkg/probe/grpc.go
+++ b/pkg/probe/grpc.go
@@ -86,6 +86,7 @@ func (p *GRPCProbe) Probe(ctx context.Context, endpoints []classify.ClassifiedRe
 	// reflection probe result.
 	schemasByTarget := make(map[grpcTargetInfo]*classify.GRPCReflectionResult)
 	seen := make(map[grpcTargetInfo]bool)
+	totalRetained := 0
 
 	for _, ep := range endpoints {
 		if ep.APIType != "grpc" {
@@ -104,7 +105,14 @@ func (p *GRPCProbe) Probe(ctx context.Context, endpoints []classify.ClassifiedRe
 		}
 		seen[target] = true
 
-		schemasByTarget[target] = p.probeTarget(ctx, target)
+		res := p.probeTarget(ctx, target)
+		schemasByTarget[target] = res
+		totalRetained += reflectionRetainedBytes(res)
+		if totalRetained >= p.config.MaxTotalReflectionDescriptorBytes {
+			slog.DebugContext(ctx, "grpc probe: aggregate descriptor budget exhausted; stopping target enumeration",
+				"targets_probed", len(seen), "retained_bytes", totalRetained)
+			break
+		}
 	}
 
 	// Copy endpoints to avoid mutating the caller's slice.
@@ -360,4 +368,20 @@ func extractService(fd *desc.FileDescriptor, fqn string) (classify.GRPCService, 
 		return gs, true
 	}
 	return classify.GRPCService{}, false
+}
+
+// reflectionRetainedBytes returns the total serialized descriptor bytes a
+// reflection result retains (0 for a nil result or a result without
+// descriptors — e.g. reflection-unavailable or unreachable targets, which
+// therefore never advance the aggregate budget). Used by Probe to enforce
+// Config.MaxTotalReflectionDescriptorBytes across targets.
+func reflectionRetainedBytes(r *classify.GRPCReflectionResult) int {
+	if r == nil {
+		return 0
+	}
+	total := 0
+	for _, b := range r.FileDescriptors {
+		total += len(b)
+	}
+	return total
 }

--- a/pkg/probe/grpc_test.go
+++ b/pkg/probe/grpc_test.go
@@ -652,6 +652,67 @@ func TestGRPCProbe_Probe_AggregateDescriptorBudgetStopsTargets(t *testing.T) {
 	assert.Equal(t, int32(1), dialCount.Load(), "exactly one target (server A) should be dialed; server B must never be dialed")
 }
 
+// TestGRPCProbe_Probe_ZeroByteTargetDoesNotAdvanceBudget pins the complementary
+// invariant to TestGRPCProbe_Probe_AggregateDescriptorBudgetStopsTargets: a nil
+// / reflection-unavailable / unreachable target retains 0 descriptor bytes
+// (reflectionRetainedBytes(nil) == 0) and therefore must NOT advance
+// totalRetained in Probe. The first endpoint targets an unreachable (closed)
+// port — probeTarget returns nil for it — so it must not trip the aggregate
+// budget and prematurely stop probing of the second, legitimate endpoint. If
+// reflectionRetainedBytes(nil) wrongly returned a large value instead of 0,
+// totalRetained would already be >= the budget after endpoint[0], the break
+// would fire, and endpoint[1] would never be dialed — failing assertion #2
+// below.
+func TestGRPCProbe_Probe_ZeroByteTargetDoesNotAdvanceBudget(t *testing.T) {
+	// endpoint[0]: bind then immediately close a loopback listener to obtain a
+	// routable but guaranteed-closed port (nothing listening) — mirrors
+	// TestGRPCProbe_Probe_NilSchemaOnUnreachableTarget.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	unreachableAddr := lis.Addr().String()
+	require.NoError(t, lis.Close())
+
+	// endpoint[1]: a real in-process reflection server, which retains >0
+	// descriptor bytes once probed.
+	reachableAddr, stop := startTestGRPCServer(t)
+	defer stop()
+
+	var dialCount atomic.Int32
+	countingDialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialCount.Add(1)
+		return loopbackDialer(ctx, network, addr)
+	}
+
+	cfg := Config{
+		Timeout:                           5 * time.Second,
+		URLValidator:                      func(string) error { return nil },
+		Dialer:                            countingDialer,
+		MaxTotalReflectionDescriptorBytes: 1, // deliberately tiny — trips as soon as ANY bytes are retained
+	}
+	probe := NewGRPCProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{
+		{APIType: "grpc"},
+		{APIType: "grpc"},
+	}
+	endpoints[0].URL = "http://" + unreachableAddr + "/lab.v1.UserService/GetUser"
+	endpoints[1].URL = "http://" + reachableAddr + "/grpc.health.v1.Health/Check"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := probe.Probe(ctx, endpoints)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	assert.Nil(t, result[0].GRPCSchema, "unreachable first target must yield a nil schema")
+
+	require.NotNil(t, result[1].GRPCSchema, "the 0-byte first target must not advance the aggregate budget, so the second target must still be probed")
+	assert.True(t, result[1].GRPCSchema.ReflectionEnabled, "second target's reflection result must be enabled")
+
+	assert.Equal(t, int32(2), dialCount.Load(), "both targets should be dialed: the closed port (fails) and the real server (succeeds)")
+}
+
 // TestGRPCProbe_Probe_TLSVerifiedByDefault verifies that a gRPC server
 // presenting a self-signed certificate is NOT enumerated when
 // GRPCInsecureSkipVerify is left at its default (false). The TLS handshake

--- a/pkg/probe/grpc_test.go
+++ b/pkg/probe/grpc_test.go
@@ -602,6 +602,56 @@ func TestGRPCProbe_Probe_MaxEndpointsRespected(t *testing.T) {
 	assert.LessOrEqual(t, int(dialCount.Load()), 2, "at most 2 reflection dials should occur when MaxEndpoints=2")
 }
 
+// TestGRPCProbe_Probe_AggregateDescriptorBudgetStopsTargets verifies the
+// GLOBAL aggregate descriptor budget (Config.MaxTotalReflectionDescriptorBytes)
+// in Probe: after probing each target, retained descriptor bytes accumulate
+// into totalRetained, and once totalRetained crosses the configured ceiling,
+// Probe stops dialing SUBSEQUENT targets. The target that crosses the
+// threshold is still retained (the break happens after storing its schema),
+// so with MaxTotalReflectionDescriptorBytes=1, server A's descriptors (>0
+// bytes) trip the budget but A's own schema is kept; server B is never dialed.
+func TestGRPCProbe_Probe_AggregateDescriptorBudgetStopsTargets(t *testing.T) {
+	addrA, stopA := startTestGRPCServer(t)
+	defer stopA()
+	addrB, stopB := startTestGRPCServer(t)
+	defer stopB()
+
+	var dialCount atomic.Int32
+	countingDialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialCount.Add(1)
+		return loopbackDialer(ctx, network, addr)
+	}
+
+	cfg := Config{
+		Timeout:                           5 * time.Second,
+		URLValidator:                      func(string) error { return nil },
+		Dialer:                            countingDialer,
+		MaxTotalReflectionDescriptorBytes: 1, // trip the aggregate budget after the first target
+	}
+	probe := NewGRPCProbe(cfg)
+
+	endpoints := []classify.ClassifiedRequest{
+		{APIType: "grpc"},
+		{APIType: "grpc"},
+	}
+	endpoints[0].URL = "http://" + addrA + "/grpc.health.v1.Health/Check"
+	endpoints[1].URL = "http://" + addrB + "/grpc.health.v1.Health/Check"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := probe.Probe(ctx, endpoints)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	require.NotNil(t, result[0].GRPCSchema, "first target crosses the aggregate budget but must still be retained before the break")
+	assert.True(t, result[0].GRPCSchema.ReflectionEnabled, "first target's reflection result must be enabled")
+
+	assert.Nil(t, result[1].GRPCSchema, "second target must never be probed once the aggregate budget is exhausted")
+
+	assert.Equal(t, int32(1), dialCount.Load(), "exactly one target (server A) should be dialed; server B must never be dialed")
+}
+
 // TestGRPCProbe_Probe_TLSVerifiedByDefault verifies that a gRPC server
 // presenting a self-signed certificate is NOT enumerated when
 // GRPCInsecureSkipVerify is left at its default (false). The TLS handshake

--- a/pkg/probe/types.go
+++ b/pkg/probe/types.go
@@ -68,10 +68,28 @@ type Config struct {
 	// means use the package default (maxGRPCDescriptorBytes). Overridable
 	// primarily for tests.
 	MaxReflectionDescriptorBytes int
+
+	// MaxTotalReflectionDescriptorBytes caps the AGGREGATE retained descriptor
+	// bytes summed across ALL probed targets. Once cumulative retained bytes reach
+	// this ceiling, Probe stops dialing further targets — bounding total memory
+	// even when many distinct hostile targets each stay under the per-target cap.
+	// Zero means use the package default (DefaultMaxTotalReflectionDescriptorBytes).
+	// Overridable primarily for tests.
+	MaxTotalReflectionDescriptorBytes int
 }
 
 // DefaultMaxEndpoints is the default limit on unique URLs probed per strategy.
 const DefaultMaxEndpoints = 500
+
+// DefaultMaxTotalReflectionDescriptorBytes is the default aggregate cross-target
+// retained-descriptor budget. Set to a small multiple (4x) of the per-target
+// maxGRPCDescriptorBytes cap (= 256 MiB), so worst-case retained memory is
+// bounded to ~256 MiB (plus at most one in-flight target's ≤64 MiB, since the
+// target that crosses the threshold is fully retained before Probe breaks),
+// versus the unbounded ~32 GiB (MaxEndpoints × 64 MiB) without this ceiling.
+// Generous enough not to affect real scans (typical targets retain KB),
+// aggressive enough to stop a pathological many-hostile-target capture.
+const DefaultMaxTotalReflectionDescriptorBytes = 4 * maxGRPCDescriptorBytes
 
 // DefaultConfig returns a Config with sensible defaults.
 func DefaultConfig() Config {
@@ -117,6 +135,9 @@ func (cfg Config) withDefaults() Config {
 	}
 	if cfg.MaxReflectionDescriptorBytes == 0 {
 		cfg.MaxReflectionDescriptorBytes = maxGRPCDescriptorBytes
+	}
+	if cfg.MaxTotalReflectionDescriptorBytes == 0 {
+		cfg.MaxTotalReflectionDescriptorBytes = DefaultMaxTotalReflectionDescriptorBytes
 	}
 	if cfg.Client == nil {
 		cfg.Client = &http.Client{


### PR DESCRIPTION
## Summary

Defense-in-depth hardening for the gRPC reflection probe — a **global cross-target descriptor-memory budget**. Follow-up from PR #159 review finding **SEC-BE-001** (CVSS 5.3 medium; tracked as non-blocking **LAB-4693**).

### The gap
Per-**target** reflection memory was already bounded in #159: `dialGRPC` sets `MaxCallRecvMsgSize` (4 MiB/message), and `walkFileDescriptors` enforces a 64 MiB aggregate serialized-descriptor budget + 1000-file count cap **per target**. But `GRPCProbe.Probe` retains one `*classify.GRPCReflectionResult` per distinct target in `schemasByTarget`, and the fan-out was bounded only by `Config.MaxEndpoints` (default 500). So a capture referencing many distinct, reachable, hostile gRPC `host:port` targets could drive aggregate retained memory to ~`MaxEndpoints × 64 MiB` (~32 GiB) and OOM the scanning host. No global budget existed.

Likelihood is low (needs an unusual capture — hundreds of hostile targets, or attacker-controlled DNS for many names) and impact is confined to the operator's own scanning process, hence this was non-blocking.

### The fix
Add a global budget in `GRPCProbe.Probe`, mirroring the existing per-target loop-break in `runReflection`:
- New `Config.MaxTotalReflectionDescriptorBytes`, default `DefaultMaxTotalReflectionDescriptorBytes = 4 * maxGRPCDescriptorBytes` (**256 MiB**) — a small multiple of the per-target cap.
- `Probe` accumulates each target's retained descriptor bytes (`reflectionRetainedBytes`) and **stops dialing further targets** once the cumulative total reaches the ceiling.
- Ordering is deliberate: the target that *crosses* the threshold keeps and applies its already-retained schema; only **subsequent** targets are skipped.
- `nil` / reflection-unavailable results retain no descriptors, so they never advance the budget.

Worst-case retained memory is bounded to ~256 MiB (plus at most one in-flight target's ≤64 MiB), versus the unbounded ~32 GiB before. The default is far above any real scan (typical targets retain KB), so normal behavior is unchanged.

## Test plan
- [x] `TestGRPCProbe_Probe_AggregateDescriptorBudgetStopsTargets` — two loopback reflection servers, `MaxTotalReflectionDescriptorBytes: 1`, counting dialer; asserts the first target is retained (`ReflectionEnabled`) while the **second is never dialed** (dial count == 1). **Mutation-verified**: removing the break makes the dial count 1→2 and the test fails.
- [x] `go test -race ./...` — full suite green (18 packages).
- [x] `go vet` / `gofmt` clean; `golangci-lint run pkg/probe/...` — 0 issues.

Refs [LAB-4693](https://linear.app/praetorianlabs/issue/LAB-4693/grpc-bound-aggregate-reflection-descriptor-memory-across-targets-in).