### PR TITLE
test(grpc): add CLI-boundary coverage for --grpc-insecure-skip-verify (LAB-4694)

### DIFF
--- a/cmd/vespasian/main.go
+++ b/cmd/vespasian/main.go
@@ -481,6 +481,23 @@ type GenerateCmd struct {
 // maxCaptureSize is the maximum capture file size (100MB).
 const maxCaptureSize = 100 * 1024 * 1024
 
+// options builds the pipeline.Options for this command from its flags. Extracted
+// so a CLI-boundary test can assert each flag reaches pipeline.Options (catching a
+// dropped assignment) without executing Run().
+func (c *GenerateCmd) options() pipeline.Options {
+	return pipeline.Options{
+		APIType:                c.APIType,
+		Confidence:             c.Confidence,
+		Probe:                  c.Probe,
+		Deduplicate:            c.Deduplicate,
+		AllowPrivate:           c.DangerousAllowPrivate,
+		GRPCInsecureSkipVerify: c.GRPCInsecureSkipVerify,
+		MergeSlugs:             c.MergeSlugs,
+		SlugThreshold:          c.SlugThreshold,
+		Status:                 statusWriter(c.Verbose),
+	}
+}
+
 // Run executes the generate command.
 func (c *GenerateCmd) Run() (err error) {
 	if err := validateSlugThreshold(c.APIType, c.MergeSlugs, c.SlugThreshold); err != nil {
@@ -532,17 +549,7 @@ func (c *GenerateCmd) Run() (err error) {
 
 	warnSSRFDisabled(c.DangerousAllowPrivate, c.Probe)
 
-	spec, err := pipeline.ClassifyProbeGenerate(ctx, requests, pipeline.Options{
-		APIType:                c.APIType,
-		Confidence:             c.Confidence,
-		Probe:                  c.Probe,
-		Deduplicate:            c.Deduplicate,
-		AllowPrivate:           c.DangerousAllowPrivate,
-		GRPCInsecureSkipVerify: c.GRPCInsecureSkipVerify,
-		MergeSlugs:             c.MergeSlugs,
-		SlugThreshold:          c.SlugThreshold,
-		Status:                 statusWriter(c.Verbose),
-	})
+	spec, err := pipeline.ClassifyProbeGenerate(ctx, requests, c.options())
 	if err != nil {
 		return err
 	}
@@ -565,6 +572,28 @@ type ScanCmd struct {
 
 	CrawlOptions
 	SlugOptions
+}
+
+// scanOptions builds the pipeline.ScanOptions for this command. The c-derived
+// fields (incl. GRPCInsecureSkipVerify) are collected here so a CLI-boundary test
+// can assert each flag reaches pipeline.ScanOptions (catching a dropped assignment)
+// without executing Run(). The two runtime-derived inputs — the resolved apiType
+// and the AfterWSDL closure (which captures bs.opts.Headers/c/c.URL) — are passed
+// in by Run().
+func (c *ScanCmd) scanOptions(apiType string, afterWSDL func(ctx context.Context, reqs []crawl.ObservedRequest) []crawl.ObservedRequest) pipeline.ScanOptions {
+	return pipeline.ScanOptions{
+		TargetURL:              c.URL,
+		APIType:                apiType,
+		Confidence:             c.Confidence,
+		Probe:                  c.Probe,
+		Deduplicate:            c.Deduplicate,
+		AllowPrivate:           c.DangerousAllowPrivate,
+		GRPCInsecureSkipVerify: c.GRPCInsecureSkipVerify,
+		MergeSlugs:             c.MergeSlugs,
+		SlugThreshold:          c.SlugThreshold,
+		Status:                 statusWriter(c.Verbose),
+		AfterWSDL:              afterWSDL,
+	}
 }
 
 // Run executes the scan command (crawl + generate pipeline).
@@ -659,27 +688,16 @@ func (c *ScanCmd) Run() error { //nolint:gocyclo // top-level orchestration
 	// gated on both c.AnalyzeJS (so --analyze-js=false suppresses the JS-bundle
 	// rescan) and c.Probe (so --probe=false stays passive — see
 	// maybeReplayJSExtracted), and is CLI-only (the SDK passes a nil AfterWSDL hook).
-	spec, apiType, foundWSDL, _, err := pipeline.ResolveAndGenerate(genCtx, requests, pipeline.ScanOptions{
-		TargetURL:              c.URL,
-		APIType:                apiType,
-		Confidence:             c.Confidence,
-		Probe:                  c.Probe,
-		Deduplicate:            c.Deduplicate,
-		AllowPrivate:           c.DangerousAllowPrivate,
-		GRPCInsecureSkipVerify: c.GRPCInsecureSkipVerify,
-		MergeSlugs:             c.MergeSlugs,
-		SlugThreshold:          c.SlugThreshold,
-		Status:                 statusWriter(c.Verbose),
-		AfterWSDL: func(ctx context.Context, reqs []crawl.ObservedRequest) []crawl.ObservedRequest {
-			return maybeReplayJSExtracted(ctx, reqs, c.Probe && c.AnalyzeJS, crawl.JSReplayConfig{
-				Headers:      bs.opts.Headers,
-				TargetURL:    c.URL,
-				AllowPrivate: c.DangerousAllowPrivate,
-				Verbose:      c.Verbose,
-				Stderr:       os.Stderr,
-			})
-		},
-	})
+	afterWSDL := func(ctx context.Context, reqs []crawl.ObservedRequest) []crawl.ObservedRequest {
+		return maybeReplayJSExtracted(ctx, reqs, c.Probe && c.AnalyzeJS, crawl.JSReplayConfig{
+			Headers:      bs.opts.Headers,
+			TargetURL:    c.URL,
+			AllowPrivate: c.DangerousAllowPrivate,
+			Verbose:      c.Verbose,
+			Stderr:       os.Stderr,
+		})
+	}
+	spec, apiType, foundWSDL, _, err := pipeline.ResolveAndGenerate(genCtx, requests, c.scanOptions(apiType, afterWSDL))
 	if err != nil {
 		return err
 	}

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -1000,6 +1000,24 @@ func TestGRPCInsecureSkipVerify_GenerateCmd(t *testing.T) {
 	}
 }
 
+// TestGRPCInsecureSkipVerify_ReachesOptions closes the AC3 boundary gap: it
+// asserts that c.GRPCInsecureSkipVerify actually reaches pipeline.Options
+// (via GenerateCmd.options()) and pipeline.ScanOptions (via
+// ScanCmd.scanOptions()) at the CLI boundary, so a dropped assignment inside
+// either method is caught — unlike TestGRPCInsecureSkipVerify_Embedded
+// (field-exposure only) and TestGRPCInsecureSkipVerify_GenerateCmd (a
+// hermetic Run() smoke test that never reaches pipeline.Options
+// construction on a REST capture).
+func TestGRPCInsecureSkipVerify_ReachesOptions(t *testing.T) {
+	require.True(t, (&GenerateCmd{GRPCInsecureSkipVerify: true}).options().GRPCInsecureSkipVerify,
+		"GenerateCmd flag must reach pipeline.Options")
+	require.False(t, (&GenerateCmd{GRPCInsecureSkipVerify: false}).options().GRPCInsecureSkipVerify)
+
+	require.True(t, (&ScanCmd{GRPCInsecureSkipVerify: true}).scanOptions("rest", nil).GRPCInsecureSkipVerify,
+		"ScanCmd flag must reach pipeline.ScanOptions")
+	require.False(t, (&ScanCmd{GRPCInsecureSkipVerify: false}).scanOptions("rest", nil).GRPCInsecureSkipVerify)
+}
+
 // TestDangerousAllowPrivate_SameOutputForPublicURLs verifies that allowPrivate=true
 // and allowPrivate=false produce identical specs when all targets are public.
 func TestDangerousAllowPrivate_SameOutputForPublicURLs(t *testing.T) {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -927,6 +927,70 @@ func TestDangerousAllowPrivate_ScanCmd(t *testing.T) {
 	}
 }
 
+// TestGRPCInsecureSkipVerify_Embedded pins that GenerateCmd and ScanCmd both
+// expose the GRPCInsecureSkipVerify kong field, catching a field removal or
+// rename on either struct. It does NOT exercise Run() and cannot catch a
+// dropped assignment of the field into pipeline.Options inside Run() (see
+// main.go:541 and main.go:669) — that semantic wiring is covered by
+// internal/pipeline's TestClassifyProbeGenerate_GRPCInsecureSkipVerify.
+func TestGRPCInsecureSkipVerify_Embedded(t *testing.T) {
+	g := &GenerateCmd{GRPCInsecureSkipVerify: true}
+	require.True(t, g.GRPCInsecureSkipVerify)
+
+	gDefault := &GenerateCmd{}
+	require.False(t, gDefault.GRPCInsecureSkipVerify)
+
+	s := &ScanCmd{GRPCInsecureSkipVerify: true}
+	require.True(t, s.GRPCInsecureSkipVerify)
+
+	sDefault := &ScanCmd{}
+	require.False(t, sDefault.GRPCInsecureSkipVerify)
+}
+
+// TestGRPCInsecureSkipVerify_GenerateCmd is a smoke test proving
+// GenerateCmd.Run() accepts GRPCInsecureSkipVerify without erroring on a
+// non-gRPC (REST) capture. It does NOT prove the flag is forwarded into
+// pipeline.Options inside Run() — a REST capture never reaches the gRPC
+// probe path that consumes it, and pipeline.Options is built inline with no
+// inspectable seam. That semantic behavior is covered by internal/pipeline's
+// TestClassifyProbeGenerate_GRPCInsecureSkipVerify.
+func TestGRPCInsecureSkipVerify_GenerateCmd(t *testing.T) {
+	requests := []crawl.ObservedRequest{
+		{
+			Method: "GET",
+			URL:    "https://example.com/api/users",
+			Headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			Response: crawl.ObservedResponse{
+				StatusCode:  200,
+				ContentType: "application/json",
+			},
+		},
+	}
+
+	capturePath := filepath.Join(t.TempDir(), "capture.json")
+	f, err := os.Create(capturePath) //nolint:gosec // G304: test file
+	if err != nil {
+		t.Fatalf("failed to create temp capture file: %v", err)
+	}
+	if writeErr := crawl.WriteCapture(f, requests); writeErr != nil {
+		_ = f.Close()
+		t.Fatalf("failed to write capture: %v", writeErr)
+	}
+	_ = f.Close()
+
+	cmd := &GenerateCmd{
+		APIType:                "rest",
+		Capture:                capturePath,
+		Probe:                  true,
+		GRPCInsecureSkipVerify: true,
+	}
+	if err := cmd.Run(); err != nil {
+		t.Errorf("GenerateCmd.Run() with GRPCInsecureSkipVerify unexpected error: %v", err)
+	}
+}
+
 // TestDangerousAllowPrivate_SameOutputForPublicURLs verifies that allowPrivate=true
 // and allowPrivate=false produce identical specs when all targets are public.
 func TestDangerousAllowPrivate_SameOutputForPublicURLs(t *testing.T) {

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -898,6 +898,7 @@ func TestDangerousAllowPrivate_GenerateCmd(t *testing.T) {
 	cmd := &GenerateCmd{
 		APIType:               "rest",
 		Capture:               capturePath,
+		Output:                filepath.Join(t.TempDir(), "spec.json"),
 		Probe:                 true,
 		DangerousAllowPrivate: true,
 	}
@@ -984,6 +985,9 @@ func TestGRPCInsecureSkipVerify_GenerateCmd(t *testing.T) {
 	cmd := &GenerateCmd{
 		APIType: "rest",
 		Capture: capturePath,
+		// Output goes to a temp file so a successful Run() doesn't write the
+		// generated spec to stdout during the test.
+		Output: filepath.Join(t.TempDir(), "spec.json"),
 		// Probe stays false: GRPCInsecureSkipVerify is consumed only by the
 		// gRPC reflection probe, which this REST capture never reaches, so
 		// Probe:true would add zero coverage of the flag while making a live

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -953,7 +953,8 @@ func TestGRPCInsecureSkipVerify_Embedded(t *testing.T) {
 // pipeline.Options inside Run() — a REST capture never reaches the gRPC
 // probe path that consumes it, and pipeline.Options is built inline with no
 // inspectable seam. That semantic behavior is covered by internal/pipeline's
-// TestClassifyProbeGenerate_GRPCInsecureSkipVerify.
+// TestClassifyProbeGenerate_GRPCInsecureSkipVerify. Probe stays false (see
+// below) since this test never exercises the gRPC probe path anyway.
 func TestGRPCInsecureSkipVerify_GenerateCmd(t *testing.T) {
 	requests := []crawl.ObservedRequest{
 		{
@@ -981,9 +982,13 @@ func TestGRPCInsecureSkipVerify_GenerateCmd(t *testing.T) {
 	_ = f.Close()
 
 	cmd := &GenerateCmd{
-		APIType:                "rest",
-		Capture:                capturePath,
-		Probe:                  true,
+		APIType: "rest",
+		Capture: capturePath,
+		// Probe stays false: GRPCInsecureSkipVerify is consumed only by the
+		// gRPC reflection probe, which this REST capture never reaches, so
+		// Probe:true would add zero coverage of the flag while making a live
+		// network call to example.com. Keep this smoke test hermetic.
+		Probe:                  false,
 		GRPCInsecureSkipVerify: true,
 	}
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Summary

Closes the CLI-boundary coverage gap for the `--grpc-insecure-skip-verify` flag, and fully satisfies **LAB-4694 AC3**. Follow-up from PR #159 review finding **TEST-001** (low; non-blocking **LAB-4694**).

Started as a test-only change; a small **behavior-neutral production seam** was added (per PR review) so a *dropped* flag assignment is caught at the CLI boundary — see "Production seam (AC3)" below.

### The gap
The flag is declared on both `GenerateCmd` and `ScanCmd` and copied into `pipeline.Options` / `pipeline.ScanOptions` inside each `Run()`. But `cmd/vespasian/main_test.go` had **zero** references to `GRPCInsecureSkipVerify` — the kong-struct wiring was uncovered at the command boundary. Worse, the `Options` structs were built *inline* inside `Run()`, so a dropped `GRPCInsecureSkipVerify: c.GRPCInsecureSkipVerify` assignment would leave the whole suite green (the AC3 concern).

### Production seam (AC3) — behavior-neutral
Extracted the inline options construction into methods that are now the **sole** construction site of each struct, so a boundary test can inspect flag propagation without executing `Run()`:
- `GenerateCmd.options() pipeline.Options` — pure, from `c` fields.
- `ScanCmd.scanOptions(apiType, afterWSDL) pipeline.ScanOptions` — takes the runtime-resolved `apiType` and the `AfterWSDL` closure; the `c`-derived fields (incl. `GRPCInsecureSkipVerify`) live in one inspectable place. The closure still captures `bs.opts.Headers`/`c`/`c.URL` as before.

Both `Run()` methods now call these. The extraction is field-for-field identical to the previous inline literals — runtime behavior, validation, and SSRF-warning ordering are unchanged (verified: pure struct construction, no I/O).

### Tests added
- **`TestGRPCInsecureSkipVerify_ReachesOptions`** *(AC3)* — asserts the flag reaches `pipeline.Options` **and** `pipeline.ScanOptions` in both directions. **Mutation-verified**: deleting `GRPCInsecureSkipVerify: c.GRPCInsecureSkipVerify` from either `options()`/`scanOptions()` turns it red. This catches the dropped-assignment regression AC3 asked for.
- **`TestGRPCInsecureSkipVerify_Embedded`** — asserts both `GenerateCmd` and `ScanCmd` expose the field (settable `true`, defaults `false`); catches a field removal/rename. Mirrors `TestSlugOptions_Embedded` / `TestDangerousAllowPrivate_ScanCmd`.
- **`TestGRPCInsecureSkipVerify_GenerateCmd`** — writes a REST capture to a temp dir (spec → temp file, not stdout) and runs `GenerateCmd.Run()` with the flag set and `Probe: false` (hermetic — no network), asserting the flag is accepted through the real `Run()` path. Mirrors `TestDangerousAllowPrivate_GenerateCmd`.

The deeper semantic behavior (skip=true vs verify-by-default) remains covered one layer down by `internal/pipeline/pipeline_test.go:TestClassifyProbeGenerate_GRPCInsecureSkipVerify`.

## Test plan
- [x] `go test -race ./cmd/vespasian/...` — pass, incl. the three new tests.
- [x] `go test -race ./...` — full suite green (18 packages).
- [x] `go vet` / `gofmt` clean; `golangci-lint run cmd/vespasian/...` — 0 issues.
- [x] Mutation check: dropping the flag assignment from either `options()`/`scanOptions()` fails `TestGRPCInsecureSkipVerify_ReachesOptions`.

Refs [LAB-4694](https://linear.app/praetorianlabs/issue/LAB-4694/grpc-add-cli-boundary-test-for-grpc-insecure-skip-verify-flag-wiring).
