### PR TITLE
docs: add GitHub issue templates (LAB-2775)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,100 @@
+name: Bug report
+description: Something in Vespasian doesn't work as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        > [!CAUTION]
+        > **Do not report security vulnerabilities here.** Public issues are visible to everyone.
+        > Follow our [security policy](https://github.com/praetorian-inc/vespasian/security/policy) instead.
+
+        > [!WARNING]
+        > **Redact before posting.** Captures and generated specs routinely contain hostnames,
+        > tokens, cookies, and request bodies from real targets. Strip anything sensitive from
+        > commands, logs, and capture excerpts below.
+
+  - type: input
+    id: version
+    attributes:
+      label: Vespasian version
+      description: Output of `vespasian version`.
+      placeholder: v1.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: OS and architecture
+      description: Include whether you're in a container or devcontainer, which often matters for browser-driven runs.
+      placeholder: Ubuntu 24.04, linux/amd64, devcontainer
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command you ran
+      description: The full command line, including flags. Redact target hostnames if they're sensitive.
+      render: shell
+    validations:
+      required: true
+
+  - type: dropdown
+    id: api-type
+    attributes:
+      label: Target API type
+      options:
+        - REST
+        - GraphQL
+        - SOAP / WSDL
+        - gRPC
+        - SPA / JS-heavy app
+        - Other or not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: capture-source
+    attributes:
+      label: Where did the traffic come from?
+      options:
+        - Headless crawl
+        - Burp Suite XML import
+        - HAR import
+        - mitmproxy import
+        - Not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      description: Include how it differed — missing endpoints, wrong spec output, a crash, an empty capture.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Output
+      description: Relevant stdout/stderr. Paste the full error rather than a summary where you can.
+      render: shell
+
+  - type: textarea
+    id: capture
+    attributes:
+      label: Capture excerpt (redacted)
+      description: A few relevant entries from `capture.json`, or the relevant part of the generated spec.
+      render: json

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/praetorian-inc/vespasian/security/policy
+    about: Do not open a public issue for security vulnerabilities. Report them privately per our security policy.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest a capability or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. The most useful requests start from a
+        concrete problem rather than a proposed implementation.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: What are you doing today, and where does Vespasian fall short? Concrete examples help more than general statements.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like Vespasian to do? A sketch of the CLI flags, output, or behavior is ideal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Other tools, workarounds, or approaches you've tried, and why they weren't enough.
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Would you be willing to contribute this?
+      description: No obligation either way — it helps us decide where to spend review time.
+      options:
+        - "Yes, I'd like to implement it"
+        - "Yes, with guidance on where to start"
+        - "No, but I'm happy to test it"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,36 @@
+name: Question
+description: Ask how to do something with Vespasian
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions are welcome here. Before filing, the [README](https://github.com/praetorian-inc/vespasian#readme)
+        covers installation, the CLI reference, and supported API types.
+
+        > [!WARNING]
+        > Redact hostnames, tokens, and request bodies from anything you paste — issues are public.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+      description: Describe the outcome you're after, not just the command that isn't working.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Commands you've run and what happened. This is usually the difference between a fast answer and a long back-and-forth.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Vespasian version
+      description: Output of `vespasian version`, if relevant.
+      placeholder: v1.0.0


### PR DESCRIPTION
## Description

Adds `.github/ISSUE_TEMPLATE/` with bug, feature, and question forms plus `config.yml`.

Vespasian is public but has no issue templates — `gh api repos/praetorian-inc/vespasian/community/profile` reports `issue_template: MISSING`. Every issue arrives as free-form prose, so the first maintainer reply is usually a request for the version, the command, and the capture source.

These are **YAML issue forms** rather than classic markdown templates, because the ticket requires working required-field validation, which only forms provide.

Resolves [LAB-2775](https://linear.app/praetorianlabs/issue/LAB-2775/add-githubissue-template-bug-feature-question-config).

## The `external-contrib-action` constraint — verified, not assumed

LAB-2775 flags that `external-contrib-action` auto-creates LAB-* tickets from incoming issues (LAB-2309 / LAB-2310 came through it) and must not break. Since issue forms change the *shape* of the issue body, this was the one real risk, so I traced the chain rather than assuming:

`external-contribution.yml` → `public-workflows/.github/workflows/external-contrib-notify.yml@v2.9.3` → `praetorian-inc/external-contrib-action@v3.0.0`

Reading that action's source (`src/linear.ts`, `src/index.ts`, `src/membership.ts`):

- `buildTitle` takes `issue.title` **verbatim** and prefixes `[External Issue] ` / `[External PR] `
- `buildDescription` embeds `issue.body` **verbatim** inside a wrapper, truncating only past `MAX_BODY_LENGTH = 10000`
- Dedup keys on the GitHub URL (`description: { contains: githubUrl }`), not on body content
- The external/internal decision is made by **org-membership check**, not by anything in the issue

**There is no structural parsing of the issue body anywhere in the action.** Issue forms produce a longer markdown body, which the action treats as opaque text. Nothing to break, and 10 000 characters is far above what these forms generate.

Caveat: this is verified by source inspection. It can't be exercised end-to-end without a genuine non-org-member opening an issue, so the ticket's "continues to create LAB-* tickets correctly" is confirmed by reading, not by a live run.

## Files

| File | Purpose |
|---|---|
| `bug.yml` | version, OS/arch, command, target API type, capture source, expected vs observed, output, redacted capture excerpt |
| `feature.yml` | problem statement, proposed solution, alternatives, willingness to contribute |
| `question.yml` | what you're trying to do, what you've tried, version |
| `config.yml` | `blank_issues_enabled: false`; routes security reports to the security policy |

Labels applied (`bug`, `enhancement`, `question`) were checked to already exist in the repo, so they'll actually attach.

## Two judgment calls

**gRPC added to the target-type dropdown.** The ticket listed "REST/GraphQL/SOAP/SPA". gRPC is a supported API type in this repo (`GRPCClassifier`, `pkg/generate/grpc`, `test/grpc-server`) and was simply missing from the ticket, so the dropdown covers REST / GraphQL / SOAP-WSDL / gRPC / SPA-JS-heavy / Other-or-not-sure. SPA is kept — it isn't an API type, but it *is* how people describe their target.

**Redaction warnings in both bug and question forms.** Captures and generated specs routinely carry hostnames, tokens, cookies, and real request bodies, and these issues are public. Same warning as in `CONTRIBUTING.md`.

## Testing

- [ ] Unit tests pass (`make test`) — **N/A**, no Go code changed
- [ ] Linter passes (`make lint`) — **N/A**, no Go code changed
- [x] Manual verification (below)

Verified:
- All four files parse as YAML (`yq`)
- Every `body` element uses a valid type; all field `id`s unique within each form
- `render` values are `shell` and `json` — both GitHub-linguist languages, which is what `render` requires
- `render` combined with `validations.required` confirmed against GitHub's form-schema docs as having no documented restriction
- `config.yml` resolves to `blank_issues_enabled=false` with one contact link
- Required fields: bug → version, environment, command, api-type, capture-source, expected, actual; feature → problem, solution, contribution; question → goal, tried

The remaining acceptance item — "New issue UI shows the three templates" — can only be confirmed after merge to `main`, since GitHub reads templates from the default branch.

## Notes

- **No merge-order dependency.** Unlike #192/#193, nothing here links a file that doesn't exist yet — `config.yml` points at the security policy tab, which renders the already-merged `SECURITY.md`. This can merge in any order.
- I deliberately did **not** add a `CONTRIBUTING.md` contact link to `config.yml`. It would be useful, but it'd create a third merge-order coupling to #193 for a nice-to-have. Easy one-line follow-up once #193 lands.
- Seven required fields on the bug form is deliberate but tunable — every one is either a single line or a dropdown with an escape option. Trivial to relax if it deters reports.
- The `question.yml` routing assumes questions belong in Issues. If GitHub Discussions is enabled under LAB-5325, this form should likely become a `contact_link` to Discussions instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
