### PR TITLE
fix(test): preflight fails on chromium snap stub instead of passing (LAB-3893)

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -16,6 +16,23 @@ permissions:
   contents: read
 
 jobs:
+  # Regression self-test for the preflight Chrome/Chromium detection logic
+  # (LAB-3893). Not label-gated — runs on every push/PR so the harness's own
+  # bash logic is validated even when the live-tests label isn't applied.
+  preflight-selftest:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Syntax check
+        run: bash -n test/setup-live-targets.sh
+
+      - name: Run preflight self-test
+        run: bash test/preflight-selftest.sh
+
   # Gate: skip PR runs unless the 'live-tests' label is present.
   # Push-to-main and workflow_dispatch always run.
   check-label:

--- a/test/README.md
+++ b/test/README.md
@@ -333,6 +333,20 @@ sudo apt install chromium-browser
 brew install --cask google-chrome
 ```
 
+**Found but not runnable:** on recent Ubuntu / WSL2 (and many CI base images),
+`/usr/bin/chromium-browser` is a snap *stub* — a launcher that satisfies
+`command -v` / `-x` but fails at runtime with "requires the chromium snap to
+be installed". `setup-live-targets.sh` probes each candidate binary with
+`--version` before accepting it, so this now fails preflight with `Found
+<path> but it is not runnable` instead of failing later during `vespasian
+crawl`. Fix with `snap install chromium`, or install `google-chrome` instead.
+
+**macOS note:** the runnability probe uses `timeout` (falling back to
+`gtimeout` from Homebrew coreutils) to guard against a hanging binary. Stock
+macOS ships neither, so on an unpatched macOS install the probe runs without a
+timeout — a binary that hangs on `--version` would block preflight rather
+than failing fast.
+
 ### Crawl produces empty capture
 
 Ensure the target service is running and healthy. Run the check from the host that started the services (`setup-live-targets.sh` binds to localhost there):

--- a/test/preflight-selftest.sh
+++ b/test/preflight-selftest.sh
@@ -36,7 +36,7 @@ trap 'rm -rf "${FIXTURE_DIR}"' EXIT
 mkdir -p "${FIXTURE_DIR}/bin"
 WORKING_BROWSER="${FIXTURE_DIR}/bin/google-chrome"
 cat > "${WORKING_BROWSER}" <<'EOF'
-#!/usr/bin/env bash
+#!/bin/bash
 echo "Fake Chrome 999.0.0.0"
 exit 0
 EOF
@@ -47,11 +47,22 @@ chmod +x "${WORKING_BROWSER}"
 mkdir -p "${FIXTURE_DIR}/snap/bin"
 SNAP_STUB="${FIXTURE_DIR}/snap/bin/chromium-browser"
 cat > "${SNAP_STUB}" <<'EOF'
-#!/usr/bin/env bash
+#!/bin/bash
 echo "chromium-browser requires the chromium snap to be installed" >&2
 exit 1
 EOF
 chmod +x "${SNAP_STUB}"
+
+# A generically-broken "browser": present, executable, fails at runtime, but
+# its path matches NONE of the snap-hint globs (not under /snap/, not named
+# chromium*). Exercises the generic "failed to run" arm of check_prerequisites.
+GENERIC_BROKEN="${FIXTURE_DIR}/bin/broken-chrome"
+cat > "${GENERIC_BROKEN}" <<'EOF'
+#!/bin/bash
+echo "broken-chrome: error while loading shared libraries" >&2
+exit 127
+EOF
+chmod +x "${GENERIC_BROKEN}"
 
 # NOTE: setup-live-targets.sh assigns CHROME_CANDIDATES unconditionally at
 # top level (not inside main()), so any override must happen AFTER sourcing
@@ -157,6 +168,51 @@ rc_d=$(echo "${result}" | sed -n '1p')
 out_d=$(echo "${result}" | sed -n '2p')
 assert_eq "case d: stub-before-working exit code is 0" "0" "${rc_d}"
 assert_eq "case d: stub-before-working selects the working browser" "${WORKING_BROWSER}" "${out_d}"
+
+# ── Case e: present-but-broken NON-snap binary → generic hint ──
+# Complements case b: a broken binary whose path matches none of the snap
+# globs must get the generic "failed to run" hint, NOT the snap-stub hint.
+# Guards the `*)` arm of check_prerequisites' case statement.
+msg_out=$(
+    (
+        # shellcheck source=setup-live-targets.sh
+        source "${SETUP_SCRIPT}"
+        # shellcheck disable=SC2034  # consumed by detect_chrome_binary from the sourced script
+        CHROME_CANDIDATES=("${GENERIC_BROKEN}")
+        set +e
+        check_prerequisites 2>&1
+    )
+) || true   # check_prerequisites exits 1 (chrome broken); we only want its output
+if printf '%s' "${msg_out}" | grep -q "failed to run" && ! printf '%s' "${msg_out}" | grep -q "snap stub"; then
+    echo "PASS: case e: non-snap broken binary gets the generic hint (not the snap hint)"
+    pass_count=$((pass_count + 1))
+else
+    echo "FAIL: case e: expected the generic 'failed to run' hint without snap-stub text"
+    fail_count=$((fail_count + 1))
+fi
+
+# ── Case f: no timeout/gtimeout on PATH → bare-probe fallback ──
+# Exercises chrome_runnable's degrade path (stock macOS ships neither
+# timeout nor gtimeout). Restrict PATH to the fixture bin dir — which holds
+# no timeout binary — so command -v timeout/gtimeout both miss and the bare
+# `"$1" --version` branch runs. A working browser must still be detected.
+result=$(
+    (
+        # shellcheck source=setup-live-targets.sh
+        source "${SETUP_SCRIPT}"
+        # shellcheck disable=SC2034  # consumed by detect_chrome_binary from the sourced script
+        CHROME_CANDIDATES=("${WORKING_BROWSER}")
+        PATH="${FIXTURE_DIR}/bin"   # no timeout/gtimeout here → force the fallback
+        set +e
+        out=$(detect_chrome_binary)
+        rc=$?
+        printf '%s\n%s\n' "${rc}" "${out}"
+    )
+)
+rc_f=$(echo "${result}" | sed -n '1p')
+out_f=$(echo "${result}" | sed -n '2p')
+assert_eq "case f: no-timeout fallback still detects a working browser (rc 0)" "0" "${rc_f}"
+assert_eq "case f: no-timeout fallback returns the working browser path" "${WORKING_BROWSER}" "${out_f}"
 
 # ── Summary ─────────────────────────────────────────────────────
 echo ""

--- a/test/preflight-selftest.sh
+++ b/test/preflight-selftest.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Copyright 2026 Praetorian Security, Inc.
+#
+# Regression self-test for the Chrome/Chromium preflight probe in
+# setup-live-targets.sh (LAB-3893). Plain bash, no test framework: creates
+# fake browser binaries, overrides CHROME_CANDIDATES, sources the setup
+# script (the BASH_SOURCE guard means main() does not run), then exercises
+# detect_chrome_binary against each scenario.
+#
+# Usage: bash test/preflight-selftest.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SCRIPT="${SCRIPT_DIR}/setup-live-targets.sh"
+
+pass_count=0
+fail_count=0
+
+assert_eq() {
+    local desc=$1 expected=$2 actual=$3
+    if [ "$expected" = "$actual" ]; then
+        echo "PASS: ${desc}"
+        pass_count=$((pass_count + 1))
+    else
+        echo "FAIL: ${desc} (expected [${expected}], got [${actual}])"
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+# ── Fixture setup ──────────────────────────────────────────────
+FIXTURE_DIR=$(mktemp -d)
+trap 'rm -rf "${FIXTURE_DIR}"' EXIT
+
+# A working "browser": prints a version string and exits 0.
+mkdir -p "${FIXTURE_DIR}/bin"
+WORKING_BROWSER="${FIXTURE_DIR}/bin/google-chrome"
+cat > "${WORKING_BROWSER}" <<'EOF'
+#!/usr/bin/env bash
+echo "Fake Chrome 999.0.0.0"
+exit 0
+EOF
+chmod +x "${WORKING_BROWSER}"
+
+# A snap-stub "browser": present, executable, but fails at runtime — path
+# contains /snap/ so it matches the snap-hint case in check_prerequisites.
+mkdir -p "${FIXTURE_DIR}/snap/bin"
+SNAP_STUB="${FIXTURE_DIR}/snap/bin/chromium-browser"
+cat > "${SNAP_STUB}" <<'EOF'
+#!/usr/bin/env bash
+echo "chromium-browser requires the chromium snap to be installed" >&2
+exit 1
+EOF
+chmod +x "${SNAP_STUB}"
+
+# NOTE: setup-live-targets.sh assigns CHROME_CANDIDATES unconditionally at
+# top level (not inside main()), so any override must happen AFTER sourcing
+# — sourcing first, then overriding, then calling detect_chrome_binary.
+
+# ── Case a: working browser present ────────────────────────────
+result=$(
+    (
+        # shellcheck source=setup-live-targets.sh
+        source "${SETUP_SCRIPT}"
+        # shellcheck disable=SC2034  # consumed by detect_chrome_binary from the sourced script
+        CHROME_CANDIDATES=("${WORKING_BROWSER}" "${SNAP_STUB}")
+        set +e
+        out=$(detect_chrome_binary)
+        rc=$?
+        printf '%s\n%s\n' "${rc}" "${out}"
+    )
+)
+rc_a=$(echo "${result}" | sed -n '1p')
+out_a=$(echo "${result}" | sed -n '2p')
+assert_eq "case a: working browser exit code is 0" "0" "${rc_a}"
+assert_eq "case a: working browser path echoed" "${WORKING_BROWSER}" "${out_a}"
+
+# ── Case b: only a snap-stub present ───────────────────────────
+result=$(
+    (
+        # shellcheck source=setup-live-targets.sh
+        source "${SETUP_SCRIPT}"
+        # shellcheck disable=SC2034  # consumed by detect_chrome_binary from the sourced script
+        CHROME_CANDIDATES=("${SNAP_STUB}")
+        set +e
+        out=$(detect_chrome_binary)
+        rc=$?
+        printf '%s\n%s\n' "${rc}" "${out}"
+    )
+)
+rc_b=$(echo "${result}" | sed -n '1p')
+out_b=$(echo "${result}" | sed -n '2p')
+assert_eq "case b: snap-stub exit code is 2" "2" "${rc_b}"
+assert_eq "case b: snap-stub path echoed" "${SNAP_STUB}" "${out_b}"
+
+# case b (continued): assert the stub path matches the snap-hint pattern
+# used by check_prerequisites' case statement, so message selection is
+# covered without duplicating check_prerequisites' full log output.
+case "${out_b}" in
+    */snap/*|*/chromium-browser|*/chromium)
+        echo "PASS: case b: stub path matches snap-hint case pattern"
+        pass_count=$((pass_count + 1))
+        ;;
+    *)
+        echo "FAIL: case b: stub path does NOT match snap-hint case pattern"
+        fail_count=$((fail_count + 1))
+        ;;
+esac
+
+# ── Case c: nothing runnable (all candidates missing) ──────────
+result=$(
+    (
+        # shellcheck source=setup-live-targets.sh
+        source "${SETUP_SCRIPT}"
+        # shellcheck disable=SC2034  # consumed by detect_chrome_binary from the sourced script
+        CHROME_CANDIDATES=("${FIXTURE_DIR}/bin/does-not-exist" "${FIXTURE_DIR}/nope")
+        set +e
+        out=$(detect_chrome_binary)
+        rc=$?
+        printf '%s\n%s\n' "${rc}" "${out}"
+    )
+)
+rc_c=$(echo "${result}" | sed -n '1p')
+out_c=$(echo "${result}" | sed -n '2p')
+assert_eq "case c: nothing found exit code is 1" "1" "${rc_c}"
+assert_eq "case c: nothing found stdout is empty" "" "${out_c}"
+
+# ── Summary ─────────────────────────────────────────────────────
+echo ""
+echo "preflight-selftest: ${pass_count} passed, ${fail_count} failed"
+[ "${fail_count}" -eq 0 ]

--- a/test/preflight-selftest.sh
+++ b/test/preflight-selftest.sh
@@ -93,19 +93,29 @@ out_b=$(echo "${result}" | sed -n '2p')
 assert_eq "case b: snap-stub exit code is 2" "2" "${rc_b}"
 assert_eq "case b: snap-stub path echoed" "${SNAP_STUB}" "${out_b}"
 
-# case b (continued): assert the stub path matches the snap-hint pattern
-# used by check_prerequisites' case statement, so message selection is
-# covered without duplicating check_prerequisites' full log output.
-case "${out_b}" in
-    */snap/*|*/chromium-browser|*/chromium)
-        echo "PASS: case b: stub path matches snap-hint case pattern"
-        pass_count=$((pass_count + 1))
-        ;;
-    *)
-        echo "FAIL: case b: stub path does NOT match snap-hint case pattern"
-        fail_count=$((fail_count + 1))
-        ;;
-esac
+# case b (continued): exercise check_prerequisites' ACTUAL message selection.
+# Run it with only the stub candidate and confirm it emits the snap-stub hint
+# (not the generic "failed to run" message). This drives the real case
+# statement, so a regression that narrows/reorders the snap pattern or swaps
+# in the generic hint would fail here. Runs in a subshell because
+# check_prerequisites calls `exit 1` when a prerequisite is missing.
+msg_out=$(
+    (
+        # shellcheck source=setup-live-targets.sh
+        source "${SETUP_SCRIPT}"
+        # shellcheck disable=SC2034  # consumed by detect_chrome_binary from the sourced script
+        CHROME_CANDIDATES=("${SNAP_STUB}")
+        set +e
+        check_prerequisites 2>&1
+    )
+) || true   # check_prerequisites exits 1 (chrome missing); we only want its output
+if printf '%s' "${msg_out}" | grep -q "snap stub"; then
+    echo "PASS: case b: check_prerequisites emits the snap-stub hint"
+    pass_count=$((pass_count + 1))
+else
+    echo "FAIL: case b: check_prerequisites did not emit the snap-stub hint"
+    fail_count=$((fail_count + 1))
+fi
 
 # ── Case c: nothing runnable (all candidates missing) ──────────
 result=$(
@@ -124,6 +134,29 @@ rc_c=$(echo "${result}" | sed -n '1p')
 out_c=$(echo "${result}" | sed -n '2p')
 assert_eq "case c: nothing found exit code is 1" "1" "${rc_c}"
 assert_eq "case c: nothing found stdout is empty" "" "${out_c}"
+
+# ── Case d: broken candidate ordered BEFORE a working one ──────
+# The real snap-stub scenario: `command -v` resolves the stub first and a
+# working browser is only found later in the candidate list. Proves the loop
+# SKIPS the non-runnable candidate and returns the later runnable one (rc 0),
+# rather than stopping at the stub (rc 2). This is the branch case a cannot
+# cover, since case a lists the working browser first.
+result=$(
+    (
+        # shellcheck source=setup-live-targets.sh
+        source "${SETUP_SCRIPT}"
+        # shellcheck disable=SC2034  # consumed by detect_chrome_binary from the sourced script
+        CHROME_CANDIDATES=("${SNAP_STUB}" "${WORKING_BROWSER}")
+        set +e
+        out=$(detect_chrome_binary)
+        rc=$?
+        printf '%s\n%s\n' "${rc}" "${out}"
+    )
+)
+rc_d=$(echo "${result}" | sed -n '1p')
+out_d=$(echo "${result}" | sed -n '2p')
+assert_eq "case d: stub-before-working exit code is 0" "0" "${rc_d}"
+assert_eq "case d: stub-before-working selects the working browser" "${WORKING_BROWSER}" "${out_d}"
 
 # ── Summary ─────────────────────────────────────────────────────
 echo ""

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -65,6 +65,49 @@ find_available_port() {
 # Prerequisites
 # ──────────────────────────────────────────────────────────────
 
+# Candidate browsers, in priority order. Overridable by tests.
+CHROME_CANDIDATES=(
+    google-chrome chromium-browser chromium chrome
+    /usr/bin/google-chrome /usr/bin/chromium-browser /usr/bin/chromium
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    /snap/bin/chromium
+)
+
+# Probe a candidate for actual runnability. --version is fast and needs no X/DBus.
+chrome_runnable() {
+    local t=""
+    if command -v timeout >/dev/null 2>&1; then
+        t=timeout
+    elif command -v gtimeout >/dev/null 2>&1; then   # macOS + coreutils
+        t=gtimeout
+    fi
+    if [ -n "$t" ]; then
+        "$t" 2 "$1" --version >/dev/null 2>&1
+    else
+        # No timeout available (e.g. stock macOS): probe directly. A binary that
+        # hangs on --version would block here — known limitation, documented in
+        # test/README.md.
+        "$1" --version >/dev/null 2>&1
+    fi
+}
+
+# Resolve + probe candidates. On success: echo the runnable binary, return 0.
+# On "present but not runnable": echo the first broken binary, return 2.
+# On "nothing found": echo nothing, return 1.
+detect_chrome_binary() {
+    local browser bin stub=""
+    for browser in "${CHROME_CANDIDATES[@]}"; do
+        bin=$(command -v "$browser" 2>/dev/null) || continue
+        if chrome_runnable "$bin"; then
+            printf '%s\n' "$bin"
+            return 0
+        fi
+        [ -z "$stub" ] && stub="$bin"
+    done
+    [ -n "$stub" ] && { printf '%s\n' "$stub"; return 2; }
+    return 1
+}
+
 check_prerequisites() {
     log_header "Checking Prerequisites"
     local failed=0
@@ -77,47 +120,31 @@ check_prerequisites() {
         failed=1
     fi
 
-    # Chrome/Chromium — presence alone is not enough. On recent Ubuntu / WSL2 /
-    # many CI base images, /usr/bin/chromium-browser is a snap *stub*: a launcher
-    # that satisfies `command -v` / `-x` but fails at runtime with "requires the
-    # chromium snap to be installed". Probe each candidate for actual runnability
-    # so preflight fails loudly here instead of during `vespasian crawl`.
-    chrome_runnable() {
-        # --version is fast and needs no X / DBus; timeout guards a hanging stub.
-        # timeout is not installed by default on macOS, so degrade gracefully.
-        if command -v timeout >/dev/null 2>&1; then
-            timeout 2 "$1" --version >/dev/null 2>&1
-        else
-            "$1" --version >/dev/null 2>&1
-        fi
-    }
-
-    local chrome_found=0
-    local chrome_stub=""
-    for browser in google-chrome chromium-browser chromium chrome \
-                   /usr/bin/google-chrome /usr/bin/chromium-browser /usr/bin/chromium \
-                   /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
-                   /snap/bin/chromium; do
-        # Resolve names and absolute paths alike to an executable path, or skip.
-        local bin
-        bin=$(command -v "$browser" 2>/dev/null) || continue
-        if chrome_runnable "$bin"; then
-            log_ok "Browser: $bin"
-            chrome_found=1
-            break
-        else
-            # Remember the first present-but-broken binary for a better message.
-            [ -z "$chrome_stub" ] && chrome_stub="$bin"
-        fi
-    done
-    if [ $chrome_found -eq 0 ]; then
-        if [ -n "$chrome_stub" ]; then
-            log_fail "Found ${chrome_stub} but it is not runnable"
-            log_info "(looks like the Ubuntu snap stub — install the chromium snap: 'snap install chromium', or use google-chrome)."
-        else
-            log_fail "Chrome/Chromium not found. Required for headless crawling."
-            log_info "Install: https://www.google.com/chrome/ or 'apt install chromium-browser'"
-        fi
+    # Chrome/Chromium — presence alone is not enough (snap stubs satisfy
+    # command -v / -x but fail at runtime). detect_chrome_binary probes
+    # runnability so preflight fails loudly here, not during `vespasian crawl`.
+    # Note: `chrome_bin=$(detect_chrome_binary) || rc=$?` (not `; rc=$?`) — under
+    # this script's `set -e`, a bare `chrome_bin=$(cmd); rc=$?` would abort the
+    # script the instant detect_chrome_binary returns non-zero, before rc=$?
+    # ever ran, and the elif/else branches below would never execute.
+    local chrome_bin rc=0
+    chrome_bin=$(detect_chrome_binary) || rc=$?
+    if [ $rc -eq 0 ]; then
+        log_ok "Browser: $chrome_bin"
+    elif [ $rc -eq 2 ]; then
+        log_fail "Found ${chrome_bin} but it is not runnable"
+        case "$chrome_bin" in
+            */snap/*|*/chromium-browser|*/chromium)
+                log_info "(looks like the Ubuntu snap stub — install the chromium snap: 'snap install chromium', or use google-chrome)."
+                ;;
+            *)
+                log_info "(the binary exists but failed to run — check permissions, missing shared libraries, or reinstall the browser)."
+                ;;
+        esac
+        failed=1
+    else
+        log_fail "Chrome/Chromium not found. Required for headless crawling."
+        log_info "Install: https://www.google.com/chrome/ or 'apt install chromium-browser'"
         failed=1
     fi
 
@@ -550,4 +577,6 @@ main() {
     log_info "Tear down with: ./test/setup-live-targets.sh --teardown"
 }
 
-main "$@"
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@"
+fi

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -77,30 +77,47 @@ check_prerequisites() {
         failed=1
     fi
 
-    # Chrome/Chromium
+    # Chrome/Chromium — presence alone is not enough. On recent Ubuntu / WSL2 /
+    # many CI base images, /usr/bin/chromium-browser is a snap *stub*: a launcher
+    # that satisfies `command -v` / `-x` but fails at runtime with "requires the
+    # chromium snap to be installed". Probe each candidate for actual runnability
+    # so preflight fails loudly here instead of during `vespasian crawl`.
+    chrome_runnable() {
+        # --version is fast and needs no X / DBus; timeout guards a hanging stub.
+        # timeout is not installed by default on macOS, so degrade gracefully.
+        if command -v timeout >/dev/null 2>&1; then
+            timeout 2 "$1" --version >/dev/null 2>&1
+        else
+            "$1" --version >/dev/null 2>&1
+        fi
+    }
+
     local chrome_found=0
-    for browser in google-chrome chromium-browser chromium chrome; do
-        if command -v "$browser" >/dev/null 2>&1; then
-            log_ok "Browser: $browser"
+    local chrome_stub=""
+    for browser in google-chrome chromium-browser chromium chrome \
+                   /usr/bin/google-chrome /usr/bin/chromium-browser /usr/bin/chromium \
+                   /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+                   /snap/bin/chromium; do
+        # Resolve names and absolute paths alike to an executable path, or skip.
+        local bin
+        bin=$(command -v "$browser" 2>/dev/null) || continue
+        if chrome_runnable "$bin"; then
+            log_ok "Browser: $bin"
             chrome_found=1
             break
+        else
+            # Remember the first present-but-broken binary for a better message.
+            [ -z "$chrome_stub" ] && chrome_stub="$bin"
         fi
     done
-    # Also check common installation paths
     if [ $chrome_found -eq 0 ]; then
-        for path in /usr/bin/google-chrome /usr/bin/chromium-browser /usr/bin/chromium \
-                    /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
-                    /snap/bin/chromium; do
-            if [ -x "$path" ]; then
-                log_ok "Browser: $path"
-                chrome_found=1
-                break
-            fi
-        done
-    fi
-    if [ $chrome_found -eq 0 ]; then
-        log_fail "Chrome/Chromium not found. Required for headless crawling."
-        log_info "Install: https://www.google.com/chrome/ or 'apt install chromium-browser'"
+        if [ -n "$chrome_stub" ]; then
+            log_fail "Found ${chrome_stub} but it is not runnable"
+            log_info "(looks like the Ubuntu snap stub — install the chromium snap: 'snap install chromium', or use google-chrome)."
+        else
+            log_fail "Chrome/Chromium not found. Required for headless crawling."
+            log_info "Install: https://www.google.com/chrome/ or 'apt install chromium-browser'"
+        fi
         failed=1
     fi
 


### PR DESCRIPTION
## Summary

`test/setup-live-targets.sh` `check_prerequisites()` accepted `/usr/bin/chromium-browser` whenever `command -v` / `-x` found it. On recent Ubuntu / WSL2 / many CI base images that path is a **snap stub** — a launcher that satisfies the presence check but fails at runtime with `requires the chromium snap to be installed`. Preflight reported `[OK] Browser: chromium-browser`, setup proceeded, and the later `vespasian crawl` broke several seconds later with a confusing message. Preflight is supposed to fail loudly *up front*.

## Fix

- Add `chrome_runnable()` — probes a candidate with `--version` under a 2s `timeout` (degrades gracefully where `timeout` is absent, e.g. macOS).
- Unify the command-name and absolute-path candidate lists into one loop that resolves each via `command -v` and accepts a browser **only if it actually runs**.
- When every candidate is present-but-broken, fail with a snap-stub-specific hint (`snap install chromium`, or use google-chrome).

## Scope

- Live-test suite only — **no** production `vespasian` behavior change.
- Out of scope (unchanged): downloading Chromium, configuring go-rod `ChromePath`.

## Verification

- `bash -n` — clean.
- `shellcheck` — 0 warnings on changed lines (only pre-existing info notes on unrelated lines remain).
- Functional test (fake binaries) across 3 scenarios: snap-stub-only → FAIL + hint; stub + working google-chrome → correctly skips the stub and selects the working browser; nothing present → generic not-found.

Note: the `live-tests` CI job is label-gated on a `live-tests` label that does not yet exist in this repo, so it will not auto-run on this PR (it runs on merge to `main`). Add the label if you want it exercised here.

Fixes [LAB-3893](https://linear.app/praetorianlabs/issue/LAB-3893/testsetup-live-targetssh-preflight-false-positive-on-chromium-snap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)