### PR TITLE
docs: add CODE_OF_CONDUCT.md (LAB-2774)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **security@praetorian.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.


### PR DESCRIPTION
## Description

Adds `CODE_OF_CONDUCT.md` at the repo root, adopting **Contributor Covenant 2.1**.

Vespasian is public but has no code of conduct — `gh api repos/praetorian-inc/vespasian/community/profile` currently reports `code_of_conduct: MISSING`. This closes that gap.

The text is **byte-identical to [praetorian-inc/trajan](https://github.com/praetorian-inc/trajan/blob/main/CODE_OF_CONDUCT.md)**, which keeps the enforcement contact and wording consistent across Praetorian OSS repos. It also guarantees GitHub's detection works: trajan's copy is trimmed relative to the upstream Covenant, and `gh repo view praetorian-inc/trajan --json codeOfConduct` was verified to return `{"key": "contributor_covenant", "name": "Contributor Covenant"}` — so the same text will be recognized here once merged.

Resolves [LAB-2774](https://linear.app/praetorianlabs/issue/LAB-2774/add-code-of-conductmd).

## Changes

- Add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) at repo root, with all seven required sections: Our Pledge, Our Standards, Enforcement Responsibilities, Scope, Enforcement, Enforcement Guidelines, Attribution
- Enforcement point of contact: `security@praetorian.com` — matching trajan's code of conduct and this repo's existing `SECURITY.md`

## Testing

- [ ] Unit tests pass (`make test`) — **N/A**, no Go code changed
- [ ] Linter passes (`make lint`) — **N/A**, no Go code changed
- [x] Manual verification (describe below)

Verified:
- All seven Contributor Covenant 2.1 sections present
- File content byte-identical to trajan's, whose text GitHub detects as `contributor_covenant`
- `praetorian.com` MX records resolve (Google Workspace), so the contact domain accepts mail. No test email was sent — delivery to the `security@` mailbox is unverified here, though it is the address already published in this repo's `SECURITY.md`

Post-merge check for the ticket's acceptance criterion:

```
gh repo view praetorian-inc/vespasian --json codeOfConduct
```

## Checklist

- [x] Code follows project conventions
- [ ] Tests added/updated for new functionality — N/A, documentation-only
- [x] Documentation updated (if applicable)

## Note on scope

LAB-2774's acceptance also asks that the code of conduct be **linked from `CONTRIBUTING.md`**. This repo has no `CONTRIBUTING.md` (it has never had one — only a short "Contributing" section in `README.md`), and that file is tracked separately in [LAB-2773](https://linear.app/praetorianlabs/issue/LAB-2773/add-contributingmd). The link is therefore left to that ticket rather than added here, and no `README.md` change is included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
