### PR TITLE
docs: add GOVERNANCE.md and align CODEOWNERS (LAB-5324)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,6 @@
 # Specify code owners for this repository.
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# This list must match the maintainer roster in GOVERNANCE.md. Change both together.
 
-* @santiago-praetorian @praetorian-peter-mueller
+* @santiago-praetorian @eli-wald @logan-bayless

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,7 +311,7 @@ test: add live coverage for HTML form extraction
 5. Keep diffs reviewable — no unrelated reformatting.
 6. Update `README.md` and the relevant `doc.go` if you change user-facing behavior or a package's public API.
 
-Review is driven by [`CODEOWNERS`](CODEOWNERS); a maintainer review is required before merge.
+Review is driven by [`CODEOWNERS`](CODEOWNERS); a maintainer review is required before merge. [`GOVERNANCE.md`](GOVERNANCE.md) lists the current maintainers and describes how decisions get made — including what to do if a pull request stalls or a review is disputed.
 
 Two CI workflows gate a PR:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,63 @@
+# Governance
+
+This document describes who maintains Vespasian, how decisions get made, and what to do when the process stalls. It exists so contributors don't have to guess who can accept a change.
+
+Vespasian is sponsored by [Praetorian](https://www.praetorian.com/), which funds its development and provides the security contact used for vulnerability and conduct reports.
+
+## Table of contents
+
+- [Maintainers](#maintainers)
+- [Decision making](#decision-making)
+- [Changes to the maintainer team](#changes-to-the-maintainer-team)
+- [Releases](#releases)
+- [Escalation](#escalation)
+- [Code of conduct](#code-of-conduct)
+
+## Maintainers
+
+Maintainers review and merge pull requests, cut releases, and set technical direction.
+
+| GitHub |
+|--------|
+| [@santiago-praetorian](https://github.com/santiago-praetorian) |
+| [@eli-wald](https://github.com/eli-wald) |
+| [@logan-bayless](https://github.com/logan-bayless) |
+
+This roster and [`CODEOWNERS`](CODEOWNERS) are kept in sync — `CODEOWNERS` is what actually drives review assignment on a pull request, so a change to one is a change to the other. If you find them disagreeing, that's a bug; please open an issue.
+
+## Decision making
+
+Most changes are routine and need no ceremony:
+
+- **Pull requests** require at least one approving review from a maintainer other than the author before merge. `CODEOWNERS` requests that review automatically.
+- **Maintainers do not self-merge** without another maintainer's approval, including for their own changes.
+- **Routine changes** — bug fixes, tests, documentation, dependency bumps — proceed on a single approval.
+- **Substantial changes** — a new API type, a breaking change to the `capture.json` format, a new runtime dependency, or anything that changes CLI behavior users rely on — should start as an issue so the discussion happens before the implementation. This is about saving contributors wasted work, not about gatekeeping.
+
+Where maintainers disagree, the expectation is that they resolve it in the open on the pull request or issue. If a disagreement can't be settled that way, it is escalated to the Praetorian team that sponsors the project.
+
+## Changes to the maintainer team
+
+- A new maintainer is proposed by an existing maintainer and confirmed by consensus of the current maintainers.
+- A maintainer may step down at any time by opening a pull request removing themselves.
+- Maintainers who have been inactive for an extended period may be moved off the roster by consensus of the remaining maintainers.
+
+Any change to the team updates both this file and [`CODEOWNERS`](CODEOWNERS) in the same pull request.
+
+## Releases
+
+Any maintainer may cut a release. Releases are triggered by pushing a `v*` tag; [`.github/workflows/release.yml`](.github/workflows/release.yml) then runs GoReleaser, which builds the binaries and publishes the GitHub release. There is no manual publishing step.
+
+## Escalation
+
+If a pull request or issue stalls:
+
+1. Comment on the thread — maintainers may simply have missed it.
+2. If there's still no response after roughly a week, `@`-mention the maintainers listed above.
+3. If a review is disputed, ask for a second maintainer to weigh in rather than relitigating with the first.
+
+## Code of conduct
+
+Participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). Report unacceptable behavior to security@praetorian.com, as described there.
+
+Security vulnerabilities follow a separate process — see [`SECURITY.md`](SECURITY.md). Do not report them in a public issue.

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the develo
 
 In short: fork the repository, create a feature branch, make sure `make check` passes, and open a Pull Request. Note that `make check` reformats as well as validates — it runs `gofmt -s -w .` first, so it may modify your working tree.
 
-This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). Security vulnerabilities should be reported per [SECURITY.md](SECURITY.md) rather than as public issues.
+This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md), and [GOVERNANCE.md](GOVERNANCE.md) lists the maintainers and how decisions are made. Security vulnerabilities should be reported per [SECURITY.md](SECURITY.md) rather than as public issues.
 
 ## License
 


### PR DESCRIPTION
## Description

Adds `GOVERNANCE.md` and updates `CODEOWNERS` to match its maintainer roster.

The repo has `CODEOWNERS`, but that's a review-routing mechanism, not a governance document. Nothing stated who maintains Vespasian, how decisions get made, who can cut a release, or what to do when a PR stalls — so an external contributor had no way to tell who could accept their change.

Resolves [LAB-5324](https://linear.app/praetorianlabs/issue/LAB-5324/add-governancemd-maintainersmd).

There is **no Praetorian precedent** for this file — `praetorian-inc/trajan`, the reference OSS repo used for the code of conduct and contributing guide, has no `GOVERNANCE.md` or `MAINTAINERS.md`. This is adapted from a standard OSS maintainer-team model instead. Everything in it is a proposal, not a description of existing written policy.

## ⚠️ CODEOWNERS change — please confirm

`CODEOWNERS` went from:

```
* @santiago-praetorian @praetorian-peter-mueller
```

to:

```
* @santiago-praetorian @eli-wald @logan-bayless
```

**This removes @praetorian-peter-mueller's code-owner status**, meaning they'll no longer be auto-requested for review. That is a real access change to a real person, so flag it if unintended — it's a one-line revert.

The rationale: the roster was specified as santiago-praetorian / eli-wald / logan-bayless, and LAB-5324's acceptance requires the roster be consistent with `CODEOWNERS`. A governance doc whose roster contradicts `CODEOWNERS` is worse than no governance doc, so the two now carry a comment saying they change together. But if Peter should keep code-owner status without being listed as a maintainer, that's a coherent position and I've simply guessed wrong.

For context on how the discrepancy surfaced: `CODEOWNERS` listed two people, but the last 25 merges came from six accounts — `santiago-praetorian` (13), `eli-wald` (4), `saullocarvalho` (3), `logan-bayless` (2), `nsportsman` (2), `gitoso` (1) — and `praetorian-peter-mueller` merged none of them. Note `saullocarvalho` and `nsportsman` merge actively but are **not** on the roster; that's per the roster decision, not an oversight, but worth a second look.

## Two acceptance items deliberately left unmet

Both were explicit decisions, recorded here so they don't read as oversights:

1. **The Code of Conduct's "community leaders" are left undefined.** LAB-5324's acceptance asked that the term resolve to named people or roles. The doc points at `CODE_OF_CONDUCT.md` and the existing `security@praetorian.com` address without defining who receives a report. Worth revisiting: the gap matters most for a report *about* a maintainer, where "report it to the maintainers" is precisely the wrong answer.
2. **Maintainer eligibility is not addressed.** The doc documents *how* someone joins the team (nomination plus consensus) but says nothing about whether non-Praetorian contributors are eligible. That was the item my original write-up flagged for legal.

## What the doc says

| Section | Content |
|---|---|
| Maintainers | Roster as a table of GitHub handles, stated to be kept in sync with `CODEOWNERS` |
| Decision making | One approving review from a non-author maintainer; no self-merge; routine vs. substantial changes; disagreements resolved in the open, escalated to the sponsoring Praetorian team |
| Maintainer-team changes | Nomination + consensus; self-removal by PR; inactivity handling |
| Releases | Any maintainer; push a `v*` tag → GoReleaser publishes. Verified against `.github/workflows/release.yml` |
| Escalation | Comment → `@`-mention after ~a week → request a second maintainer for disputed reviews |
| Code of conduct | Points at `CODE_OF_CONDUCT.md` and `SECURITY.md` |

Handles are listed **without real names** deliberately — I'm not going to guess at people's names from git metadata and risk misnaming them.

## Merge order — stacked on #193

This PR is **based on #193's branch**, not `main`, so the diff shows only the GOVERNANCE delta. GitHub retargets it to `main` automatically once #193 merges.

**Merge #192 → #193 → this.** `GOVERNANCE.md` links `CODE_OF_CONDUCT.md` (#192), and the `CONTRIBUTING.md` / `README.md` links this PR adds need `CONTRIBUTING.md` (#193) to exist.

Those cross-links live here rather than in #193 deliberately: each link travels with the PR that adds its target, so no intermediate state on `main` ever points at a file that isn't there. #194 is independent.

Chain: **#192 → #193 → #195 → #196**.

## Testing

- [ ] Unit tests pass (`make test`) — **N/A**, no Go code changed
- [ ] Linter passes (`make lint`) — **N/A**, no Go code changed
- [x] Manual verification (below)

Verified:
- All three roster handles resolve to real GitHub accounts (`gh api users/…`) — no dead links
- Release mechanics checked against `.github/workflows/release.yml` (`on: push: tags: v*` → GoReleaser), not assumed
- Every internal link resolves except `CODE_OF_CONDUCT.md` (see merge order)
- `CODEOWNERS` roster and `GOVERNANCE.md` roster are byte-consistent

The "linked from CONTRIBUTING.md and README.md" acceptance item lands in #193, as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
