### PR TITLE
fix(test): harden setup-live-targets.sh against orphan PIDs and silent port exhaustion (LAB-2893)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ make deps                     # go mod download && go mod tidy
 
 # Clean
 make clean                    # Remove bin/, dist/, coverage.out
+
+# Live test services
+make live-test-clean          # Stop live test services (escape hatch for orphaned processes)
 ```
 
 ## Architecture

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ clean:
 	rm -rf $(BUILD_DIR) dist coverage.out
 
 # Escape hatch for orphaned live-test services: stops every recorded generation
-# and sweeps any orphans left by a setup run that never tore down.
+# (kills recorded PIDs only, which is safe). For untracked orphans whose pid log
+# was lost, run ./test/setup-live-targets.sh --teardown --sweep directly.
 live-test-clean:
 	./test/setup-live-targets.sh --teardown

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS   := -s -w -X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT) -X main.buildDate=$(BUILD_DATE)
 
-.PHONY: build test lint fmt vet check coverage clean deps
+.PHONY: build test lint fmt vet check coverage clean deps live-test-clean
 
 build:
 	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/vespasian
@@ -35,3 +35,8 @@ deps:
 
 clean:
 	rm -rf $(BUILD_DIR) dist coverage.out
+
+# Escape hatch for orphaned live-test services: stops every recorded generation
+# and sweeps any orphans left by a setup run that never tore down.
+live-test-clean:
+	./test/setup-live-targets.sh --teardown

--- a/test/README.md
+++ b/test/README.md
@@ -89,6 +89,24 @@ Options:
   --help             Show this help message
 ```
 
+The script is resilient to repeated runs: every started PID is recorded (per
+service, appended across runs), so `--teardown` kills **every** generation, not
+just the most recent. Running setup again without a teardown first detects and
+kills the stale processes from the previous run (logged as `Killing stale
+process …`) before starting fresh, so orphans never accumulate and exhaust the
+port range. If the pid logs are lost, teardown also sweeps orphans by executable
+name (Go targets) or listening port (the `node`-based graphql-server).
+
+Shortcut escape hatch for orphaned services:
+
+```bash
+make live-test-clean        # == ./test/setup-live-targets.sh --teardown
+```
+
+A regression test (`test/setup-live-targets_test.sh`) covers the
+teardown/sweep/port-exhaustion behavior with lightweight stand-ins and needs no
+live services — run it directly: `./test/setup-live-targets_test.sh`.
+
 ### run-live-tests.sh
 
 ```bash
@@ -314,7 +332,9 @@ test/
 
 ### Port conflicts
 
-If setup fails with port errors, use `--teardown` first, then retry:
+If setup fails with a "Cannot find available port" error, it now prints the
+processes holding the port window so you can see what to stop. Use `--teardown`
+(or `make live-test-clean`) first, then retry:
 
 ```bash
 ./test/setup-live-targets.sh --teardown

--- a/test/README.md
+++ b/test/README.md
@@ -86,6 +86,7 @@ Options:
                      Valid: rest-api,soap-service,graphql-server,grpc-server
   --skip-start       Only build, don't start services
   --teardown         Stop all running targets and clean up
+  --sweep            With --teardown, also sweep untracked orphans by name/port
   --help             Show this help message
 ```
 
@@ -94,13 +95,19 @@ service, appended across runs), so `--teardown` kills **every** generation, not
 just the most recent. Running setup again without a teardown first detects and
 kills the stale processes from the previous run (logged as `Killing stale
 process …`) before starting fresh, so orphans never accumulate and exhaust the
-port range. If the pid logs are lost, teardown also sweeps orphans by executable
-name (Go targets) or listening port (the `node`-based graphql-server).
+port range.
 
-Shortcut escape hatch for orphaned services:
+Because every generation is recorded, normal teardown never needs to guess which
+processes are ours. The broad orphan sweep — killing by executable basename (Go
+targets) or any `node` listening in the graphql port window — is therefore
+**opt-in** via `--sweep`, and off by default: it matches purely by name/port and
+could otherwise kill an unrelated process (a developer's own same-named service,
+or any `node` on those ports). Reach for it only to recover a pre-existing orphan
+whose pid log was lost:
 
 ```bash
-make live-test-clean        # == ./test/setup-live-targets.sh --teardown
+make live-test-clean                        # == --teardown; kills recorded PIDs only (safe)
+./test/setup-live-targets.sh --teardown --sweep   # also sweep untracked orphans (last resort)
 ```
 
 A regression test (`test/setup-live-targets_test.sh`) covers the

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -717,6 +717,7 @@ parse_args() {
     PARSED_TARGETS="$ALL_TARGETS"
     PARSED_SKIP_START=false
     PARSED_TEARDOWN=false
+    SWEEP_ORPHANS=false   # reset with the other parsed flags so parse_args is idempotent
 
     while [ $# -gt 0 ]; do
         case "$1" in

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -12,6 +12,8 @@
 #                      Valid: rest-api,soap-service,graphql-server,concat-spa
 #   --skip-start       Only build, don't start services
 #   --teardown         Stop all running targets and clean up
+#   --sweep            With --teardown, also sweep untracked orphans by name/port
+#                      (off by default; can match unrelated processes)
 #   --help             Show this help message
 
 set -euo pipefail
@@ -32,6 +34,14 @@ STATE_DIR="${SETUP_LIVE_TARGETS_STATE_DIR:-$SCRIPT_DIR}"
 # cleanup, and orphan sweeps all iterate the same set.
 MANAGED_SERVICES="rest-api soap-service graphql-server grpc-server concat-spa"
 CONFIG_FILE="${STATE_DIR}/.live-test-config"
+
+# Whether teardown may fall back to the broad orphan sweep (kill by executable
+# basename / listening port) for a service that has no pid log. OFF by default:
+# the pid log records every started generation, so a normal teardown never needs
+# it, and the sweep can match UNRELATED processes — a developer's own same-named
+# service, or any `node` listening in the graphql port window. Enable explicitly
+# with `--sweep` for the rare pre-existing-orphan / lost-pid-log case.
+SWEEP_ORPHANS=false
 
 # Default ports
 DEFAULT_REST_API_PORT=8990
@@ -476,8 +486,9 @@ orphan_pids_by_port() {
 # Kill orphaned processes for a service whose pid log was lost. Go services have
 # unique executable names and are swept by exact basename; graphql-server runs
 # as `node`, so it is swept by its listening-port window. Echoes the number of
-# processes killed. Called by stop_service ONLY when no pid log existed — the
-# pid log is the primary, reliable mechanism; this is the fallback.
+# processes killed. Called by stop_service ONLY under --sweep AND when no pid log
+# existed — the pid log is the primary, reliable mechanism; this opt-in fallback
+# can match unrelated processes, so it is never run by default.
 sweep_orphans() {
     local name=$1 killed=0 binary base pid
     binary="$(service_binary "$name")"
@@ -521,9 +532,10 @@ stop_service() {
     done < <(recorded_pids "$name")
     clear_recorded_pids "$name"
 
-    # Belt-and-suspenders: the broad orphan sweep runs only when the pid log was
-    # lost. A normal teardown after setup has the log and never reaches here.
-    if [ "$no_log" -ne 0 ]; then
+    # Fallback orphan sweep: opt-in (--sweep) AND only when this service has no
+    # pid log. Off by default because the sweep matches by name/port and can hit
+    # unrelated processes; the pid log already covers every normal teardown.
+    if [ "$no_log" -ne 0 ] && [ "$SWEEP_ORPHANS" = true ]; then
         stopped=$((stopped + $(sweep_orphans "$name")))
     fi
 
@@ -620,12 +632,15 @@ usage() {
     echo "                     Valid: rest-api,soap-service,graphql-server,grpc-server,concat-spa"
     echo "  --skip-start       Only build, don't start services"
     echo "  --teardown         Stop all running targets and clean up"
+    echo "  --sweep            With --teardown, also sweep untracked orphans by"
+    echo "                     name/port (off by default; can match unrelated processes)"
     echo "  --help             Show this help message"
     echo ""
     echo "Examples:"
     echo "  $0                              # Build and start all targets"
     echo "  $0 --targets rest-api           # Only set up rest-api"
     echo "  $0 --teardown                   # Stop everything and clean up"
+    echo "  $0 --teardown --sweep           # Also sweep untracked orphans (last resort)"
 }
 
 main() {
@@ -645,6 +660,10 @@ main() {
                 ;;
             --teardown)
                 teardown=true
+                shift
+                ;;
+            --sweep)
+                SWEEP_ORPHANS=true
                 shift
                 ;;
             --help)

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -16,8 +16,14 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# SCRIPT_DIR may be pre-set by the regression test to isolate PID/state files in
+# a temp dir; default to the directory this script lives in.
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Services managed by this script. Kept in one place so teardown, stale-state
+# cleanup, and orphan sweeps all iterate the same set.
+MANAGED_SERVICES="rest-api soap-service graphql-server grpc-server concat-spa"
 CONFIG_FILE="${SCRIPT_DIR}/.live-test-config"
 
 # Default ports
@@ -59,6 +65,22 @@ find_available_port() {
         fi
     done
     echo "$port"
+}
+
+# Print the processes holding the port window [base, base+20] so an exhausted
+# range points the engineer straight at the offending orphans.
+show_port_holders() {
+    local base=$1
+    local end=$((base + 20))
+    log_info "Listening processes on TCP ${base}-${end}:"
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -nP -iTCP:"${base}-${end}" -sTCP:LISTEN 2>/dev/null | sed 's/^/    /' || true
+    elif command -v ss >/dev/null 2>&1; then
+        ss -ltnH 2>/dev/null | awk -v b="$base" -v e="$end" \
+            '{ n = split($4, a, ":"); p = a[n]; if (p >= b && p <= e) print "    " $0 }' || true
+    else
+        log_info "    (install lsof or ss to list port holders)"
+    fi
 }
 
 # ──────────────────────────────────────────────────────────────
@@ -195,13 +217,62 @@ wait_for_http() {
     done
 }
 
+# Append a started PID to the service's pid log. Every generation is recorded
+# (append, not overwrite) so teardown can kill them all, not just the latest.
+record_pid() {
+    local name=$1 pid=$2
+    echo "$pid" >> "${SCRIPT_DIR}/.${name}.pids"
+}
+
+# Kill a PID if it is alive: TERM, brief grace period, then KILL. Works for
+# processes started by a *previous* setup run (not children of this shell), so
+# it polls for exit instead of relying on `wait`. Returns 0 if the PID was
+# alive (and is now signalled), 1 if it was already gone.
+kill_pid() {
+    local pid=$1
+    kill -0 "$pid" 2>/dev/null || return 1
+    kill "$pid" 2>/dev/null || true
+    local _
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        kill -0 "$pid" 2>/dev/null || return 0
+        sleep 0.2
+    done
+    kill -9 "$pid" 2>/dev/null || true
+    return 0
+}
+
+# Exact process basename to sweep for a service, or empty when it must be swept
+# by port instead. graphql-server runs as `node server.js`, so sweeping it by
+# name would kill unrelated node processes — it is swept by port in stop_service.
+service_binary() {
+    case "$1" in
+        rest-api)     echo "rest-api" ;;
+        soap-service) echo "soap-service" ;;
+        concat-spa)   echo "concat-spa" ;;
+        grpc-server)  echo "grpc-server" ;;
+        *)            echo "" ;;
+    esac
+}
+
+# Default base port for a service, used for port-based orphan sweeps.
+service_default_port() {
+    case "$1" in
+        rest-api)       echo "$DEFAULT_REST_API_PORT" ;;
+        soap-service)   echo "$DEFAULT_SOAP_SERVICE_PORT" ;;
+        graphql-server) echo "$DEFAULT_GRAPHQL_SERVER_PORT" ;;
+        grpc-server)    echo "$DEFAULT_GRPC_SERVER_PORT" ;;
+        concat-spa)     echo "$DEFAULT_CONCAT_SPA_PORT" ;;
+        *)              echo "" ;;
+    esac
+}
+
 start_rest_api() {
     local port=$1
     log_info "Starting rest-api on port ${port}..."
     cd "${SCRIPT_DIR}/rest-api"
     PORT="$port" ./rest-api &
     local pid=$!
-    echo "$pid" > "${SCRIPT_DIR}/.rest-api.pid"
+    record_pid rest-api "$pid"
 
     if wait_for_http "http://localhost:${port}/api/health" 15; then
         log_ok "rest-api started (PID: ${pid}, port: ${port})"
@@ -218,7 +289,7 @@ start_concat_spa() {
     cd "${SCRIPT_DIR}/concat-spa"
     PORT="$port" ./concat-spa &
     local pid=$!
-    echo "$pid" > "${SCRIPT_DIR}/.concat-spa.pid"
+    record_pid concat-spa "$pid"
 
     if wait_for_http "http://localhost:${port}/healthz" 15; then
         log_ok "concat-spa started (PID: ${pid}, port: ${port})"
@@ -235,7 +306,7 @@ start_soap_service() {
     cd "${SCRIPT_DIR}/soap-service"
     PORT="$port" WSDL_PATH="${SCRIPT_DIR}/soap-service/service.wsdl" ./soap-service &
     local pid=$!
-    echo "$pid" > "${SCRIPT_DIR}/.soap-service.pid"
+    record_pid soap-service "$pid"
 
     if wait_for_http "http://localhost:${port}/service.wsdl" 15; then
         log_ok "soap-service started (PID: ${pid}, port: ${port})"
@@ -252,7 +323,7 @@ start_graphql_server() {
     cd "${SCRIPT_DIR}/graphql-server"
     PORT="$port" node server.js > "${SCRIPT_DIR}/.graphql-server.log" 2>&1 &
     local pid=$!
-    echo "$pid" > "${SCRIPT_DIR}/.graphql-server.pid"
+    record_pid graphql-server "$pid"
 
     if wait_for_http "http://localhost:${port}/" 15; then
         log_ok "graphql-server started (PID: ${pid}, port: ${port})"
@@ -296,7 +367,7 @@ start_grpc_server() {
     cd "${SCRIPT_DIR}/grpc-server"
     GRPC_PORT="$port" ./grpc-server &
     local pid=$!
-    echo "$pid" > "${SCRIPT_DIR}/.grpc-server.pid"
+    record_pid grpc-server "$pid"
 
     if wait_for_grpc "localhost" "${port}" 15; then
         log_ok "grpc-server started (PID: ${pid}, port: ${port})"
@@ -307,24 +378,94 @@ start_grpc_server() {
     fi
 }
 
+# Kill every PID recorded for a service, across all setup generations, then
+# sweep any orphans whose pid log was lost. Idempotent.
 stop_service() {
     local name=$1
-    local pidfile="${SCRIPT_DIR}/.${name}.pid"
+    local stopped=0
+    local pidfile pid
 
-    if [ -f "$pidfile" ]; then
-        local pid
-        pid=$(cat "$pidfile")
-        if kill -0 "$pid" 2>/dev/null; then
-            kill "$pid" 2>/dev/null || true
-            wait "$pid" 2>/dev/null || true
-            log_ok "Stopped ${name} (PID: ${pid})"
-        else
-            log_info "${name} already stopped"
-        fi
+    # 1. Kill every recorded generation. Read both the append-log (.pids, current
+    #    format) and any legacy single-PID file (.pid) left by older setups.
+    for pidfile in "${SCRIPT_DIR}/.${name}.pids" "${SCRIPT_DIR}/.${name}.pid"; do
+        [ -f "$pidfile" ] || continue
+        while read -r pid || [ -n "$pid" ]; do
+            [ -n "${pid//[[:space:]]/}" ] || continue
+            if kill_pid "$pid"; then
+                log_ok "Stopped ${name} (PID: ${pid})"
+                stopped=$((stopped + 1))
+            fi
+        done < "$pidfile"
         rm -f "$pidfile"
+    done
+
+    # 2. Belt-and-suspenders sweep for orphans not covered by a pid log.
+    stopped=$((stopped + $(sweep_orphans "$name")))
+
+    if [ "$stopped" -eq 0 ]; then
+        log_info "${name}: no running processes found"
+    fi
+}
+
+# Kill orphaned processes for a service that are not tracked in a pid log.
+# Go services have unique executable names and are swept by exact basename
+# (current user only). graphql-server runs as `node`, so it is swept by its
+# listening-port window instead — sweeping `node` by name is unsafe.
+# Echoes the number of processes killed.
+sweep_orphans() {
+    local name=$1
+    local killed=0
+    local binary pid
+    binary=$(service_binary "$name")
+
+    if [ -n "$binary" ] && command -v pgrep >/dev/null 2>&1; then
+        for pid in $(pgrep -x -U "$(id -u)" "$binary" 2>/dev/null || true); do
+            if kill_pid "$pid"; then
+                log_warn "Swept orphan ${name} (PID: ${pid}, matched '${binary}')" >&2
+                killed=$((killed + 1))
+            fi
+        done
     else
-        # Try pkill as fallback
-        pkill -f "${SCRIPT_DIR}/${name}" 2>/dev/null && log_ok "Stopped ${name} via pkill" || true
+        # Port-based sweep across the window setup could have used (base..base+20).
+        local base port
+        base=$(service_default_port "$name")
+        if [ -n "$base" ] && command -v lsof >/dev/null 2>&1; then
+            for port in $(seq "$base" $((base + 20))); do
+                for pid in $(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true); do
+                    if kill_pid "$pid"; then
+                        log_warn "Swept orphan ${name} (PID: ${pid}, port ${port})" >&2
+                        killed=$((killed + 1))
+                    fi
+                done
+            done
+        fi
+    fi
+
+    echo "$killed"
+}
+
+# Detect and kill processes left behind by a previous setup that did not tear
+# down (e.g. "ran setup twice"). Logs an explicit line per stale process so the
+# accidental-double-setup case is no longer silent.
+cleanup_stale_state() {
+    local found=0
+    local name pidfile pid
+    for name in $MANAGED_SERVICES; do
+        for pidfile in "${SCRIPT_DIR}/.${name}.pids" "${SCRIPT_DIR}/.${name}.pid"; do
+            [ -f "$pidfile" ] || continue
+            while read -r pid || [ -n "$pid" ]; do
+                [ -n "${pid//[[:space:]]/}" ] || continue
+                if kill -0 "$pid" 2>/dev/null; then
+                    log_warn "Killing stale process ${name} (PID: ${pid}) from a previous setup"
+                    kill_pid "$pid" || true
+                    found=1
+                fi
+            done < "$pidfile"
+            rm -f "$pidfile"
+        done
+    done
+    if [ "$found" -eq 1 ]; then
+        log_ok "Cleared stale processes from a previous run"
     fi
 }
 
@@ -335,20 +476,17 @@ stop_service() {
 do_teardown() {
     log_header "Tearing Down Live Targets"
 
-    stop_service "rest-api"
-    stop_service "soap-service"
-    stop_service "graphql-server"
-    stop_service "grpc-server"
-    stop_service "concat-spa"
+    local name
+    for name in $MANAGED_SERVICES; do
+        stop_service "$name"
+    done
 
-    # Clean up config and PID files
+    # Clean up config, PID logs (both formats), and other state.
     rm -f "${CONFIG_FILE}"
-    rm -f "${SCRIPT_DIR}/.rest-api.pid"
-    rm -f "${SCRIPT_DIR}/.soap-service.pid"
-    rm -f "${SCRIPT_DIR}/.graphql-server.pid"
-    rm -f "${SCRIPT_DIR}/.concat-spa.pid"
+    for name in $MANAGED_SERVICES; do
+        rm -f "${SCRIPT_DIR}/.${name}.pid" "${SCRIPT_DIR}/.${name}.pids"
+    done
     rm -f "${SCRIPT_DIR}/.graphql-server.log"
-    rm -f "${SCRIPT_DIR}/.grpc-server.pid"
     rm -rf "${SCRIPT_DIR}/.results"
 
     log_ok "Teardown complete"
@@ -463,6 +601,10 @@ main() {
         exit 0
     fi
 
+    # ── Clear any leftovers from a previous setup that never tore down ──
+    # Frees ports held by stale orphans before we probe for availability.
+    cleanup_stale_state
+
     # ── Resolve ports and start services ──
     # Each port is resolved immediately before starting that service so the
     # next service's port check sees the previous one as occupied.
@@ -473,45 +615,52 @@ main() {
     for target in "${TARGET_ARRAY[@]}"; do
         case "$target" in
             rest-api)
-                REST_API_PORT=$(find_available_port "$DEFAULT_REST_API_PORT")
+                # `|| true` disarms `set -e` for this substitution so the
+                # `[ -z ]` check below runs instead of the script dying silently.
+                REST_API_PORT=$(find_available_port "$DEFAULT_REST_API_PORT") || true
                 if [ -z "$REST_API_PORT" ]; then
                     log_fail "Cannot find available port for rest-api (tried ${DEFAULT_REST_API_PORT}-$((DEFAULT_REST_API_PORT + 20)))"
+                    show_port_holders "$DEFAULT_REST_API_PORT"
                     exit 1
                 fi
                 log_ok "rest-api: port ${REST_API_PORT}"
                 start_rest_api "$REST_API_PORT" || start_failed=1
                 ;;
             soap-service)
-                SOAP_SERVICE_PORT=$(find_available_port "$DEFAULT_SOAP_SERVICE_PORT")
+                SOAP_SERVICE_PORT=$(find_available_port "$DEFAULT_SOAP_SERVICE_PORT") || true
                 if [ -z "$SOAP_SERVICE_PORT" ]; then
                     log_fail "Cannot find available port for soap-service (tried ${DEFAULT_SOAP_SERVICE_PORT}-$((DEFAULT_SOAP_SERVICE_PORT + 20)))"
+                    show_port_holders "$DEFAULT_SOAP_SERVICE_PORT"
                     exit 1
                 fi
                 log_ok "soap-service: port ${SOAP_SERVICE_PORT}"
                 start_soap_service "$SOAP_SERVICE_PORT" || start_failed=1
                 ;;
             graphql-server)
-                GRAPHQL_SERVER_PORT=$(find_available_port "$DEFAULT_GRAPHQL_SERVER_PORT")
+                GRAPHQL_SERVER_PORT=$(find_available_port "$DEFAULT_GRAPHQL_SERVER_PORT") || true
                 if [ -z "$GRAPHQL_SERVER_PORT" ]; then
                     log_fail "Cannot find available port for graphql-server (tried ${DEFAULT_GRAPHQL_SERVER_PORT}-$((DEFAULT_GRAPHQL_SERVER_PORT + 20)))"
+                    show_port_holders "$DEFAULT_GRAPHQL_SERVER_PORT"
                     exit 1
                 fi
                 log_ok "graphql-server: port ${GRAPHQL_SERVER_PORT}"
                 start_graphql_server "$GRAPHQL_SERVER_PORT" || start_failed=1
                 ;;
             grpc-server)
-                GRPC_SERVER_PORT=$(find_available_port "$DEFAULT_GRPC_SERVER_PORT")
+                GRPC_SERVER_PORT=$(find_available_port "$DEFAULT_GRPC_SERVER_PORT") || true
                 if [ -z "$GRPC_SERVER_PORT" ]; then
                     log_fail "Cannot find available port for grpc-server (tried ${DEFAULT_GRPC_SERVER_PORT}-$((DEFAULT_GRPC_SERVER_PORT + 20)))"
+                    show_port_holders "$DEFAULT_GRPC_SERVER_PORT"
                     exit 1
                 fi
                 log_ok "grpc-server: port ${GRPC_SERVER_PORT}"
                 start_grpc_server "$GRPC_SERVER_PORT" || start_failed=1
                 ;;
             concat-spa)
-                CONCAT_SPA_PORT=$(find_available_port "$DEFAULT_CONCAT_SPA_PORT")
+                CONCAT_SPA_PORT=$(find_available_port "$DEFAULT_CONCAT_SPA_PORT") || true
                 if [ -z "$CONCAT_SPA_PORT" ]; then
                     log_fail "Cannot find available port for concat-spa (tried ${DEFAULT_CONCAT_SPA_PORT}-$((DEFAULT_CONCAT_SPA_PORT + 20)))"
+                    show_port_holders "$DEFAULT_CONCAT_SPA_PORT"
                     exit 1
                 fi
                 log_ok "concat-spa: port ${CONCAT_SPA_PORT}"
@@ -533,4 +682,8 @@ main() {
     log_info "Tear down with: ./test/setup-live-targets.sh --teardown"
 }
 
-main "$@"
+# Run main only when executed directly. When sourced (by the regression test)
+# the functions are defined but main does not run.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -303,19 +303,40 @@ service_default_port() {
 }
 
 # True if $pid is alive AND its command matches the identity expected for service
-# $name — the Go binary basename, or `node` for the node-based graphql-server.
-# PID logs and PID files can outlive a reboot, after which the OS may recycle a
-# recorded PID onto an unrelated process; this guard stops us from killing that
-# innocent process. `comm` is compared by basename to tolerate macOS returning a
-# full path where Linux returns the bare (≤15 char) name.
+# $name. PID logs and PID files can outlive a reboot, after which the OS may
+# recycle a recorded PID onto an unrelated process; this guard stops us from
+# killing that innocent process. `comm` is compared by basename to tolerate macOS
+# returning a full path where Linux returns the bare (≤15 char) name.
+#
+# Services with a unique executable (the Go targets) match by exact basename.
+# graphql-server has no unique name — it runs as `node server.js`, and `comm` for
+# any node process is just `node` — so an exact-name match alone would accept ANY
+# of the user's node processes onto which the recorded PID may have been recycled.
+# For it we additionally require the PID to be listening in the service's port
+# window, reusing the same node-in-window identity filter as the orphan sweep
+# (orphan_pids_by_port). If that check cannot run (e.g. lsof unavailable) we
+# decline the match rather than kill an unverified node process.
 pid_matches_service() {
-    local pid=$1 name=$2 comm binary
+    local pid=$1 name=$2 comm binary base wpid
     comm="$(ps -p "$pid" -o comm= 2>/dev/null)"
     comm="$(basename "$comm" 2>/dev/null)"
     [ -n "$comm" ] || return 1
+
     binary="$(service_binary "$name")"
-    [ -n "$binary" ] || binary="node"
-    [ "$comm" = "$binary" ]
+    if [ -n "$binary" ]; then
+        [ "$comm" = "$binary" ]
+        return
+    fi
+
+    # No unique binary → node-based graphql-server: require node AND a listening
+    # socket in the service's port window before treating it as a match.
+    [ "$comm" = "node" ] || return 1
+    base="$(service_default_port "$name")"
+    [ -n "$base" ] || return 1
+    for wpid in $(orphan_pids_by_port "$base"); do
+        [ "$wpid" = "$pid" ] && return 0
+    done
+    return 1
 }
 
 start_rest_api() {

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -16,15 +16,22 @@
 
 set -euo pipefail
 
-# SCRIPT_DIR may be pre-set by the regression test to isolate PID/state files in
-# a temp dir; default to the directory this script lives in.
-SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+# Directory this script lives in. Resolved from BASH_SOURCE only — never trusted
+# from the environment, since it decides where common.sh is sourced from and
+# where the service binaries are executed.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Directory for mutable state: PID logs, config, service logs. Defaults to
+# SCRIPT_DIR. The regression test points this at a temp dir (via the dedicated
+# SETUP_LIVE_TARGETS_STATE_DIR override) to isolate state, without redirecting
+# where the script sources code from.
+STATE_DIR="${SETUP_LIVE_TARGETS_STATE_DIR:-$SCRIPT_DIR}"
 
 # Services managed by this script. Kept in one place so teardown, stale-state
 # cleanup, and orphan sweeps all iterate the same set.
 MANAGED_SERVICES="rest-api soap-service graphql-server grpc-server concat-spa"
-CONFIG_FILE="${SCRIPT_DIR}/.live-test-config"
+CONFIG_FILE="${STATE_DIR}/.live-test-config"
 
 # Default ports
 DEFAULT_REST_API_PORT=8990
@@ -80,6 +87,25 @@ show_port_holders() {
             '{ n = split($4, a, ":"); p = a[n]; if (p >= b && p <= e) print "    " $0 }' || true
     else
         log_info "    (install lsof or ss to list port holders)"
+    fi
+}
+
+# Resolve an available port for a service, or exit 1 after logging a diagnostic
+# that names the processes holding the range. On success sets RESOLVED_PORT.
+#
+# Callers MUST invoke this as a statement, never inside `$(...)`: `exit` in a
+# command substitution kills only the subshell, so the script would carry on
+# with an empty port. The `|| true` disarms `set -e` for the command
+# substitution so the `[ -z ]` check runs instead of the script dying silently
+# on an exhausted range (LAB-2893 Bug 2).
+RESOLVED_PORT=""
+resolve_port_or_die() {
+    local name=$1 default_port=$2
+    RESOLVED_PORT="$(find_available_port "$default_port")" || true
+    if [ -z "$RESOLVED_PORT" ]; then
+        log_fail "Cannot find available port for ${name} (tried ${default_port}-$((default_port + 20)))"
+        show_port_holders "$default_port"
+        exit 1
     fi
 }
 
@@ -221,7 +247,7 @@ wait_for_http() {
 # (append, not overwrite) so teardown can kill them all, not just the latest.
 record_pid() {
     local name=$1 pid=$2
-    echo "$pid" >> "${SCRIPT_DIR}/.${name}.pids"
+    echo "$pid" >> "${STATE_DIR}/.${name}.pids"
 }
 
 # Kill a PID if it is alive: TERM, brief grace period, then KILL. Works for
@@ -264,6 +290,22 @@ service_default_port() {
         concat-spa)     echo "$DEFAULT_CONCAT_SPA_PORT" ;;
         *)              echo "" ;;
     esac
+}
+
+# True if $pid is alive AND its command matches the identity expected for service
+# $name — the Go binary basename, or `node` for the node-based graphql-server.
+# PID logs and PID files can outlive a reboot, after which the OS may recycle a
+# recorded PID onto an unrelated process; this guard stops us from killing that
+# innocent process. `comm` is compared by basename to tolerate macOS returning a
+# full path where Linux returns the bare (≤15 char) name.
+pid_matches_service() {
+    local pid=$1 name=$2 comm binary
+    comm="$(ps -p "$pid" -o comm= 2>/dev/null)"
+    comm="$(basename "$comm" 2>/dev/null)"
+    [ -n "$comm" ] || return 1
+    binary="$(service_binary "$name")"
+    [ -n "$binary" ] || binary="node"
+    [ "$comm" = "$binary" ]
 }
 
 start_rest_api() {
@@ -321,7 +363,7 @@ start_graphql_server() {
     local port=$1
     log_info "Starting graphql-server on port ${port}..."
     cd "${SCRIPT_DIR}/graphql-server"
-    PORT="$port" node server.js > "${SCRIPT_DIR}/.graphql-server.log" 2>&1 &
+    PORT="$port" node server.js > "${STATE_DIR}/.graphql-server.log" 2>&1 &
     local pid=$!
     record_pid graphql-server "$pid"
 
@@ -378,65 +420,83 @@ start_grpc_server() {
     fi
 }
 
-# Kill every PID recorded for a service, across all setup generations, then
-# sweep any orphans whose pid log was lost. Idempotent.
-stop_service() {
-    local name=$1
-    local stopped=0
-    local pidfile pid
-
-    # 1. Kill every recorded generation. Read both the append-log (.pids, current
-    #    format) and any legacy single-PID file (.pid) left by older setups.
-    for pidfile in "${SCRIPT_DIR}/.${name}.pids" "${SCRIPT_DIR}/.${name}.pid"; do
+# Echo every PID recorded for a service, one per line, skipping blanks. Reads
+# both the append-log (.pids, current format) and any legacy single-PID file
+# (.pid) left by older setups. Read-only — the caller decides when to clear.
+recorded_pids() {
+    local name=$1 pidfile pid
+    for pidfile in "${STATE_DIR}/.${name}.pids" "${STATE_DIR}/.${name}.pid"; do
         [ -f "$pidfile" ] || continue
         while read -r pid || [ -n "$pid" ]; do
             [ -n "${pid//[[:space:]]/}" ] || continue
-            if kill_pid "$pid"; then
-                log_ok "Stopped ${name} (PID: ${pid})"
-                stopped=$((stopped + 1))
-            fi
+            echo "$pid"
         done < "$pidfile"
-        rm -f "$pidfile"
     done
-
-    # 2. Belt-and-suspenders sweep for orphans not covered by a pid log.
-    stopped=$((stopped + $(sweep_orphans "$name")))
-
-    if [ "$stopped" -eq 0 ]; then
-        log_info "${name}: no running processes found"
-    fi
 }
 
-# Kill orphaned processes for a service that are not tracked in a pid log.
-# Go services have unique executable names and are swept by exact basename
-# (current user only). graphql-server runs as `node`, so it is swept by its
-# listening-port window instead — sweeping `node` by name is unsafe.
-# Echoes the number of processes killed.
-sweep_orphans() {
+# Remove both pid-log formats for a service.
+clear_recorded_pids() {
     local name=$1
-    local killed=0
-    local binary pid
-    binary=$(service_binary "$name")
+    rm -f "${STATE_DIR}/.${name}.pids" "${STATE_DIR}/.${name}.pid"
+}
 
-    if [ -n "$binary" ] && command -v pgrep >/dev/null 2>&1; then
-        for pid in $(pgrep -x -U "$(id -u)" "$binary" 2>/dev/null || true); do
+# True if a pid log (either format) exists for a service.
+has_recorded_pids() {
+    local name=$1
+    [ -f "${STATE_DIR}/.${name}.pids" ] || [ -f "${STATE_DIR}/.${name}.pid" ]
+}
+
+# Orphan-discovery seams. Overridable when the script is sourced: the regression
+# test stubs these so its sweeps stay confined to the test's own stand-ins and
+# never touch the developer's real process table.
+#
+# By exact executable basename, current user only. `pgrep -x` matches the whole
+# name (not a substring), so only a process actually named "$1" is returned.
+orphan_pids_by_name() {
+    command -v pgrep >/dev/null 2>&1 || return 0
+    pgrep -x -U "$(id -u)" "$1" 2>/dev/null || true
+}
+
+# By listening-port window [base, base+20], restricted to `node` processes: the
+# graphql-server runs as `node`, and the identity filter avoids killing an
+# unrelated service that merely listens in the same range. `-nP` skips the
+# reverse-DNS / port-name lookups that could otherwise hang teardown.
+orphan_pids_by_port() {
+    local base=$1
+    local end=$((base + 20)) port pid comm
+    command -v lsof >/dev/null 2>&1 || return 0
+    for port in $(seq "$base" "$end"); do
+        for pid in $(lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true); do
+            comm="$(ps -p "$pid" -o comm= 2>/dev/null)"
+            [ "$(basename "$comm" 2>/dev/null)" = "node" ] && echo "$pid"
+        done
+    done
+}
+
+# Kill orphaned processes for a service whose pid log was lost. Go services have
+# unique executable names and are swept by exact basename; graphql-server runs
+# as `node`, so it is swept by its listening-port window. Echoes the number of
+# processes killed. Called by stop_service ONLY when no pid log existed — the
+# pid log is the primary, reliable mechanism; this is the fallback.
+sweep_orphans() {
+    local name=$1 killed=0 binary base pid
+    binary="$(service_binary "$name")"
+
+    if [ -n "$binary" ]; then
+        for pid in $(orphan_pids_by_name "$binary"); do
             if kill_pid "$pid"; then
                 log_warn "Swept orphan ${name} (PID: ${pid}, matched '${binary}')" >&2
                 killed=$((killed + 1))
             fi
         done
     else
-        # Port-based sweep across the window setup could have used (base..base+20).
-        local base port
-        base=$(service_default_port "$name")
-        if [ -n "$base" ] && command -v lsof >/dev/null 2>&1; then
-            for port in $(seq "$base" $((base + 20))); do
-                for pid in $(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true); do
-                    if kill_pid "$pid"; then
-                        log_warn "Swept orphan ${name} (PID: ${pid}, port ${port})" >&2
-                        killed=$((killed + 1))
-                    fi
-                done
+        base="$(service_default_port "$name")"
+        if [ -n "$base" ]; then
+            for pid in $(orphan_pids_by_port "$base"); do
+                if kill_pid "$pid"; then
+                    log_warn "Swept orphan ${name} (PID: ${pid}, node in port window)" >&2
+                    killed=$((killed + 1))
+                fi
             done
         fi
     fi
@@ -444,25 +504,56 @@ sweep_orphans() {
     echo "$killed"
 }
 
+# Kill every PID recorded for a service across all setup generations, then — only
+# if no pid log was found — sweep orphans left by a run whose log was lost. Every
+# recorded PID is identity-checked before signalling (see pid_matches_service),
+# so a recycled PID is skipped rather than killed. Idempotent.
+stop_service() {
+    local name=$1 stopped=0 pid no_log=1
+    has_recorded_pids "$name" && no_log=0
+
+    while read -r pid; do
+        pid_matches_service "$pid" "$name" || continue
+        if kill_pid "$pid"; then
+            log_ok "Stopped ${name} (PID: ${pid})"
+            stopped=$((stopped + 1))
+        fi
+    done < <(recorded_pids "$name")
+    clear_recorded_pids "$name"
+
+    # Belt-and-suspenders: the broad orphan sweep runs only when the pid log was
+    # lost. A normal teardown after setup has the log and never reaches here.
+    if [ "$no_log" -ne 0 ]; then
+        stopped=$((stopped + $(sweep_orphans "$name")))
+    fi
+
+    if [ "$stopped" -eq 0 ]; then
+        log_info "${name}: no running processes found"
+    fi
+}
+
 # Detect and kill processes left behind by a previous setup that did not tear
 # down (e.g. "ran setup twice"). Logs an explicit line per stale process so the
-# accidental-double-setup case is no longer silent.
+# accidental-double-setup case is no longer silent. Each recorded PID is
+# identity-checked first, so a recycled PID is skipped rather than killed.
+#
+# By design this relies solely on the pid log — it deliberately does NOT run the
+# broad basename/port orphan sweep that stop_service uses. Keeping the aggressive
+# sweep confined to the explicit teardown escape hatch avoids killing unrelated
+# processes on every routine setup. If a prior run's pid log was lost while its
+# process still holds a port, find_available_port simply steps past the occupied
+# port, and a truly exhausted range is reported by show_port_holders — so a fresh
+# setup still proceeds. Run `--teardown` to reap such an orphan.
 cleanup_stale_state() {
-    local found=0
-    local name pidfile pid
+    local found=0 name pid
     for name in $MANAGED_SERVICES; do
-        for pidfile in "${SCRIPT_DIR}/.${name}.pids" "${SCRIPT_DIR}/.${name}.pid"; do
-            [ -f "$pidfile" ] || continue
-            while read -r pid || [ -n "$pid" ]; do
-                [ -n "${pid//[[:space:]]/}" ] || continue
-                if kill -0 "$pid" 2>/dev/null; then
-                    log_warn "Killing stale process ${name} (PID: ${pid}) from a previous setup"
-                    kill_pid "$pid" || true
-                    found=1
-                fi
-            done < "$pidfile"
-            rm -f "$pidfile"
-        done
+        while read -r pid; do
+            pid_matches_service "$pid" "$name" || continue
+            log_warn "Killing stale process ${name} (PID: ${pid}) from a previous setup"
+            kill_pid "$pid" || true
+            found=1
+        done < <(recorded_pids "$name")
+        clear_recorded_pids "$name"
     done
     if [ "$found" -eq 1 ]; then
         log_ok "Cleared stale processes from a previous run"
@@ -484,10 +575,10 @@ do_teardown() {
     # Clean up config, PID logs (both formats), and other state.
     rm -f "${CONFIG_FILE}"
     for name in $MANAGED_SERVICES; do
-        rm -f "${SCRIPT_DIR}/.${name}.pid" "${SCRIPT_DIR}/.${name}.pids"
+        clear_recorded_pids "$name"
     done
-    rm -f "${SCRIPT_DIR}/.graphql-server.log"
-    rm -rf "${SCRIPT_DIR}/.results"
+    rm -f "${STATE_DIR}/.graphql-server.log"
+    rm -rf "${STATE_DIR}/.results"
 
     log_ok "Teardown complete"
 }
@@ -615,54 +706,32 @@ main() {
     for target in "${TARGET_ARRAY[@]}"; do
         case "$target" in
             rest-api)
-                # `|| true` disarms `set -e` for this substitution so the
-                # `[ -z ]` check below runs instead of the script dying silently.
-                REST_API_PORT=$(find_available_port "$DEFAULT_REST_API_PORT") || true
-                if [ -z "$REST_API_PORT" ]; then
-                    log_fail "Cannot find available port for rest-api (tried ${DEFAULT_REST_API_PORT}-$((DEFAULT_REST_API_PORT + 20)))"
-                    show_port_holders "$DEFAULT_REST_API_PORT"
-                    exit 1
-                fi
+                resolve_port_or_die rest-api "$DEFAULT_REST_API_PORT"
+                REST_API_PORT=$RESOLVED_PORT
                 log_ok "rest-api: port ${REST_API_PORT}"
                 start_rest_api "$REST_API_PORT" || start_failed=1
                 ;;
             soap-service)
-                SOAP_SERVICE_PORT=$(find_available_port "$DEFAULT_SOAP_SERVICE_PORT") || true
-                if [ -z "$SOAP_SERVICE_PORT" ]; then
-                    log_fail "Cannot find available port for soap-service (tried ${DEFAULT_SOAP_SERVICE_PORT}-$((DEFAULT_SOAP_SERVICE_PORT + 20)))"
-                    show_port_holders "$DEFAULT_SOAP_SERVICE_PORT"
-                    exit 1
-                fi
+                resolve_port_or_die soap-service "$DEFAULT_SOAP_SERVICE_PORT"
+                SOAP_SERVICE_PORT=$RESOLVED_PORT
                 log_ok "soap-service: port ${SOAP_SERVICE_PORT}"
                 start_soap_service "$SOAP_SERVICE_PORT" || start_failed=1
                 ;;
             graphql-server)
-                GRAPHQL_SERVER_PORT=$(find_available_port "$DEFAULT_GRAPHQL_SERVER_PORT") || true
-                if [ -z "$GRAPHQL_SERVER_PORT" ]; then
-                    log_fail "Cannot find available port for graphql-server (tried ${DEFAULT_GRAPHQL_SERVER_PORT}-$((DEFAULT_GRAPHQL_SERVER_PORT + 20)))"
-                    show_port_holders "$DEFAULT_GRAPHQL_SERVER_PORT"
-                    exit 1
-                fi
+                resolve_port_or_die graphql-server "$DEFAULT_GRAPHQL_SERVER_PORT"
+                GRAPHQL_SERVER_PORT=$RESOLVED_PORT
                 log_ok "graphql-server: port ${GRAPHQL_SERVER_PORT}"
                 start_graphql_server "$GRAPHQL_SERVER_PORT" || start_failed=1
                 ;;
             grpc-server)
-                GRPC_SERVER_PORT=$(find_available_port "$DEFAULT_GRPC_SERVER_PORT") || true
-                if [ -z "$GRPC_SERVER_PORT" ]; then
-                    log_fail "Cannot find available port for grpc-server (tried ${DEFAULT_GRPC_SERVER_PORT}-$((DEFAULT_GRPC_SERVER_PORT + 20)))"
-                    show_port_holders "$DEFAULT_GRPC_SERVER_PORT"
-                    exit 1
-                fi
+                resolve_port_or_die grpc-server "$DEFAULT_GRPC_SERVER_PORT"
+                GRPC_SERVER_PORT=$RESOLVED_PORT
                 log_ok "grpc-server: port ${GRPC_SERVER_PORT}"
                 start_grpc_server "$GRPC_SERVER_PORT" || start_failed=1
                 ;;
             concat-spa)
-                CONCAT_SPA_PORT=$(find_available_port "$DEFAULT_CONCAT_SPA_PORT") || true
-                if [ -z "$CONCAT_SPA_PORT" ]; then
-                    log_fail "Cannot find available port for concat-spa (tried ${DEFAULT_CONCAT_SPA_PORT}-$((DEFAULT_CONCAT_SPA_PORT + 20)))"
-                    show_port_holders "$DEFAULT_CONCAT_SPA_PORT"
-                    exit 1
-                fi
+                resolve_port_or_die concat-spa "$DEFAULT_CONCAT_SPA_PORT"
+                CONCAT_SPA_PORT=$RESOLVED_PORT
                 log_ok "concat-spa: port ${CONCAT_SPA_PORT}"
                 start_concat_spa "$CONCAT_SPA_PORT" || start_failed=1
                 ;;

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -664,23 +664,28 @@ usage() {
     echo "  $0 --teardown --sweep           # Also sweep untracked orphans (last resort)"
 }
 
-main() {
-    local targets="$ALL_TARGETS"
-    local skip_start=false
-    local teardown=false
+# Parse CLI arguments into globals, separated from main() so the flag→variable
+# wiring (notably --sweep → SWEEP_ORPHANS) is unit-testable without running the
+# side-effecting setup/teardown main() performs. Sets PARSED_TARGETS,
+# PARSED_SKIP_START, PARSED_TEARDOWN and (on --sweep) SWEEP_ORPHANS. Exits on
+# --help (0) and unknown option (1), matching the original inline behaviour.
+parse_args() {
+    PARSED_TARGETS="$ALL_TARGETS"
+    PARSED_SKIP_START=false
+    PARSED_TEARDOWN=false
 
     while [ $# -gt 0 ]; do
         case "$1" in
             --targets)
-                targets="$2"
+                PARSED_TARGETS="$2"
                 shift 2
                 ;;
             --skip-start)
-                skip_start=true
+                PARSED_SKIP_START=true
                 shift
                 ;;
             --teardown)
-                teardown=true
+                PARSED_TEARDOWN=true
                 shift
                 ;;
             --sweep)
@@ -698,6 +703,13 @@ main() {
                 ;;
         esac
     done
+}
+
+main() {
+    parse_args "$@"
+    local targets="$PARSED_TARGETS"
+    local skip_start="$PARSED_SKIP_START"
+    local teardown="$PARSED_TEARDOWN"
 
     if [ "$teardown" = true ]; then
         do_teardown

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -538,13 +538,13 @@ orphan_pids_by_name() {
 # reverse-DNS / port-name lookups that could otherwise hang teardown.
 orphan_pids_by_port() {
     local base=$1
-    local end=$((base + 20)) port pid comm
+    local end=$((base + 20)) pid comm
     command -v lsof >/dev/null 2>&1 || return 0
-    for port in $(seq "$base" "$end"); do
-        for pid in $(lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true); do
-            comm="$(ps -p "$pid" -o comm= 2>/dev/null)"
-            [ "$(basename "$comm" 2>/dev/null)" = "node" ] && echo "$pid"
-        done
+    # One ranged lsof call (mirrors show_port_holders) instead of 21 per-port
+    # invocations; -t yields de-duplicated PIDs, which we then filter to node.
+    for pid in $(lsof -nP -tiTCP:"${base}-${end}" -sTCP:LISTEN 2>/dev/null || true); do
+        comm="$(ps -p "$pid" -o comm= 2>/dev/null)"
+        [ "$(basename "$comm" 2>/dev/null)" = "node" ] && echo "$pid"
     done
 }
 
@@ -750,6 +750,10 @@ parse_args() {
     done
 }
 
+# Pipeline orchestrator: parse args → teardown? → prereqs → build → stale
+# cleanup → resolve ports + start → write config. Intentionally longer than the
+# ~60-line guideline: each stage is a distinct sequential step that delegates to
+# a helper, with no shared state worth extracting into further functions.
 main() {
     parse_args "$@"
     local targets="$PARSED_TARGETS"

--- a/test/setup-live-targets_test.sh
+++ b/test/setup-live-targets_test.sh
@@ -15,6 +15,12 @@
 #   * Port exhaustion is detected AND the caller's failure path runs under
 #     `set -e` (Bug 2) instead of a silent exit.
 #   * show_port_holders lists the processes holding an exhausted range (AC2).
+#   * graphql-server (node) is matched only when node AND listening in its port
+#     window; kill_pid escalates SIGTERM -> SIGKILL.
+#   * parse_args maps the CLI flags (esp. --sweep -> SWEEP_ORPHANS, default off).
+#   * An already-dead recorded PID is handled gracefully (not counted stopped).
+#   * The real orphan-discovery seams filter by node-in-port-window and by exact
+#     basename + current user.
 #
 # No Go build, Node, or Chrome required — the test spawns lightweight stand-ins,
 # so it runs in the offline CI job. Run directly:
@@ -365,14 +371,23 @@ assert_eq "$PARSED_TARGETS" "rest-api,soap-service" "--targets captures the list
 assert_eq "$rc" "1" "unknown option exits 1"
 SWEEP_ORPHANS=false
 
-# ── Test 15: a recorded PID that already exited is declined cleanly ──────────
-echo "Test 15: an already-dead recorded PID is skipped, not errored on"
+# ── Test 15: a recorded PID from a generation that already exited is handled ──
+echo "Test 15: an already-dead recorded PID is handled gracefully, not counted as stopped"
+# A generation that exited on its own leaves its PID in the log. stop_service
+# must decline it (identity check yields empty comm), so it is NOT reported as a
+# process it stopped, it clears the log, and it does not error under set -euo
+# pipefail. (The recycled-PID guarantee — a LIVE PID whose comm mismatches — is
+# pinned separately by Tests 3 and 13.)
 spawn_sleep_pid; dead=$REPLY
 kill -9 "$dead" 2>/dev/null || true
 for _ in 1 2 3 4 5 6 7 8 9 10; do is_alive "$dead" || break; sleep 0.2; done
 record_pid rest-api "$dead"
 out="$(stop_service rest-api 2>&1)"
-assert_contains "$out" "no running processes found" "dead recorded PID declined (empty-comm branch)"
+assert_contains "$out" "no running processes found" "dead recorded PID: nothing reported stopped"
+case "$out" in
+    *"Stopped rest-api"*) fail "dead recorded PID must not be counted as stopped" ;;
+    *)                    ok "dead recorded PID not counted as stopped" ;;
+esac
 assert_no_file "${STATE_DIR}/.rest-api.pids" "pid log cleared after declining a dead PID"
 
 # ── Test 16: real orphan_pids_by_port keeps the node-only port-window filter ──
@@ -393,17 +408,24 @@ if command -v lsof >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
 
     # A node-named listener in the window must be RETURNED. Copy the python
     # interpreter to a binary literally named 'node' so its comm == 'node'.
-    cp "$(command -v python3)" "${STATE_DIR}/node"
-    nport="$(free_port)"
-    "${STATE_DIR}/node" -m http.server "$nport" --bind 127.0.0.1 >/dev/null 2>&1 &
-    np=$!; SPAWNED_PIDS+=("$np"); disown "$np" 2>/dev/null || true
-    for _ in 1 2 3 4 5 6 7 8 9 10; do lsof -nP -iTCP:"$nport" -sTCP:LISTEN >/dev/null 2>&1 && break; sleep 0.2; done
-    got="$(real_orphan_pids_by_port "$nport")"
-    case " $got " in
-        *" $np "*) ok "node listener in window is returned" ;;
-        *)         fail "node listener in window is returned (got '$got')" ;;
-    esac
-    kill -9 "$np" 2>/dev/null || true
+    # rm -f first: a prior 'node' copy (Test 13) may still be exiting, and cp
+    # over a running executable fails "Text file busy"; unlinking then creating a
+    # fresh file avoids that. Skip the sub-case if the copy cannot be made.
+    rm -f "${STATE_DIR}/node"
+    if ! cp "$(command -v python3)" "${STATE_DIR}/node"; then
+        fail "could not stage node stand-in (cp failed)"
+    else
+        nport="$(free_port)"
+        "${STATE_DIR}/node" -m http.server "$nport" --bind 127.0.0.1 >/dev/null 2>&1 &
+        np=$!; SPAWNED_PIDS+=("$np"); disown "$np" 2>/dev/null || true
+        for _ in 1 2 3 4 5 6 7 8 9 10; do lsof -nP -iTCP:"$nport" -sTCP:LISTEN >/dev/null 2>&1 && break; sleep 0.2; done
+        got="$(real_orphan_pids_by_port "$nport")"
+        case " $got " in
+            *" $np "*) ok "node listener in window is returned" ;;
+            *)         fail "node listener in window is returned (got '$got')" ;;
+        esac
+        kill -9 "$np" 2>/dev/null || true
+    fi
 else
     echo "  skip - lsof and python3 required"
 fi

--- a/test/setup-live-targets_test.sh
+++ b/test/setup-live-targets_test.sh
@@ -357,9 +357,11 @@ kill -9 "$notnode" 2>/dev/null || true
 echo "Test 14: parse_args maps CLI flags to their variables"
 # main()'s arg parsing lives in parse_args() so the flag→variable contract is
 # testable without running the side-effecting setup/teardown (or the real sweep).
-SWEEP_ORPHANS=false; parse_args --teardown
+# Seed SWEEP_ORPHANS=true first so this discriminates the reset: parse_args must
+# clear it back to false when --sweep is absent (deleting that reset fails here).
+SWEEP_ORPHANS=true; parse_args --teardown
 assert_eq "$PARSED_TEARDOWN" "true" "--teardown sets teardown"
-assert_eq "$SWEEP_ORPHANS" "false" "teardown alone leaves the sweep OFF (footgun stays closed)"
+assert_eq "$SWEEP_ORPHANS" "false" "parse_args resets SWEEP_ORPHANS off when --sweep absent (footgun stays closed)"
 SWEEP_ORPHANS=false; parse_args --teardown --sweep
 assert_eq "$SWEEP_ORPHANS" "true" "--sweep opts into the orphan sweep"
 SWEEP_ORPHANS=false; parse_args --skip-start

--- a/test/setup-live-targets_test.sh
+++ b/test/setup-live-targets_test.sh
@@ -7,11 +7,14 @@
 #   * Teardown kills EVERY started generation, not just the most recent
 #     (orphan-PID accumulation across repeated setup runs).
 #   * Legacy single-PID files (.<name>.pid) are still honoured.
+#   * Recorded/stale PIDs are killed only when they still belong to the service
+#     (identity check), so a recycled PID is never killed.
 #   * Orphans with no pid log are swept by basename (Go services) and by
 #     listening port (node/graphql), never by pkill-ing `node` by name.
 #   * Stale processes are cleaned up on setup startup.
-#   * Port exhaustion is detected (find_available_port returns empty) so the
-#     caller's failure message runs instead of a silent `set -e` exit.
+#   * Port exhaustion is detected AND the caller's failure path runs under
+#     `set -e` (Bug 2) instead of a silent exit.
+#   * show_port_holders lists the processes holding an exhausted range (AC2).
 #
 # No Go build, Node, or Chrome required — the test spawns lightweight stand-ins,
 # so it runs in the offline CI job. Run directly:
@@ -23,9 +26,10 @@ set -uo pipefail
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_UNDER_TEST="${THIS_DIR}/setup-live-targets.sh"
 
-# Isolate all PID/state files in a temp dir so we never touch the real test/ tree.
+# Isolate all PID/state files in a temp dir so we never touch the real test/
+# tree. This uses the dedicated state-dir override, NOT SCRIPT_DIR — the script
+# always resolves SCRIPT_DIR from its own location and sources common.sh there.
 STATE_DIR="$(mktemp -d)"
-cp "${THIS_DIR}/common.sh" "${STATE_DIR}/common.sh"
 
 # Track every PID we spawn so cleanup is guaranteed even if an assertion fails.
 SPAWNED_PIDS=()
@@ -39,15 +43,25 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Source the script with an overridden SCRIPT_DIR. The main() guard means only
-# the functions load — nothing is started.
-export SCRIPT_DIR="${STATE_DIR}"
+# Source the script with the state dir redirected to our temp dir. The main()
+# guard means only the functions load — nothing is started.
+export SETUP_LIVE_TARGETS_STATE_DIR="${STATE_DIR}"
 # shellcheck source=/dev/null
 source "${SCRIPT_UNDER_TEST}"
 
 # The sourced script enables `set -euo pipefail`; relax it so assertions that
 # probe for dead processes (expected non-zero exits) don't abort the harness.
 set +e +u
+
+# Sandbox the orphan-discovery seams for the entire run so a sweep can NEVER
+# reach the developer's real process table (`pgrep -x rest-api` / an lsof port
+# scan would otherwise match a dev's own service). Each test that exercises a
+# sweep sets the matching _sweep_* variable to its OWN stand-in PID; the real
+# pgrep/lsof discovery in the seams is intentionally not exercised offline.
+_name_sweep_pid=""
+_port_sweep_pid=""
+orphan_pids_by_name() { [ -n "$_name_sweep_pid" ] && echo "$_name_sweep_pid"; return 0; }
+orphan_pids_by_port() { [ -n "$_port_sweep_pid" ] && echo "$_port_sweep_pid"; return 0; }
 
 # ── Test harness ──────────────────────────────────────────────────────────
 PASS=0
@@ -80,27 +94,43 @@ assert_eq() {
     if [ "$1" = "$2" ]; then ok "$3"; else fail "$3 (expected '$2', got '$1')"; fi
 }
 
-# Spawn a long-lived background process; sets REPLY to its PID and records it.
-spawn_sleep() {
-    sleep 600 &
-    REPLY=$!
-    SPAWNED_PIDS+=("$REPLY")
+assert_contains() {
+    case "$1" in
+        *"$2"*) ok "$3" ;;
+        *)      fail "$3 (missing '$2' in output)" ;;
+    esac
 }
 
-# Spawn a long-lived process whose executable basename is $1 (so `pgrep -x`
-# matches it, mirroring a real compiled Go target). Copies the real `sleep`.
+# Spawn a long-lived process whose executable basename is $1, so both `pgrep -x`
+# and the pid_matches_service identity check see it as that service (mirrors a
+# real compiled Go target). Copies the real `sleep`. Sets REPLY to its PID.
 spawn_named() {
-    cp "$(command -v sleep)" "${STATE_DIR}/$1"
+    # Reuse an existing stand-in binary — copying over one that is still running
+    # fails with "Text file busy" and is unnecessary (same bytes).
+    [ -x "${STATE_DIR}/$1" ] || cp "$(command -v sleep)" "${STATE_DIR}/$1"
     "${STATE_DIR}/$1" 600 &
     REPLY=$!
     SPAWNED_PIDS+=("$REPLY")
+    disown "$REPLY" 2>/dev/null || true   # silence async "Killed" job notices
+}
+
+# Find a free localhost TCP port for a test listener (independent of any stub of
+# port_in_use later in the file).
+free_port() {
+    python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
 }
 
 # ── Test 1: teardown kills every generation (append-log) ────────────────────
 echo "Test 1: teardown kills every started generation"
-spawn_sleep; p1=$REPLY
-spawn_sleep; p2=$REPLY
-spawn_sleep; p3=$REPLY
+spawn_named rest-api; p1=$REPLY
+spawn_named rest-api; p2=$REPLY
+spawn_named rest-api; p3=$REPLY
 record_pid rest-api "$p1"
 record_pid rest-api "$p2"
 record_pid rest-api "$p3"
@@ -112,48 +142,53 @@ assert_no_file "${STATE_DIR}/.rest-api.pids" "pid log removed after teardown"
 
 # ── Test 2: legacy single-PID file is honoured ──────────────────────────────
 echo "Test 2: legacy .pid file is still killed"
-spawn_sleep; p=$REPLY
+spawn_named soap-service; p=$REPLY
 echo "$p" > "${STATE_DIR}/.soap-service.pid"
 stop_service soap-service >/dev/null 2>&1
 assert_dead "$p" "legacy-pidfile process killed"
 assert_no_file "${STATE_DIR}/.soap-service.pid" "legacy pid file removed"
 
-# ── Test 3: orphan with no pid log swept by basename (Go service) ───────────
-echo "Test 3: untracked orphan swept by basename"
-if command -v pgrep >/dev/null 2>&1; then
-    spawn_named grpc-server; p=$REPLY   # comm == grpc-server, no pid log recorded
-    assert_alive "$p" "orphan running before sweep"
-    stop_service grpc-server >/dev/null 2>&1
-    assert_dead "$p" "orphan swept by exact basename"
-else
-    echo "  skip - pgrep not available"
-fi
+# ── Test 3: recorded PID that is NOT the service is spared (recycled PID) ────
+echo "Test 3: recycled PID (identity mismatch) is not killed"
+spawn_sleep_pid() { sleep 600 & REPLY=$!; SPAWNED_PIDS+=("$REPLY"); disown "$REPLY" 2>/dev/null || true; }
+spawn_sleep_pid; imposter=$REPLY   # comm == 'sleep', not 'rest-api'
+record_pid rest-api "$imposter"
+stop_service rest-api >/dev/null 2>&1
+assert_alive "$imposter" "process whose comm != service basename is spared"
+kill -9 "$imposter" 2>/dev/null || true
 
-# ── Test 4: graphql orphan swept by port, never by pkill node ───────────────
-echo "Test 4: graphql orphan swept by listening port (not by killing node)"
-if command -v lsof >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 \
-   && ! port_in_use "$DEFAULT_GRAPHQL_SERVER_PORT"; then
-    python3 -m http.server "$DEFAULT_GRAPHQL_SERVER_PORT" --bind 127.0.0.1 >/dev/null 2>&1 &
+# ── Test 4: untracked orphan swept by basename (Go service) ─────────────────
+echo "Test 4: untracked orphan swept by basename"
+spawn_named grpc-server; p=$REPLY   # comm == grpc-server, no pid log recorded
+_name_sweep_pid="$p"                 # sandbox: sweep sees only this stand-in
+assert_alive "$p" "orphan running before sweep"
+stop_service grpc-server >/dev/null 2>&1
+assert_dead "$p" "orphan swept via name seam (no pid log present)"
+_name_sweep_pid=""
+
+# ── Test 5: graphql orphan swept by port seam, never by pkill node ──────────
+echo "Test 5: graphql orphan swept by listening-port seam"
+if command -v python3 >/dev/null 2>&1; then
+    port="$(free_port)"
+    python3 -m http.server "$port" --bind 127.0.0.1 >/dev/null 2>&1 &
     p=$!
     SPAWNED_PIDS+=("$p")
-    # Wait for the listener to bind.
-    for _ in 1 2 3 4 5 6 7 8 9 10; do
-        if port_in_use "$DEFAULT_GRAPHQL_SERVER_PORT"; then break; fi
-        sleep 0.2
-    done
+    disown "$p" 2>/dev/null || true
+    _port_sweep_pid="$p"             # sandbox: sweep sees only this stand-in
     assert_alive "$p" "port listener running before sweep"
     stop_service graphql-server >/dev/null 2>&1
-    assert_dead "$p" "listener swept by port"
+    assert_dead "$p" "listener swept via port seam (no pid log present)"
+    _port_sweep_pid=""
 else
-    echo "  skip - lsof/python3 unavailable or default graphql port busy"
+    echo "  skip - python3 unavailable"
 fi
 
-# ── Test 5: setup → setup → teardown leaves zero processes (acceptance) ──────
-echo "Test 5: two setup generations accumulate, teardown kills all"
+# ── Test 6: setup → setup → teardown leaves zero processes (acceptance) ──────
+echo "Test 6: two setup generations accumulate, teardown kills all"
 gen_pids=()
 for _round in 1 2; do
     for svc in rest-api soap-service concat-spa; do
-        spawn_sleep
+        spawn_named "$svc"
         record_pid "$svc" "$REPLY"
         gen_pids+=("$REPLY")
     done
@@ -165,26 +200,79 @@ for gp in "${gen_pids[@]}"; do
 done
 assert_eq "$all_dead" "1" "all 6 processes across 2 generations killed"
 
-# ── Test 6: stale-state cleanup on setup startup ────────────────────────────
-echo "Test 6: cleanup_stale_state kills leftovers and clears pid logs"
-spawn_sleep; p=$REPLY
+# ── Test 7: stale-state cleanup on setup startup ────────────────────────────
+echo "Test 7: cleanup_stale_state kills leftovers and clears pid logs"
+spawn_named rest-api; p=$REPLY
 record_pid rest-api "$p"
-cleanup_stale_state >/dev/null 2>&1
+out="$(cleanup_stale_state 2>&1)"
 assert_dead "$p" "stale process killed at startup"
+assert_contains "$out" "Killing stale process rest-api" "explicit stale-kill log line (AC3)"
 assert_no_file "${STATE_DIR}/.rest-api.pids" "stale pid log cleared at startup"
 
-# ── Test 7: port exhaustion is detectable (Bug 2) ───────────────────────────
-echo "Test 7: find_available_port returns empty when the window is exhausted"
-# Force every probed port to look occupied.
+# ── Test 8: show_port_holders lists processes holding the range (AC2) ────────
+echo "Test 8: show_port_holders reports listeners on the port window"
+if command -v python3 >/dev/null 2>&1 \
+   && { command -v lsof >/dev/null 2>&1 || command -v ss >/dev/null 2>&1; }; then
+    hp="$(free_port)"
+    python3 -m http.server "$hp" --bind 127.0.0.1 >/dev/null 2>&1 &
+    lp=$!
+    SPAWNED_PIDS+=("$lp")
+    disown "$lp" 2>/dev/null || true
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if lsof -nP -iTCP:"$hp" -sTCP:LISTEN >/dev/null 2>&1 \
+           || ss -ltnH 2>/dev/null | grep -q ":$hp "; then break; fi
+        sleep 0.2
+    done
+    out="$(show_port_holders "$hp" 2>&1)"
+    assert_contains "$out" "Listening processes on TCP ${hp}-$((hp + 20))" "prints the scanned window header"
+    assert_contains "$out" ":${hp}" "lists the listener holding the base port"
+    kill -9 "$lp" 2>/dev/null || true
+else
+    echo "  skip - python3 and (lsof or ss) required"
+fi
+
+# ── Test 9: find_available_port increments past busy ports to the next free ──
+echo "Test 9: find_available_port returns the first free port in the window"
+# Busy for 19000..19002, free from 19003 on.
 # shellcheck disable=SC2317  # invoked indirectly by find_available_port
-port_in_use() { return 0; }
+port_in_use() { [ "$1" -lt 19003 ]; }
 result=$(find_available_port 19000) || true
-assert_eq "$result" "" "exhausted range yields empty string (caller check runs)"
-# And the happy path still returns the base port when free.
+assert_eq "$result" "19003" "skips 3 busy ports, returns base+3"
+# Busy across the whole 21-port window (19000..19020); free only at base+21.
 # shellcheck disable=SC2317  # invoked indirectly by find_available_port
-port_in_use() { return 1; }
+port_in_use() { [ "$1" -le 19020 ]; }
 result=$(find_available_port 19000) || true
-assert_eq "$result" "19000" "free base port returned"
+assert_eq "$result" "" "does not overrun the window edge (base+20)"
+
+# ── Test 10: exhaustion failure path runs under set -e (Bug 2 regression) ────
+echo "Test 10: resolve_port_or_die logs and exits 1 under set -e (not silent)"
+# Simulate an exhausted range. This must FAIL if the `|| true` in
+# resolve_port_or_die is removed: set -e would then abort the command
+# substitution before log_fail runs, so no message would be printed.
+# shellcheck disable=SC2317  # invoked indirectly by resolve_port_or_die
+find_available_port() { echo ""; return 1; }
+out="$( set -e; resolve_port_or_die rest-api 19000 2>&1 )"
+rc=$?
+# NOTE: rc==1 alone does NOT prove the fix — with `|| true` removed, set -e also
+# aborts the subshell with status 1. The discriminating (red-green) guard is the
+# message assertion below: reverting `|| true` makes set -e exit BEFORE log_fail,
+# so the message disappears and this assertion fails.
+assert_eq "$rc" "1" "exits 1 on exhaustion"
+assert_contains "$out" "Cannot find available port for rest-api" "prints failure message instead of dying silently"
+
+# ── Test 11: kill_pid escalates to SIGKILL when SIGTERM is ignored ──────────
+echo "Test 11: a SIGTERM-ignoring process is force-killed (SIGKILL escalation)"
+# A copy of bash named 'concat-spa' (so pid_matches_service accepts it) that
+# traps and ignores SIGTERM — only kill_pid's SIGKILL fallback can end it.
+rm -f "${STATE_DIR}/concat-spa"
+cp "$(command -v bash)" "${STATE_DIR}/concat-spa"
+"${STATE_DIR}/concat-spa" -c "trap '' TERM; while :; do sleep 1; done" &
+stubborn=$!
+SPAWNED_PIDS+=("$stubborn")
+disown "$stubborn" 2>/dev/null || true
+record_pid concat-spa "$stubborn"
+stop_service concat-spa >/dev/null 2>&1
+assert_dead "$stubborn" "SIGTERM-ignoring process force-killed via SIGKILL escalation"
 
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""

--- a/test/setup-live-targets_test.sh
+++ b/test/setup-live-targets_test.sh
@@ -431,6 +431,20 @@ if command -v lsof >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
             *)         fail "node listener in window is returned (got '$got')" ;;
         esac
         kill -9 "$np" 2>/dev/null || true
+
+        # A node listener OFF the base port (mid-window) must also be returned.
+        # This pins the range SPAN: collapsing the query back to only the base
+        # port (dropping the `-${end}`) would miss this and fail here.
+        offport="$(free_port)"
+        "${STATE_DIR}/node" -m http.server "$offport" --bind 127.0.0.1 >/dev/null 2>&1 &
+        op=$!; SPAWNED_PIDS+=("$op"); disown "$op" 2>/dev/null || true
+        for _ in 1 2 3 4 5 6 7 8 9 10; do lsof -nP -iTCP:"$offport" -sTCP:LISTEN >/dev/null 2>&1 && break; sleep 0.2; done
+        got="$(real_orphan_pids_by_port "$((offport - 5))")"   # listener sits at base+5
+        case " $got " in
+            *" $op "*) ok "node listener mid-window (base+5) is returned (range span)" ;;
+            *)         fail "node listener mid-window (base+5) is returned (got '$got')" ;;
+        esac
+        kill -9 "$op" 2>/dev/null || true
     fi
 else
     skip "lsof and python3 required"

--- a/test/setup-live-targets_test.sh
+++ b/test/setup-live-targets_test.sh
@@ -53,11 +53,19 @@ source "${SCRIPT_UNDER_TEST}"
 # probe for dead processes (expected non-zero exits) don't abort the harness.
 set +e +u
 
+# Preserve the REAL seam implementations before we sandbox them, under aliased
+# names, so Tests 16-17 can exercise the actual node-in-port-window and
+# exact-name/user filters (the security-relevant guards) instead of the stub.
+# `declare -f` renders the sourced function body; prefixing renames the copy.
+eval "real_$(declare -f orphan_pids_by_port)"
+eval "real_$(declare -f orphan_pids_by_name)"
+
 # Sandbox the orphan-discovery seams for the entire run so a sweep can NEVER
 # reach the developer's real process table (`pgrep -x rest-api` / an lsof port
 # scan would otherwise match a dev's own service). Each test that exercises a
 # sweep sets the matching _sweep_* variable to its OWN stand-in PID; the real
-# pgrep/lsof discovery in the seams is intentionally not exercised offline.
+# pgrep/lsof discovery in the seams is exercised only by Tests 16-17, each
+# confined to a stand-in the harness spawns itself.
 _name_sweep_pid=""
 _port_sweep_pid=""
 orphan_pids_by_name() { [ -n "$_name_sweep_pid" ] && echo "$_name_sweep_pid"; return 0; }
@@ -338,6 +346,88 @@ stop_service graphql-server >/dev/null 2>&1
 assert_alive "$notnode" "non-node PID recorded as graphql-server is spared"
 _port_sweep_pid=""
 kill -9 "$notnode" 2>/dev/null || true
+
+# ── Test 14: parse_args wires the CLI flags (esp. --sweep → SWEEP_ORPHANS) ───
+echo "Test 14: parse_args maps CLI flags to their variables"
+# main()'s arg parsing lives in parse_args() so the flag→variable contract is
+# testable without running the side-effecting setup/teardown (or the real sweep).
+SWEEP_ORPHANS=false; parse_args --teardown
+assert_eq "$PARSED_TEARDOWN" "true" "--teardown sets teardown"
+assert_eq "$SWEEP_ORPHANS" "false" "teardown alone leaves the sweep OFF (footgun stays closed)"
+SWEEP_ORPHANS=false; parse_args --teardown --sweep
+assert_eq "$SWEEP_ORPHANS" "true" "--sweep opts into the orphan sweep"
+SWEEP_ORPHANS=false; parse_args --skip-start
+assert_eq "$PARSED_SKIP_START" "true" "--skip-start sets skip_start"
+SWEEP_ORPHANS=false; parse_args --targets rest-api,soap-service
+assert_eq "$PARSED_TARGETS" "rest-api,soap-service" "--targets captures the list"
+# Unknown option exits 1 (run in a subshell so the exit does not abort the harness).
+( parse_args --bogus >/dev/null 2>&1 ); rc=$?
+assert_eq "$rc" "1" "unknown option exits 1"
+SWEEP_ORPHANS=false
+
+# ── Test 15: a recorded PID that already exited is declined cleanly ──────────
+echo "Test 15: an already-dead recorded PID is skipped, not errored on"
+spawn_sleep_pid; dead=$REPLY
+kill -9 "$dead" 2>/dev/null || true
+for _ in 1 2 3 4 5 6 7 8 9 10; do is_alive "$dead" || break; sleep 0.2; done
+record_pid rest-api "$dead"
+out="$(stop_service rest-api 2>&1)"
+assert_contains "$out" "no running processes found" "dead recorded PID declined (empty-comm branch)"
+assert_no_file "${STATE_DIR}/.rest-api.pids" "pid log cleared after declining a dead PID"
+
+# ── Test 16: real orphan_pids_by_port keeps the node-only port-window filter ──
+echo "Test 16: real orphan_pids_by_port returns node listeners, excludes non-node"
+if command -v lsof >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    # A non-node listener in the window must be EXCLUDED (the guard against
+    # killing an unrelated service that merely listens in the range).
+    nnport="$(free_port)"
+    python3 -m http.server "$nnport" --bind 127.0.0.1 >/dev/null 2>&1 &
+    nn=$!; SPAWNED_PIDS+=("$nn"); disown "$nn" 2>/dev/null || true
+    for _ in 1 2 3 4 5 6 7 8 9 10; do lsof -nP -iTCP:"$nnport" -sTCP:LISTEN >/dev/null 2>&1 && break; sleep 0.2; done
+    got="$(real_orphan_pids_by_port "$nnport")"
+    case " $got " in
+        *" $nn "*) fail "non-node listener excluded by node filter (got '$got')" ;;
+        *)         ok "non-node listener excluded by node filter" ;;
+    esac
+    kill -9 "$nn" 2>/dev/null || true
+
+    # A node-named listener in the window must be RETURNED. Copy the python
+    # interpreter to a binary literally named 'node' so its comm == 'node'.
+    cp "$(command -v python3)" "${STATE_DIR}/node"
+    nport="$(free_port)"
+    "${STATE_DIR}/node" -m http.server "$nport" --bind 127.0.0.1 >/dev/null 2>&1 &
+    np=$!; SPAWNED_PIDS+=("$np"); disown "$np" 2>/dev/null || true
+    for _ in 1 2 3 4 5 6 7 8 9 10; do lsof -nP -iTCP:"$nport" -sTCP:LISTEN >/dev/null 2>&1 && break; sleep 0.2; done
+    got="$(real_orphan_pids_by_port "$nport")"
+    case " $got " in
+        *" $np "*) ok "node listener in window is returned" ;;
+        *)         fail "node listener in window is returned (got '$got')" ;;
+    esac
+    kill -9 "$np" 2>/dev/null || true
+else
+    echo "  skip - lsof and python3 required"
+fi
+
+# ── Test 17: real orphan_pids_by_name matches by exact basename, current user ─
+echo "Test 17: real orphan_pids_by_name returns only the exact-named stand-in"
+if command -v pgrep >/dev/null 2>&1; then
+    # Improbable name so the real pgrep can never match a developer's process.
+    # Kept <=15 chars: `pgrep -x` matches the truncated comm, not the full argv.
+    uniq="zzcap$$"
+    cp "$(command -v sleep)" "${STATE_DIR}/${uniq}"
+    "${STATE_DIR}/${uniq}" 600 &
+    up=$!; SPAWNED_PIDS+=("$up"); disown "$up" 2>/dev/null || true
+    got="$(real_orphan_pids_by_name "$uniq")"
+    case " $got " in
+        *" $up "*) ok "exact-named stand-in returned by name seam" ;;
+        *)         fail "exact-named stand-in returned (got '$got')" ;;
+    esac
+    got="$(real_orphan_pids_by_name "${uniq}-nope")"
+    assert_eq "$got" "" "a non-matching name returns nothing"
+    kill -9 "$up" 2>/dev/null || true
+else
+    echo "  skip - pgrep required"
+fi
 
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""

--- a/test/setup-live-targets_test.sh
+++ b/test/setup-live-targets_test.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Copyright 2026 Praetorian Security, Inc.
+#
+# Regression test for test/setup-live-targets.sh hardening (LAB-2893).
+#
+# Verifies:
+#   * Teardown kills EVERY started generation, not just the most recent
+#     (orphan-PID accumulation across repeated setup runs).
+#   * Legacy single-PID files (.<name>.pid) are still honoured.
+#   * Orphans with no pid log are swept by basename (Go services) and by
+#     listening port (node/graphql), never by pkill-ing `node` by name.
+#   * Stale processes are cleaned up on setup startup.
+#   * Port exhaustion is detected (find_available_port returns empty) so the
+#     caller's failure message runs instead of a silent `set -e` exit.
+#
+# No Go build, Node, or Chrome required — the test spawns lightweight stand-ins,
+# so it runs in the offline CI job. Run directly:
+#
+#   ./test/setup-live-targets_test.sh
+
+set -uo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="${THIS_DIR}/setup-live-targets.sh"
+
+# Isolate all PID/state files in a temp dir so we never touch the real test/ tree.
+STATE_DIR="$(mktemp -d)"
+cp "${THIS_DIR}/common.sh" "${STATE_DIR}/common.sh"
+
+# Track every PID we spawn so cleanup is guaranteed even if an assertion fails.
+SPAWNED_PIDS=()
+
+cleanup() {
+    local pid
+    for pid in "${SPAWNED_PIDS[@]:-}"; do
+        if [ -n "$pid" ]; then kill -9 "$pid" 2>/dev/null || true; fi
+    done
+    rm -rf "${STATE_DIR}"
+}
+trap cleanup EXIT
+
+# Source the script with an overridden SCRIPT_DIR. The main() guard means only
+# the functions load — nothing is started.
+export SCRIPT_DIR="${STATE_DIR}"
+# shellcheck source=/dev/null
+source "${SCRIPT_UNDER_TEST}"
+
+# The sourced script enables `set -euo pipefail`; relax it so assertions that
+# probe for dead processes (expected non-zero exits) don't abort the harness.
+set +e +u
+
+# ── Test harness ──────────────────────────────────────────────────────────
+PASS=0
+FAIL=0
+
+ok()   { echo "  ok   - $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL - $1"; FAIL=$((FAIL + 1)); }
+
+is_alive() { kill -0 "$1" 2>/dev/null; }
+
+assert_dead() {
+    # Give the async kill a moment to land.
+    local pid=$1 desc=$2 _
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if ! is_alive "$pid"; then ok "$desc"; return; fi
+        sleep 0.2
+    done
+    fail "$desc (PID $pid still alive)"
+}
+
+assert_alive() {
+    if is_alive "$1"; then ok "$2"; else fail "$2 (PID $1 already dead)"; fi
+}
+
+assert_no_file() {
+    if [ ! -e "$1" ]; then ok "$2"; else fail "$2 (file $1 still present)"; fi
+}
+
+assert_eq() {
+    if [ "$1" = "$2" ]; then ok "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+
+# Spawn a long-lived background process; sets REPLY to its PID and records it.
+spawn_sleep() {
+    sleep 600 &
+    REPLY=$!
+    SPAWNED_PIDS+=("$REPLY")
+}
+
+# Spawn a long-lived process whose executable basename is $1 (so `pgrep -x`
+# matches it, mirroring a real compiled Go target). Copies the real `sleep`.
+spawn_named() {
+    cp "$(command -v sleep)" "${STATE_DIR}/$1"
+    "${STATE_DIR}/$1" 600 &
+    REPLY=$!
+    SPAWNED_PIDS+=("$REPLY")
+}
+
+# ── Test 1: teardown kills every generation (append-log) ────────────────────
+echo "Test 1: teardown kills every started generation"
+spawn_sleep; p1=$REPLY
+spawn_sleep; p2=$REPLY
+spawn_sleep; p3=$REPLY
+record_pid rest-api "$p1"
+record_pid rest-api "$p2"
+record_pid rest-api "$p3"
+stop_service rest-api >/dev/null 2>&1
+assert_dead "$p1" "generation 1 killed"
+assert_dead "$p2" "generation 2 killed"
+assert_dead "$p3" "generation 3 (latest) killed"
+assert_no_file "${STATE_DIR}/.rest-api.pids" "pid log removed after teardown"
+
+# ── Test 2: legacy single-PID file is honoured ──────────────────────────────
+echo "Test 2: legacy .pid file is still killed"
+spawn_sleep; p=$REPLY
+echo "$p" > "${STATE_DIR}/.soap-service.pid"
+stop_service soap-service >/dev/null 2>&1
+assert_dead "$p" "legacy-pidfile process killed"
+assert_no_file "${STATE_DIR}/.soap-service.pid" "legacy pid file removed"
+
+# ── Test 3: orphan with no pid log swept by basename (Go service) ───────────
+echo "Test 3: untracked orphan swept by basename"
+if command -v pgrep >/dev/null 2>&1; then
+    spawn_named grpc-server; p=$REPLY   # comm == grpc-server, no pid log recorded
+    assert_alive "$p" "orphan running before sweep"
+    stop_service grpc-server >/dev/null 2>&1
+    assert_dead "$p" "orphan swept by exact basename"
+else
+    echo "  skip - pgrep not available"
+fi
+
+# ── Test 4: graphql orphan swept by port, never by pkill node ───────────────
+echo "Test 4: graphql orphan swept by listening port (not by killing node)"
+if command -v lsof >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 \
+   && ! port_in_use "$DEFAULT_GRAPHQL_SERVER_PORT"; then
+    python3 -m http.server "$DEFAULT_GRAPHQL_SERVER_PORT" --bind 127.0.0.1 >/dev/null 2>&1 &
+    p=$!
+    SPAWNED_PIDS+=("$p")
+    # Wait for the listener to bind.
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if port_in_use "$DEFAULT_GRAPHQL_SERVER_PORT"; then break; fi
+        sleep 0.2
+    done
+    assert_alive "$p" "port listener running before sweep"
+    stop_service graphql-server >/dev/null 2>&1
+    assert_dead "$p" "listener swept by port"
+else
+    echo "  skip - lsof/python3 unavailable or default graphql port busy"
+fi
+
+# ── Test 5: setup → setup → teardown leaves zero processes (acceptance) ──────
+echo "Test 5: two setup generations accumulate, teardown kills all"
+gen_pids=()
+for _round in 1 2; do
+    for svc in rest-api soap-service concat-spa; do
+        spawn_sleep
+        record_pid "$svc" "$REPLY"
+        gen_pids+=("$REPLY")
+    done
+done
+do_teardown >/dev/null 2>&1
+all_dead=1
+for gp in "${gen_pids[@]}"; do
+    if is_alive "$gp"; then all_dead=0; fi
+done
+assert_eq "$all_dead" "1" "all 6 processes across 2 generations killed"
+
+# ── Test 6: stale-state cleanup on setup startup ────────────────────────────
+echo "Test 6: cleanup_stale_state kills leftovers and clears pid logs"
+spawn_sleep; p=$REPLY
+record_pid rest-api "$p"
+cleanup_stale_state >/dev/null 2>&1
+assert_dead "$p" "stale process killed at startup"
+assert_no_file "${STATE_DIR}/.rest-api.pids" "stale pid log cleared at startup"
+
+# ── Test 7: port exhaustion is detectable (Bug 2) ───────────────────────────
+echo "Test 7: find_available_port returns empty when the window is exhausted"
+# Force every probed port to look occupied.
+# shellcheck disable=SC2317  # invoked indirectly by find_available_port
+port_in_use() { return 0; }
+result=$(find_available_port 19000) || true
+assert_eq "$result" "" "exhausted range yields empty string (caller check runs)"
+# And the happy path still returns the base port when free.
+# shellcheck disable=SC2317  # invoked indirectly by find_available_port
+port_in_use() { return 1; }
+result=$(find_available_port 19000) || true
+assert_eq "$result" "19000" "free base port returned"
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "──────────────────────────────────────────"
+echo "Passed: ${PASS}   Failed: ${FAIL}"
+echo "──────────────────────────────────────────"
+[ "$FAIL" -eq 0 ]

--- a/test/setup-live-targets_test.sh
+++ b/test/setup-live-targets_test.sh
@@ -85,9 +85,13 @@ export SWEEP_ORPHANS
 # ── Test harness ──────────────────────────────────────────────────────────
 PASS=0
 FAIL=0
+SKIP=0
 
 ok()   { echo "  ok   - $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL - $1"; FAIL=$((FAIL + 1)); }
+# Tool-prerequisite skips are counted so the summary can surface dropped coverage
+# (a bare "Passed: N Failed: 0" would otherwise hide silently skipped tests).
+skip() { echo "  skip - $1"; SKIP=$((SKIP + 1)); }
 
 is_alive() { kill -0 "$1" 2>/dev/null; }
 
@@ -203,7 +207,7 @@ if command -v python3 >/dev/null 2>&1; then
     SWEEP_ORPHANS=false
     _port_sweep_pid=""
 else
-    echo "  skip - python3 unavailable"
+    skip "python3 unavailable"
 fi
 
 # ── Test 6: setup → setup → teardown leaves zero processes (acceptance) ──────
@@ -255,7 +259,7 @@ if command -v python3 >/dev/null 2>&1 \
     assert_contains "$out" ":${hp}" "lists the listener holding the base port"
     kill -9 "$lp" 2>/dev/null || true
 else
-    echo "  skip - python3 and (lsof or ss) required"
+    skip "python3 and (lsof or ss) required"
 fi
 
 # ── Test 9: find_available_port increments past busy ports to the next free ──
@@ -429,7 +433,7 @@ if command -v lsof >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
         kill -9 "$np" 2>/dev/null || true
     fi
 else
-    echo "  skip - lsof and python3 required"
+    skip "lsof and python3 required"
 fi
 
 # ── Test 17: real orphan_pids_by_name matches by exact basename, current user ─
@@ -450,12 +454,12 @@ if command -v pgrep >/dev/null 2>&1; then
     assert_eq "$got" "" "a non-matching name returns nothing"
     kill -9 "$up" 2>/dev/null || true
 else
-    echo "  skip - pgrep required"
+    skip "pgrep required"
 fi
 
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "──────────────────────────────────────────"
-echo "Passed: ${PASS}   Failed: ${FAIL}"
+echo "Passed: ${PASS}   Skipped: ${SKIP}   Failed: ${FAIL}"
 echo "──────────────────────────────────────────"
 [ "$FAIL" -eq 0 ]

--- a/test/setup-live-targets_test.sh
+++ b/test/setup-live-targets_test.sh
@@ -63,6 +63,11 @@ _port_sweep_pid=""
 orphan_pids_by_name() { [ -n "$_name_sweep_pid" ] && echo "$_name_sweep_pid"; return 0; }
 orphan_pids_by_port() { [ -n "$_port_sweep_pid" ] && echo "$_port_sweep_pid"; return 0; }
 
+# SWEEP_ORPHANS is defined by the sourced script and read by stop_service; tests
+# toggle it to gate the opt-in sweep. Marked exported so shellcheck sees it as
+# consumed externally (the reader is in the sourced file, not this one).
+export SWEEP_ORPHANS
+
 # ── Test harness ──────────────────────────────────────────────────────────
 PASS=0
 FAIL=0
@@ -157,17 +162,19 @@ stop_service rest-api >/dev/null 2>&1
 assert_alive "$imposter" "process whose comm != service basename is spared"
 kill -9 "$imposter" 2>/dev/null || true
 
-# ── Test 4: untracked orphan swept by basename (Go service) ─────────────────
-echo "Test 4: untracked orphan swept by basename"
+# ── Test 4: untracked orphan swept by basename under --sweep (Go service) ────
+echo "Test 4: untracked orphan swept by basename when --sweep is enabled"
 spawn_named grpc-server; p=$REPLY   # comm == grpc-server, no pid log recorded
 _name_sweep_pid="$p"                 # sandbox: sweep sees only this stand-in
+SWEEP_ORPHANS=true                   # opt in to the fallback sweep
 assert_alive "$p" "orphan running before sweep"
 stop_service grpc-server >/dev/null 2>&1
-assert_dead "$p" "orphan swept via name seam (no pid log present)"
+assert_dead "$p" "orphan swept via name seam (no pid log, --sweep on)"
+SWEEP_ORPHANS=false
 _name_sweep_pid=""
 
-# ── Test 5: graphql orphan swept by port seam, never by pkill node ──────────
-echo "Test 5: graphql orphan swept by listening-port seam"
+# ── Test 5: graphql orphan swept by port seam under --sweep, never pkill node ─
+echo "Test 5: graphql orphan swept by listening-port seam when --sweep is enabled"
 if command -v python3 >/dev/null 2>&1; then
     port="$(free_port)"
     python3 -m http.server "$port" --bind 127.0.0.1 >/dev/null 2>&1 &
@@ -175,9 +182,11 @@ if command -v python3 >/dev/null 2>&1; then
     SPAWNED_PIDS+=("$p")
     disown "$p" 2>/dev/null || true
     _port_sweep_pid="$p"             # sandbox: sweep sees only this stand-in
+    SWEEP_ORPHANS=true               # opt in to the fallback sweep
     assert_alive "$p" "port listener running before sweep"
     stop_service graphql-server >/dev/null 2>&1
-    assert_dead "$p" "listener swept via port seam (no pid log present)"
+    assert_dead "$p" "listener swept via port seam (no pid log, --sweep on)"
+    SWEEP_ORPHANS=false
     _port_sweep_pid=""
 else
     echo "  skip - python3 unavailable"
@@ -273,6 +282,16 @@ disown "$stubborn" 2>/dev/null || true
 record_pid concat-spa "$stubborn"
 stop_service concat-spa >/dev/null 2>&1
 assert_dead "$stubborn" "SIGTERM-ignoring process force-killed via SIGKILL escalation"
+
+# ── Test 12: default teardown does NOT sweep untracked processes ────────────
+echo "Test 12: without --sweep, an untracked same-named process is left alone"
+spawn_named grpc-server; safe=$REPLY   # comm == grpc-server, NO pid log recorded
+_name_sweep_pid="$safe"                # if the sweep ran, this is what it would kill
+# SWEEP_ORPHANS is false here (default) — the sweep must NOT run.
+stop_service grpc-server >/dev/null 2>&1
+assert_alive "$safe" "untracked process spared when --sweep is off (footgun closed by default)"
+_name_sweep_pid=""
+kill -9 "$safe" 2>/dev/null || true
 
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""

--- a/test/setup-live-targets_test.sh
+++ b/test/setup-live-targets_test.sh
@@ -194,9 +194,13 @@ fi
 
 # ── Test 6: setup → setup → teardown leaves zero processes (acceptance) ──────
 echo "Test 6: two setup generations accumulate, teardown kills all"
+# All Go-style services (unique executable basename) share the identical
+# do_teardown loop, so covering four of them exercises the accumulation path.
+# graphql-server is intentionally omitted here: its identity check requires a
+# node-named process listening in its port window (covered dedicated in Test 13).
 gen_pids=()
 for _round in 1 2; do
-    for svc in rest-api soap-service concat-spa; do
+    for svc in rest-api soap-service concat-spa grpc-server; do
         spawn_named "$svc"
         record_pid "$svc" "$REPLY"
         gen_pids+=("$REPLY")
@@ -207,7 +211,7 @@ all_dead=1
 for gp in "${gen_pids[@]}"; do
     if is_alive "$gp"; then all_dead=0; fi
 done
-assert_eq "$all_dead" "1" "all 6 processes across 2 generations killed"
+assert_eq "$all_dead" "1" "all 8 processes across 2 generations killed"
 
 # ── Test 7: stale-state cleanup on setup startup ────────────────────────────
 echo "Test 7: cleanup_stale_state kills leftovers and clears pid logs"
@@ -242,25 +246,36 @@ fi
 
 # ── Test 9: find_available_port increments past busy ports to the next free ──
 echo "Test 9: find_available_port returns the first free port in the window"
+# The port_in_use overrides are scoped to the command-substitution subshells so
+# they never leak into later tests (test isolation); the assertions run in the
+# parent shell so the PASS/FAIL counters persist.
 # Busy for 19000..19002, free from 19003 on.
-# shellcheck disable=SC2317  # invoked indirectly by find_available_port
-port_in_use() { [ "$1" -lt 19003 ]; }
-result=$(find_available_port 19000) || true
+result=$(
+    # shellcheck disable=SC2317,SC2329  # invoked indirectly by find_available_port
+    port_in_use() { [ "$1" -lt 19003 ]; }
+    find_available_port 19000
+) || true
 assert_eq "$result" "19003" "skips 3 busy ports, returns base+3"
 # Busy across the whole 21-port window (19000..19020); free only at base+21.
-# shellcheck disable=SC2317  # invoked indirectly by find_available_port
-port_in_use() { [ "$1" -le 19020 ]; }
-result=$(find_available_port 19000) || true
+result=$(
+    # shellcheck disable=SC2317,SC2329  # invoked indirectly by find_available_port
+    port_in_use() { [ "$1" -le 19020 ]; }
+    find_available_port 19000
+) || true
 assert_eq "$result" "" "does not overrun the window edge (base+20)"
 
 # ── Test 10: exhaustion failure path runs under set -e (Bug 2 regression) ────
 echo "Test 10: resolve_port_or_die logs and exits 1 under set -e (not silent)"
 # Simulate an exhausted range. This must FAIL if the `|| true` in
 # resolve_port_or_die is removed: set -e would then abort the command
-# substitution before log_fail runs, so no message would be printed.
-# shellcheck disable=SC2317  # invoked indirectly by resolve_port_or_die
-find_available_port() { echo ""; return 1; }
-out="$( set -e; resolve_port_or_die rest-api 19000 2>&1 )"
+# substitution before log_fail runs, so no message would be printed. The
+# find_available_port override is scoped to the subshell so it does not leak.
+out="$(
+    # shellcheck disable=SC2317,SC2329  # invoked indirectly by resolve_port_or_die
+    find_available_port() { echo ""; return 1; }
+    set -e
+    resolve_port_or_die rest-api 19000 2>&1
+)"
 rc=$?
 # NOTE: rc==1 alone does NOT prove the fix — with `|| true` removed, set -e also
 # aborts the subshell with status 1. The discriminating (red-green) guard is the
@@ -292,6 +307,37 @@ stop_service grpc-server >/dev/null 2>&1
 assert_alive "$safe" "untracked process spared when --sweep is off (footgun closed by default)"
 _name_sweep_pid=""
 kill -9 "$safe" 2>/dev/null || true
+
+# ── Test 13: graphql-server node fallback identity check ────────────────────
+echo "Test 13: graphql-server recorded PID matched only as node AND in its window"
+# graphql-server has no unique binary; pid_matches_service accepts a recorded PID
+# only when comm == 'node' AND it holds a port in the service window. The window
+# check reuses orphan_pids_by_port, stubbed above to echo $_port_sweep_pid.
+
+# (a) node process listening in the window → identity-verified → killed.
+spawn_named node; gqp=$REPLY            # comm == 'node'
+_port_sweep_pid="$gqp"                  # stub: this node PID holds a window port
+record_pid graphql-server "$gqp"
+stop_service graphql-server >/dev/null 2>&1
+assert_dead "$gqp" "node PID listening in the graphql window is matched and killed"
+_port_sweep_pid=""
+
+# (b) node process NOT in the window → recycled-PID guard spares it.
+spawn_named node; nowin=$REPLY          # comm == 'node' but not in the window
+_port_sweep_pid=""                      # stub: no window listeners
+record_pid graphql-server "$nowin"
+stop_service graphql-server >/dev/null 2>&1
+assert_alive "$nowin" "node PID not in the graphql window is spared"
+kill -9 "$nowin" 2>/dev/null || true
+
+# (c) non-node process recorded as graphql-server → comm mismatch → spared.
+spawn_sleep_pid; notnode=$REPLY         # comm == 'sleep'
+_port_sweep_pid="$notnode"              # even if it "held" a port, comm != node
+record_pid graphql-server "$notnode"
+stop_service graphql-server >/dev/null 2>&1
+assert_alive "$notnode" "non-node PID recorded as graphql-server is spared"
+_port_sweep_pid=""
+kill -9 "$notnode" 2>/dev/null || true
 
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Hardens `test/setup-live-targets.sh` against two related defects that combined into a confusing failure mode — silent script exit plus unbounded orphan accumulation across setup runs (surfaced during PR #101 / LAB-2106 live-test validation, where 7 generations of orphans exhausted the 8990–9010 port window).

Fixes [LAB-2893](https://linear.app/praetorianlabs/issue/LAB-2893). Sub-issue of the [13T-146](https://linear.app/praetorianlabs/issue/13T-146) live-test-reliability epic.

## Bug 1 — teardown only killed the latest generation

Each `setup` overwrote the single `.<name>.pid` file, so prior generations were forgotten and lived forever. The `pkill -f "${SCRIPT_DIR}/${name}"` fallback matched the binary's *directory*, but processes run with relative argv (`./rest-api`), so the substring match never hit.

**Fix:** every started PID is appended to a per-service pid log (`.<name>.pids`); teardown kills **every** generation (and still honours legacy `.pid` files). As a belt-and-suspenders sweep when a pid log is lost, Go targets are swept by exact basename (`pgrep -x`, current user only) and `graphql-server` — which runs as `node` — is swept by **listening port**, never by `pkill`-ing `node` by name.

## Bug 2 — silent exit on port exhaustion

Under `set -euo pipefail`, `find_available_port`'s exit-1 propagated to the command substitution and tripped `set -e` *before* the `[ -z … ]` / `log_fail` check, so the script just died with no message.

**Fix:** `|| true` on each of the five port-resolve sites so the existing failure message runs; the failure path now prints the processes holding the port window.

## Additional hardening

- **Stale-pidfile detection on setup startup** — kills leftovers from a setup that never tore down, with explicit `Killing stale process …` log lines.
- **`make live-test-clean`** — documented escape hatch (delegates to `--teardown`).
- README updated (resilience notes, escape hatch, port diagnostics).

## Regression test

`test/setup-live-targets_test.sh` — self-contained, spawns lightweight stand-ins (copied `sleep`, a `python3 http.server` listener), sources the script's functions, and needs no live services. 15 assertions covering: every-generation teardown, legacy `.pid`, basename sweep, port-based sweep, **setup → setup → teardown leaves zero processes**, stale cleanup, and port-exhaustion detection.

## Acceptance criteria

- [x] Teardown kills every process started by every prior setup, not just the most recent.
- [x] Setup prints a clear failure message on port exhaustion, including which processes hold the range.
- [x] Stale-pidfile detection on startup with explicit "killing stale process" log lines.
- [x] Regression test: setup → setup → teardown asserts zero processes remain.

## Verification

- Regression test: **15/15 pass**.
- `shellcheck -S warning` clean; `bash -n` clean.
- Real end-to-end repro driven with `rest-api`: `setup` → `setup` (logged `Killing stale process rest-api (PID: 16025)`, reused the freed port — **no accumulation**) → `teardown` → port empty, zero orphans, no state files left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
