### PR TITLE
ci(deps): stop dependabot bumping the leaderboard pin (ENG-5687)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,35 @@ updates:
       interval: weekly
     commit-message:
       prefix: "ci"
+    ignore:
+      # The leaderboard reusables are SHA-pinned, and the pinned SHA is
+      # allow-listed by `job_workflow_ref` in the LeaderboardMetricsRole IAM
+      # trust policy in guard. Bumping the pin therefore does not just change a
+      # version — it presents a `job_workflow_ref` that is NOT on the trust
+      # list, so OIDC AssumeRole is denied and the run fails.
+      #
+      # That failure is SILENT in the only way that matters: nothing alerts on
+      # it, so contribution metrics simply stop being delivered and the loss is
+      # only discoverable by auditing run conclusions after the fact. brutus#229
+      # and augustus#241 were both merged as routine dependabot bumps and each
+      # took its repo's metrics dark until someone went looking (ENG-5687).
+      #
+      # Rolling this pin is a COORDINATED operation, not a dependency update:
+      # add the new SHA to the IAM trust policy and deploy it to prod BEFORE
+      # the pin moves (the ENG-4164 runbook). Dependabot cannot do that half,
+      # so it must not do this half either. Roll it by hand as part of that
+      # runbook.
+      #
+      # The wildcard comes first so a leaderboard reusable added later is
+      # covered without a follow-up edit here — an ignore rule whose absence is
+      # invisible is exactly the failure mode above. The two exact names are
+      # then listed as well, and they are NOT redundancy for its own sake: the
+      # wildcard's match semantics against a reusable-workflow dependency name
+      # are unverified in this org, whereas the exact form is empirically proven
+      # (augustus and brutus have had zero leaderboard bumps since adopting it).
+      # If the wildcard silently fails to match, the exact entries still hold —
+      # and a control that cannot be tested before it is needed should not be
+      # the only control.
+      - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-*"
+      - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml"
+      - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-backfill.yml"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,16 +40,27 @@ updates:
       # skipped — same pin, same available upgrade, same ecosystem run,
       # differing only in the ignore rule.
       #
-      # The `leaderboard-*` wildcard is OPPORTUNISTIC FORWARD COVERAGE and is
-      # NOT load-bearing. Its match semantics against a reusable-workflow
-      # dependency name are unverified in this org, and — the part that
-      # matters — they CANNOT be verified by watching this rule work:
-      # suppression happens if EITHER the wildcard or an exact name matches, so
-      # a quiet dependabot run only proves the exact names held and says
-      # nothing about the wildcard. Reading it as "a reusable added later needs
-      # no edit here" would rebuild the very failure mode this rule exists to
-      # stop — a control that looks present, does nothing, and tells no one.
+      # The two exact entries below are the load-bearing control. The
+      # `leaderboard-*` wildcard is forward coverage for the window between "a
+      # new coupled reusable lands" and "someone remembers to add its exact
+      # name" — which is exactly how this was learned the expensive way.
+      #
+      # The wildcard's behaviour is NOT observable from here, in either
+      # direction. An ignore list is match-ANY, so a quiet dependabot run proves
+      # only that SOMETHING matched and never which entry; watching this rule
+      # work can therefore never confirm the wildcard fires. Its match semantics
+      # against a reusable-workflow dependency name are unverified in this org.
+      #
+      # So do not read the wildcard EITHER way:
+      #   - NOT as "a reusable added later needs no edit here". If it does not
+      #     match, metrics go dark silently. Always add the exact name.
+      #   - NOT as inert. If it DOES match, it equally suppresses a future
+      #     leaderboard-*.yml that has NO IAM coupling and would be safe to
+      #     auto-bump — silently, with no error and nothing to alert on. If you
+      #     add such a reusable and its pin never updates, this line is why, and
+      #     the remedy is to narrow or remove the wildcard.
       - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml"
       - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-backfill.yml"
-      # Non-load-bearing; see above. Never a substitute for an exact entry.
+      # Forward coverage only. Never a substitute for an exact entry, and see
+      # the over-suppression note above before adding an uncoupled reusable.
       - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,16 +32,24 @@ updates:
       # so it must not do this half either. Roll it by hand as part of that
       # runbook.
       #
-      # The wildcard comes first so a leaderboard reusable added later is
-      # covered without a follow-up edit here — an ignore rule whose absence is
-      # invisible is exactly the failure mode above. The two exact names are
-      # then listed as well, and they are NOT redundancy for its own sake: the
-      # wildcard's match semantics against a reusable-workflow dependency name
-      # are unverified in this org, whereas the exact form is empirically proven
-      # (augustus and brutus have had zero leaderboard bumps since adopting it).
-      # If the wildcard silently fails to match, the exact entries still hold —
-      # and a control that cannot be tested before it is needed should not be
-      # the only control.
-      - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-*"
+      # The EXACT NAMES are what do the work here, so ADDING A NEW LEADERBOARD
+      # REUSABLE MEANS ADDING ITS EXACT NAME to this list. Only the exact form
+      # has evidence behind it: augustus and brutus both still pin v2.16.3 with
+      # v2.16.13 available, and both took a github-actions bump for
+      # claude-md-drift.yml on 2026-08-02 while the leaderboard pin was
+      # skipped — same pin, same available upgrade, same ecosystem run,
+      # differing only in the ignore rule.
+      #
+      # The `leaderboard-*` wildcard is OPPORTUNISTIC FORWARD COVERAGE and is
+      # NOT load-bearing. Its match semantics against a reusable-workflow
+      # dependency name are unverified in this org, and — the part that
+      # matters — they CANNOT be verified by watching this rule work:
+      # suppression happens if EITHER the wildcard or an exact name matches, so
+      # a quiet dependabot run only proves the exact names held and says
+      # nothing about the wildcard. Reading it as "a reusable added later needs
+      # no edit here" would rebuild the very failure mode this rule exists to
+      # stop — a control that looks present, does nothing, and tells no one.
       - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml"
       - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-backfill.yml"
+      # Non-load-bearing; see above. Never a substitute for an exact entry.
+      - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-*"


### PR DESCRIPTION
## Problem

The leaderboard reusables are SHA-pinned, and that pinned SHA is allow-listed by `job_workflow_ref` in the **`LeaderboardMetricsRole` IAM trust policy in guard**. So a pin bump is not a version change — it presents a `job_workflow_ref` that is *not* on the trust list, OIDC `AssumeRole` is denied, and the metrics run fails.

The failure is **silent**. `leaderboard-metrics.yml` contains no failure-notification construct, and there is no reconciliation job anywhere, so contribution metrics simply stop being delivered and the loss is only discoverable by auditing run conclusions after the fact.

This has already landed twice as a routine merged bump:

| PR | merged | effect |
| -- | -- | -- |
| `brutus#229` | 2026-07-11 | metrics dark until repaired 07-16 (`brutus#266`) |
| `augustus#241` | 2026-07-11 | metrics dark until reverted 07-26 (`augustus#252`) |

**`vespasian#198` is the same bump, open against this repo right now** (`c351826e` v2.16.3 → `96b68220` v2.16.13). This repo has no ignore rule, so merging it would take vespasian's metrics dark exactly as above.

## Fix

An `ignore:` entry on the `github-actions` ecosystem. Rolling this pin is a coordinated operation — the new SHA must be added to the IAM trust policy and deployed to prod *before* the pin moves (the ENG-4164 runbook). Dependabot cannot do that half, so it must not do this half either.

## Why three entries and not one

- The **two exact names come first, and they are what do the work.** `leaderboard-backfill.yml` is listed because the ENG-5688 fan-out adds that second pinned reusable — identical trust-policy coupling, its own separately-trusted pin `6c715ccf` (v2.17.0) — so the control precedes the dependency rather than following the first broken bump. **Stated so it is not mistaken for a tested control: that entry is a no-op today**, since no backfill caller exists in this repo yet.
- The **`leaderboard-*` wildcard is explicitly NOT load-bearing**, and the file's comment says so in as many words. A dependabot `ignore` list is **match-ANY**: suppression happens if *either* the wildcard or an exact name matches, which makes the wildcard **unobservable** here — no outcome distinguishes "it matched" from "it is inert." Its semantics against a *reusable-workflow* dependency name are unverified in this org and cannot be verified from this PR.

The harm would not be the untested wildcard itself; it would be the instruction a future engineer infers from it. "A reusable added later needs no edit here" would rebuild the exact failure mode this rule exists to stop — a control that looks present, does nothing, and tells no one. So the comment states the opposite in the imperative: **adding a new leaderboard reusable means adding its exact name to this list.**

The exact-name form is also the only one with a positive control behind it, rather than just an absence of PRs: augustus and brutus both still pin **v2.16.3 while v2.16.13 is available**, and both took a `github-actions` dependabot bump on **2026-08-02** for a *different* public-workflows reusable (`claude-md-drift.yml`) while the leaderboard pin was skipped. Same pin, same available upgrade, same ecosystem run — the only difference is the ignore rule.

## Verification

- `dependabot.yml` parses as YAML; the `github-actions` entry has exactly the 3 ignore entries and the `gomod` entry is untouched (`32` insertions, `0` deletions, 1 file).
- **Post-merge check on the exact-name path:** if the rule takes effect, Dependabot should auto-close `vespasian#198` on its next run with an ignore notice. If #198 is still open and unremarked after the next weekly run, then all three entries failed to match and this needs revisiting — please do not close #198 by hand before then.
- **Correction, on the record.** An earlier revision of this body called that a falsifier for the change *as a whole*, and a reviewer on this PR called it "the right way to de-risk" the wildcard. Both were wrong, and the claim is withdrawn. Because the ignore list is match-any, the exact names suppress the bump regardless, so an auto-close confirms only the exact-name path and carries **zero** information about the wildcard — the check could not have failed for the reason I claimed it would pass. Confirmed and fixed in `96656cbf` by demoting the wildcard rather than by trusting the check.

## Not in scope

This is the per-repo stopgap. It is a manually-maintained control that must be re-adopted in every repo and degrades silently, so it is not the durable fix — that is a scheduled reconciler that detects a delivery gap regardless of cause, tracked separately under ENG-5687/ENG-5690.

Refs ENG-5687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

