### PR TITLE
docs: forward-merge GOVERNANCE.md, SUPPORT.md and CODEOWNERS roster (LAB-5870)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Report a security vulnerability
     url: https://github.com/praetorian-inc/vespasian/security/policy
     about: Do not open a public issue for security vulnerabilities. Report them privately per our security policy.
+  - name: Support guide
+    url: https://github.com/praetorian-inc/vespasian/blob/main/SUPPORT.md
+    about: Which template to pick, the context to include, and what response to expect.

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -27,8 +27,8 @@ jobs:
       # outbound network traffic. Audit mode is non-blocking — it logs egress
       # to the StepSecurity dashboard without enforcing an allowlist. Flip to
       # 'block' with an allowed-endpoints list once telemetry confirms the set.
-      # DUPLICATED across preflight-selftest / validator-regression / test.
-      # harden-runner is a SHA-pinned security control: bump ALL THREE copies
+      # DUPLICATED across preflight-selftest / validator-regression / docs-check /
+      # test. harden-runner is a SHA-pinned security control: bump ALL FOUR copies
       # in lockstep — a missed copy silently leaves a job on a stale pin.
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
@@ -60,8 +60,8 @@ jobs:
       # outbound network traffic. Audit mode is non-blocking — it logs egress
       # to the StepSecurity dashboard without enforcing an allowlist. Flip to
       # 'block' with an allowed-endpoints list once telemetry confirms the set.
-      # DUPLICATED across preflight-selftest / validator-regression / test.
-      # harden-runner is a SHA-pinned security control: bump ALL THREE copies
+      # DUPLICATED across preflight-selftest / validator-regression / docs-check /
+      # test. harden-runner is a SHA-pinned security control: bump ALL FOUR copies
       # in lockstep — a missed copy silently leaves a job on a stale pin.
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
@@ -94,6 +94,42 @@ jobs:
 
       - name: Validator regression test
         run: ./test/validate_test.sh
+
+  # Community-health docs guard (LAB-5870). Asserts the required docs exist, every
+  # relative markdown link and heading anchor resolves, and the CODEOWNERS '*' roster
+  # matches the GOVERNANCE.md maintainer table. LAB-5870 existed because GOVERNANCE.md
+  # and SUPPORT.md were absent from main for a week with nothing to notice; run against
+  # that commit this job fails on both files.
+  #
+  # Lives here rather than in ci.yml because ci.yml's paths filter is Go-only, so a
+  # docs-only PR never triggers it — the job that guards docs must not itself be gated
+  # on Go files changing. Outside the check-label gate for the same reason as
+  # preflight-selftest and validator-regression: 'skip-live-tests' must not disable it.
+  docs-check:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      # Defense-in-depth (LAB-4732 / SEC-BE-002): monitor and record all
+      # outbound network traffic. Audit mode is non-blocking — it logs egress
+      # to the StepSecurity dashboard without enforcing an allowlist. Flip to
+      # 'block' with an allowed-endpoints list once telemetry confirms the set.
+      # DUPLICATED across preflight-selftest / validator-regression / docs-check /
+      # test. harden-runner is a SHA-pinned security control: bump ALL FOUR copies
+      # in lockstep — a missed copy silently leaves a job on a stale pin.
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      # fetch-depth 0 is NOT needed: the checker reads the working tree and uses
+      # `git ls-files`, which works on a shallow clone.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Check community-health docs
+        run: python3 test/check-docs.py --verbose
 
   # Gate: run by default; skip PR runs only when 'skip-live-tests' label is present.
   # Push-to-main and workflow_dispatch always run.
@@ -131,8 +167,8 @@ jobs:
       # 'block' with an allowed-endpoints list once telemetry confirms the set
       # (expected: github.com, proxy.golang.org, sum.golang.org,
       # storage.googleapis.com, objects.githubusercontent.com, registry.npmjs.org).
-      # DUPLICATED across preflight-selftest / validator-regression / test.
-      # harden-runner is a SHA-pinned security control: bump ALL THREE copies
+      # DUPLICATED across preflight-selftest / validator-regression / docs-check /
+      # test. harden-runner is a SHA-pinned security control: bump ALL FOUR copies
       # in lockstep — a missed copy silently leaves a job on a stale pin.
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,11 @@ make lint                     # Runs golangci-lint (gocritic, misspell, revive)
 # Format
 make fmt                      # Runs gofmt -s -w .
 
-# All checks (format, vet, lint, test)
+# All checks (format, vet, lint, test, docs)
 make check
+
+# Community-health docs only (presence, link/anchor resolution, CODEOWNERS roster)
+make check-docs
 
 # Coverage
 make coverage                 # Generates coverage.out and prints per-function coverage
@@ -127,6 +130,8 @@ The `test/` directory contains live test targets:
 
 `test/validate_test.sh` is the regression test that locks in those validators' reject behaviour: it asserts valid specs still pass and that every malformed / substring-trap fixture is rejected (e.g. an expected `GetUser` SOAP operation must no longer be satisfied by `GetUserList`). It needs only node plus the installed `test/spec-validators` deps — no Go build and no live services — and runs in about a second.
 
+`test/check-docs.py` guards the community-health docs (LAB-5870): the required root set exists, every relative markdown link and heading anchor resolves, and the `*` owner line in `CODEOWNERS` matches the maintainer table in `GOVERNANCE.md`. It exists because `GOVERNANCE.md` and `SUPPORT.md` were absent from `main` for a week — two stacked PRs merged into feature branches that nothing merges from again — and no check noticed; run against that commit it fails on both files. Python rather than shell because the link and anchor logic needs real parsing and these scripts are authored on macOS to run on Linux, where the `sed`/`grep`/`stat` flag sets diverge in both directions. Wired into `make check` and run in CI as the ungated `docs-check` job.
+
 See `test/README.md` for how to run the suite, including the `TEST_HOST` override for devcontainer setups.
 
 ## Code Conventions
@@ -150,4 +155,4 @@ GitHub Actions runs on push to main and PRs:
 - **ci.yml**: Build, test (`go test -race`, 80% coverage threshold), lint (golangci-lint v2), and format check. Runs on all pushes and PRs.
 - **live-tests.yml**: A single **test** job runs all targets via `test/run-live-tests.sh --group offline` then `--group live`. Before the offline run it does `npm ci --ignore-scripts` in `test/spec-validators` (via `actions/setup-node` with `cache: npm` keyed on `test/spec-validators/package-lock.json`), because the offline `generate-{rest,graphql,wsdl}` targets validate their output with the real parsers rather than grep. Target groups (`OFFLINE_TARGETS` / `LIVE_TARGETS`) are defined in `test/run-live-tests.sh` — the workflow references groups, not individual targets, so adding a target means editing one array in the runner. A drift-guard step (`test/test-runner-args.sh`) fails CI if a dispatch target is not covered by `OFFLINE_TARGETS`, `LIVE_TARGETS`, or the config-only set (e.g. `grpc-server`). Uses the stable Chrome shipped with the ubuntu-24.04 runner. The **test** job is gated: it `needs` a `check-label` job and runs on every PR by default; add the `skip-live-tests` label to bypass. Always runs on push to `main` and `workflow_dispatch`.
 
-  Two fast jobs sit deliberately **outside** that label gate, so `skip-live-tests` cannot switch off the regression net: **preflight-selftest** (`test/preflight-selftest.sh`, Chrome/Chromium detection logic, LAB-3893) and **validator-regression**, which does its own `npm ci --ignore-scripts` in `test/spec-validators` and then runs `./test/validate_test.sh` to prove the spec validators still reject malformed specs. Both are ~5-minute-timeout jobs needing no Go build and no live services. All three jobs (`preflight-selftest`, `validator-regression`, `test`) open with a `step-security/harden-runner` step in `egress-policy: audit` mode (LAB-4732 / SEC-BE-002) — defense-in-depth network monitoring that logs (does not block) outbound traffic; `registry.npmjs.org` is part of the anticipated allowlist. The `--ignore-scripts` flag on both installs is SEC-BE-001: it blocks npm lifecycle scripts from executing under the non-blocking audit-only egress policy.
+  Three fast jobs sit deliberately **outside** that label gate, so `skip-live-tests` cannot switch off the regression net: **preflight-selftest** (`test/preflight-selftest.sh`, Chrome/Chromium detection logic, LAB-3893); **validator-regression**, which does its own `npm ci --ignore-scripts` in `test/spec-validators` and then runs `./test/validate_test.sh` to prove the spec validators still reject malformed specs; and **docs-check** (`test/check-docs.py`, LAB-5870). All three need no Go build and no live services and carry a ~5-minute timeout. `docs-check` lives in this workflow rather than `ci.yml` because `ci.yml`'s `paths` filter is Go-only — a docs-only PR never triggers it, so the job guarding docs cannot be gated on Go files changing. All four jobs (`preflight-selftest`, `validator-regression`, `docs-check`, `test`) open with a `step-security/harden-runner` step in `egress-policy: audit` mode (LAB-4732 / SEC-BE-002) — defense-in-depth network monitoring that logs (does not block) outbound traffic; `registry.npmjs.org` is part of the anticipated allowlist. The `--ignore-scripts` flag on both installs is SEC-BE-001: it blocks npm lifecycle scripts from executing under the non-blocking audit-only egress policy.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,6 @@
 # Specify code owners for this repository.
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# This list must match the maintainer roster in GOVERNANCE.md. Change both together.
 
-* @santiago-praetorian @praetorian-peter-mueller
+* @santiago-praetorian @eli-wald @logan-bayless

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,11 +316,11 @@ Review is driven by [`CODEOWNERS`](CODEOWNERS); a maintainer review is required 
 Two CI workflows gate a PR:
 
 - **CI** — build, test, lint, and format check. Runs only when a PR touches Go sources, `go.mod`, `go.sum`, `.golangci*`, or the `Makefile`, so docs-only PRs intentionally show no CI run.
-- **Live Tests** — the end-to-end suite, on every PR.
+- **Live Tests** — the end-to-end suite, on every PR. It also carries the checks that must run regardless of what a PR touches, including **docs-check** (`test/check-docs.py`): required docs present, every relative link and heading anchor resolving, and the `CODEOWNERS` roster matching `GOVERNANCE.md`. Run it locally with `make check-docs`; `make check` includes it.
 
 ### PR checklist
 
-- [ ] `make check` passes (fmt, vet, lint, test)
+- [ ] `make check` passes (fmt, vet, lint, test, check-docs)
 - [ ] Tests added or updated for the change
 - [ ] New classifier / generator / importer / probe registered where the pipeline expects it
 - [ ] Commit messages follow conventional commit format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,9 +329,9 @@ Two CI workflows gate a PR:
 
 ## Reporting issues
 
-Bug reports, feature requests, and questions all go through GitHub Issues. [`SUPPORT.md`](SUPPORT.md) is the single source for where to ask what, the context to include, and what response to expect — it is kept there rather than duplicated here so the two cannot drift.
+Bug reports, feature requests, and questions all go through GitHub Issues. The forms in [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE) are what a filed issue is actually held to — they collect the required context as form fields. [`SUPPORT.md`](SUPPORT.md) explains which template to pick and what response to expect; that guidance is kept there rather than restated here.
 
-One thing worth repeating: captures and generated specs routinely contain hostnames, tokens, cookies, and request bodies from real targets. Redact before attaching anything to a public issue.
+One thing worth repeating: captures and generated specs carry real hostnames, tokens, cookies, and request bodies. Redact before attaching anything to a public issue.
 
 ## Security disclosures
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,7 +311,7 @@ test: add live coverage for HTML form extraction
 5. Keep diffs reviewable — no unrelated reformatting.
 6. Update `README.md` and the relevant `doc.go` if you change user-facing behavior or a package's public API.
 
-Review is driven by [`CODEOWNERS`](CODEOWNERS); a maintainer review is required before merge.
+Review is driven by [`CODEOWNERS`](CODEOWNERS); a maintainer review is required before merge. [`GOVERNANCE.md`](GOVERNANCE.md) lists the current maintainers and describes how decisions get made — including what to do if a pull request stalls or a review is disputed.
 
 Two CI workflows gate a PR:
 
@@ -329,17 +329,9 @@ Two CI workflows gate a PR:
 
 ## Reporting issues
 
-Open a GitHub issue and include:
+Bug reports, feature requests, and questions all go through GitHub Issues. [`SUPPORT.md`](SUPPORT.md) is the single source for where to ask what, the context to include, and what response to expect — it is kept there rather than duplicated here so the two cannot drift.
 
-- What you expected versus what happened
-- Steps to reproduce — the CLI command and flags, and the capture source (crawl, Burp XML, HAR, mitmproxy)
-- Vespasian version (`vespasian version`)
-- Go version (`go version`), OS, and architecture
-- A **redacted** `capture.json` excerpt where relevant
-
-Captures and generated specs routinely contain hostnames, tokens, cookies, and request bodies from real targets. Redact before attaching anything to a public issue.
-
-Questions belong in issues too.
+One thing worth repeating: captures and generated specs routinely contain hostnames, tokens, cookies, and request bodies from real targets. Redact before attaching anything to a public issue.
 
 ## Security disclosures
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,63 @@
+# Governance
+
+This document describes who maintains Vespasian, how decisions get made, and what to do when the process stalls. It exists so contributors don't have to guess who can accept a change.
+
+Vespasian is sponsored by [Praetorian](https://www.praetorian.com/), which funds its development and provides the security contact used for vulnerability and conduct reports.
+
+## Table of contents
+
+- [Maintainers](#maintainers)
+- [Decision making](#decision-making)
+- [Changes to the maintainer team](#changes-to-the-maintainer-team)
+- [Releases](#releases)
+- [Escalation](#escalation)
+- [Code of conduct](#code-of-conduct)
+
+## Maintainers
+
+Maintainers review and merge pull requests, cut releases, and set technical direction.
+
+| GitHub |
+|--------|
+| [@santiago-praetorian](https://github.com/santiago-praetorian) |
+| [@eli-wald](https://github.com/eli-wald) |
+| [@logan-bayless](https://github.com/logan-bayless) |
+
+This roster and [`CODEOWNERS`](CODEOWNERS) are kept in sync — `CODEOWNERS` is what actually drives review assignment on a pull request, so a change to one is a change to the other. If you find them disagreeing, that's a bug; please open an issue.
+
+## Decision making
+
+Most changes are routine and need no ceremony:
+
+- **Pull requests** require at least one approving review from a maintainer other than the author before merge. `CODEOWNERS` requests that review automatically.
+- **Maintainers do not self-merge** without another maintainer's approval, including for their own changes.
+- **Routine changes** — bug fixes, tests, documentation, dependency bumps — proceed on a single approval.
+- **Substantial changes** — a new API type, a breaking change to the `capture.json` format, a new runtime dependency, or anything that changes CLI behavior users rely on — should start as an issue so the discussion happens before the implementation. This is about saving contributors wasted work, not about gatekeeping.
+
+Where maintainers disagree, the expectation is that they resolve it in the open on the pull request or issue. If a disagreement can't be settled that way, it is escalated to the Praetorian team that sponsors the project.
+
+## Changes to the maintainer team
+
+- A new maintainer is proposed by an existing maintainer and confirmed by consensus of the current maintainers.
+- A maintainer may step down at any time by opening a pull request removing themselves.
+- Maintainers who have been inactive for an extended period may be moved off the roster by consensus of the remaining maintainers.
+
+Any change to the team updates both this file and [`CODEOWNERS`](CODEOWNERS) in the same pull request.
+
+## Releases
+
+Any maintainer may cut a release. Releases are triggered by pushing a `v*` tag; [`.github/workflows/release.yml`](.github/workflows/release.yml) then runs GoReleaser, which builds the binaries and publishes the GitHub release. There is no manual publishing step.
+
+## Escalation
+
+If a pull request or issue stalls:
+
+1. Comment on the thread — maintainers may simply have missed it.
+2. If there's still no response after roughly a week, `@`-mention the maintainers listed above.
+3. If a review is disputed, ask for a second maintainer to weigh in rather than relitigating with the first.
+
+## Code of conduct
+
+Participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). Report unacceptable behavior to security@praetorian.com, as described there.
+
+Security vulnerabilities follow a separate process — see [`SECURITY.md`](SECURITY.md). Do not report them in a public issue.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,7 +29,7 @@ This roster and [`CODEOWNERS`](CODEOWNERS) are kept in sync — `CODEOWNERS` is 
 
 Most changes are routine and need no ceremony:
 
-- **Pull requests** require at least one approving review from a maintainer other than the author before merge. `CODEOWNERS` requests that review automatically.
+- **Pull requests** require at least one approving review before merge; a branch ruleset enforces that. The approval is expected to come from a maintainer other than the author, and `CODEOWNERS` requests that review automatically, but code-owner approval is convention here rather than an enforced gate.
 - **Maintainers do not self-merge** without another maintainer's approval, including for their own changes.
 - **Routine changes** — bug fixes, tests, documentation, dependency bumps — proceed on a single approval.
 - **Substantial changes** — a new API type, a breaking change to the `capture.json` format, a new runtime dependency, or anything that changes CLI behavior users rely on — should start as an issue so the discussion happens before the implementation. This is about saving contributors wasted work, not about gatekeeping.
@@ -46,7 +46,9 @@ Any change to the team updates both this file and [`CODEOWNERS`](CODEOWNERS) in 
 
 ## Releases
 
-Any maintainer may cut a release. Releases are triggered by pushing a `v*` tag; [`.github/workflows/release.yml`](.github/workflows/release.yml) then runs GoReleaser, which builds the binaries and publishes the GitHub release. There is no manual publishing step.
+Releases are triggered by pushing a `v*` tag; [`.github/workflows/release.yml`](.github/workflows/release.yml) then runs GoReleaser, which builds the binaries and publishes the GitHub release. There is no manual publishing step.
+
+Creating the tag is the gated part. An organization-level ruleset restricts creation of `refs/tags/v*`, so being on the roster above does not by itself let you cut a release. A maintainer without that permission asks a Praetorian organization administrator to create the tag.
 
 ## Escalation
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS   := -s -w -X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT) -X main.buildDate=$(BUILD_DATE)
 
-.PHONY: build test lint fmt vet check coverage clean deps live-test-clean
+.PHONY: build test lint fmt vet check check-docs coverage clean deps live-test-clean
 
 build:
 	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/vespasian
@@ -23,7 +23,13 @@ fmt:
 vet:
 	go vet ./...
 
-check: fmt vet lint test
+check: fmt vet lint test check-docs
+
+# Community-health docs: presence, link/anchor resolution, CODEOWNERS-vs-GOVERNANCE
+# roster equality. Also runs as its own CI job, because ci.yml's paths filter means a
+# docs-only PR never reaches this Makefile.
+check-docs:
+	python3 test/check-docs.py
 
 coverage:
 	go test -race -coverprofile=coverage.out $$(go list ./... | grep -v '/test/')

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the develo
 
 In short: fork the repository, create a feature branch, make sure `make check` passes, and open a Pull Request. Note that `make check` reformats as well as validates — it runs `gofmt -s -w .` first, so it may modify your working tree.
 
-This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). Security vulnerabilities should be reported per [SECURITY.md](SECURITY.md) rather than as public issues.
+This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md), and [GOVERNANCE.md](GOVERNANCE.md) lists the maintainers and how decisions are made. For questions and support, see [SUPPORT.md](SUPPORT.md). Security vulnerabilities should be reported per [SECURITY.md](SECURITY.md) rather than as public issues.
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,46 @@
+# Support
+
+Thanks for using Vespasian. This page explains where to ask, what to include, and what to expect back.
+
+## Where to ask
+
+Everything goes through [GitHub Issues](https://github.com/praetorian-inc/vespasian/issues):
+
+| You want to | Open an issue and |
+|---|---|
+| Ask how to do something, or check whether behavior is expected | say it's a question, and include the context below |
+| Report something that doesn't work | describe expected versus actual, with the context below |
+| Suggest a capability or improvement | describe the use case it unblocks |
+| Report a security vulnerability | **don't** — see [SECURITY.md](SECURITY.md) |
+
+Start at [new issue](https://github.com/praetorian-inc/vespasian/issues/new). Before filing, the [README](README.md) covers installation, the CLI reference, which API types are supported, and an [FAQ](README.md#frequently-asked-questions) — a fair number of questions are answered there.
+
+If you're unsure whether something is a bug or a misunderstanding, say so and file it as a question. Working that out is our job, not yours.
+
+## What to include
+
+Vespasian's behavior depends heavily on what it was pointed at and how the traffic was captured, so a question without that context usually costs a round trip. Include:
+
+- **Version** — output of `vespasian version`
+- **OS and architecture**, and whether you're running in a container or devcontainer
+- **Go version** (`go version`) if you built from source
+- **The command you ran**, with flags
+- **Where the traffic came from** — headless crawl, Burp Suite XML, HAR, or mitmproxy import
+- **What you expected** versus what happened
+- **A relevant excerpt** of `capture.json` or the generated spec
+
+**Redact before posting.** Captures and generated specs routinely contain hostnames, tokens, cookies, and request bodies from real targets. Issues are public and are not the place for any of that. Strip it, or replace it with representative dummy values.
+
+## What to expect
+
+Vespasian is maintained by [Praetorian](https://www.praetorian.com/) alongside other work. Issues are answered on a **best-effort basis — there is no response-time commitment or SLA.**
+
+In practice:
+
+- Questions and bug reports with the context above get answered fastest, because there's nothing to ask for first.
+- Reproducible bugs are prioritized over ones we can't reproduce.
+- A quiet issue hasn't been rejected. Comment on the thread — maintainers may simply have missed it — and if it's still quiet after roughly a week, escalate per [GOVERNANCE.md](GOVERNANCE.md).
+
+## Security
+
+**Never report a security vulnerability in a public issue.** Follow [SECURITY.md](SECURITY.md) — email security@praetorian.com. The same applies to anything sensitive you find in a capture of a third party's system.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,16 +4,16 @@ Thanks for using Vespasian. This page explains where to ask, what to include, an
 
 ## Where to ask
 
-Everything goes through [GitHub Issues](https://github.com/praetorian-inc/vespasian/issues):
+Questions, bug reports, and feature requests go through [GitHub Issues](https://github.com/praetorian-inc/vespasian/issues):
 
-| You want to | Open an issue and |
-|---|---|
-| Ask how to do something, or check whether behavior is expected | say it's a question, and include the context below |
-| Report something that doesn't work | describe expected versus actual, with the context below |
-| Suggest a capability or improvement | describe the use case it unblocks |
-| Report a security vulnerability | **don't** — see [SECURITY.md](SECURITY.md) |
+| You want to | Template | And |
+|---|---|---|
+| Ask how to do something, or check whether behavior is expected | **Question** | include the context below |
+| Report something that doesn't work | **Bug report** | describe expected versus actual, with the context below |
+| Suggest a capability or improvement | **Feature request** | describe the use case it unblocks |
+| Report a security vulnerability | none — **don't** | see [`SECURITY.md`](SECURITY.md) |
 
-Start at [new issue](https://github.com/praetorian-inc/vespasian/issues/new). Before filing, the [README](README.md) covers installation, the CLI reference, which API types are supported, and an [FAQ](README.md#frequently-asked-questions) — a fair number of questions are answered there.
+Start at [new issue](https://github.com/praetorian-inc/vespasian/issues/new/choose) and pick the matching template; each one asks for the context below as form fields. Before filing, the [README](README.md) covers installation, the CLI reference, which API types are supported, and an [FAQ](README.md#frequently-asked-questions) — a fair number of questions are answered there.
 
 If you're unsure whether something is a bug or a misunderstanding, say so and file it as a question. Working that out is our job, not yours.
 
@@ -39,8 +39,8 @@ In practice:
 
 - Questions and bug reports with the context above get answered fastest, because there's nothing to ask for first.
 - Reproducible bugs are prioritized over ones we can't reproduce.
-- A quiet issue hasn't been rejected. Comment on the thread — maintainers may simply have missed it — and if it's still quiet after roughly a week, escalate per [GOVERNANCE.md](GOVERNANCE.md).
+- A quiet issue hasn't been rejected. If a thread stays quiet, follow the escalation steps in [`GOVERNANCE.md`](GOVERNANCE.md).
 
 ## Security
 
-**Never report a security vulnerability in a public issue.** Follow [SECURITY.md](SECURITY.md) — email security@praetorian.com. The same applies to anything sensitive you find in a capture of a third party's system.
+**Never report a security vulnerability in a public issue.** Follow [`SECURITY.md`](SECURITY.md) — email security@praetorian.com. The same applies to anything sensitive you find in a capture of a third party's system.

--- a/test/check-docs.py
+++ b/test/check-docs.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Assert the repository's community-health docs are present, linked, and self-consistent.
+
+Three checks, each independently reportable:
+
+1. presence   — the community-health set exists at the repository root. LAB-5870 landed
+                after GOVERNANCE.md and SUPPORT.md were absent from `main` for a week
+                because two stacked PRs merged into feature branches that nothing merges
+                from again. Nothing in CI noticed.
+2. links      — every relative markdown link and heading anchor resolves. A cross-link
+                added alongside a new document is the other half of that failure: the
+                document can be present and the link to it still dead.
+3. roster     — the `*` owner line in CODEOWNERS matches the maintainer table in
+                GOVERNANCE.md. Both files assert they are kept in sync and each points at
+                the other, but CODEOWNERS is what actually drives review assignment, so a
+                one-sided edit misroutes reviews while both documents still read as
+                authoritative.
+
+Written in Python rather than shell deliberately: the link and slug logic needs real
+parsing, and the surrounding scripts are developed on macOS and run on Linux, where the
+`sed`/`grep`/`stat` flag sets diverge in both directions.
+
+Exit status is 0 when every check passes, 1 otherwise. Run with --verbose to list what
+was checked rather than only what failed.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Community-health files that must exist at the repository root. GitHub surfaces each of
+# these in its own UI slot, so an absent one degrades silently rather than erroring.
+REQUIRED_ROOT_FILES = [
+    "README.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md",
+    "SECURITY.md",
+    "SUPPORT.md",
+    "GOVERNANCE.md",
+    "LICENSE",
+    "CODEOWNERS",
+]
+
+# Directories whose markdown is not ours to validate.
+SKIP_DIR_PARTS = {"node_modules", ".worktrees", "vendor", "dist", "bin"}
+
+# Inline markdown links and images: [text](target) / ![alt](target), optional "title".
+# Reference-style links carry no inline target and are deliberately not matched.
+LINK_RE = re.compile(r"!?\[(?P<text>[^\]]*)\]\((?P<target>[^)\s]+)(?:\s+\"[^\"]*\")?\)")
+HEADING_RE = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<text>.+?)\s*$", re.MULTILINE)
+FENCE_RE = re.compile(r"^([ \t]*)(```|~~~)", re.MULTILINE)
+
+
+def repo_root():
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def tracked_markdown(root):
+    out = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "*.md", "*.markdown"],
+        capture_output=True, text=True, check=True,
+    )
+    paths = []
+    for line in out.stdout.splitlines():
+        p = Path(line)
+        if SKIP_DIR_PARTS & set(p.parts):
+            continue
+        paths.append(p)
+    return sorted(paths)
+
+
+def strip_fenced_blocks(text):
+    """Blank out fenced code blocks so links inside samples are not validated.
+
+    Lines are replaced rather than removed so reported line numbers stay accurate.
+    """
+    lines = text.split("\n")
+    out, fence = [], None
+    for line in lines:
+        m = FENCE_RE.match(line)
+        marker = m.group(2) if m else None
+        if fence is None and marker:
+            fence = marker
+            out.append("")
+            continue
+        if fence is not None:
+            # A closing fence is the same marker character run, nothing else on the line.
+            if marker and line.strip().startswith(fence):
+                fence = None
+            out.append("")
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def slugify(heading_text):
+    """GitHub's heading-anchor algorithm, as applied to already-rendered heading text.
+
+    Inline markdown is stripped first (backticks, emphasis, and link syntax reduced to
+    its text) because the anchor derives from the rendered text, not the source.
+    """
+    t = LINK_RE.sub(lambda m: m.group("text"), heading_text)
+    t = t.replace("`", "").replace("*", "").replace("_", "")
+    t = t.lower()
+    t = re.sub(r"[^a-z0-9 \-]", "", t)
+    return t.strip().replace(" ", "-")
+
+
+def anchors_for(path, cache):
+    """Every anchor a markdown file exposes, including GitHub's -1/-2 duplicate suffixes."""
+    if path in cache:
+        return cache[path]
+    try:
+        text = strip_fenced_blocks(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError):
+        cache[path] = set()
+        return cache[path]
+    seen, anchors = {}, set()
+    for m in HEADING_RE.finditer(text):
+        base = slugify(m.group("text"))
+        if not base:
+            continue
+        n = seen.get(base, 0)
+        anchors.add(base if n == 0 else f"{base}-{n}")
+        seen[base] = n + 1
+    # Explicit HTML anchors authors may have placed by hand.
+    for m in re.finditer(r"<a\s+[^>]*(?:name|id)=[\"']([^\"']+)[\"']", text):
+        anchors.add(m.group(1))
+    cache[path] = anchors
+    return anchors
+
+
+def check_presence(root, failures, verbose):
+    for name in REQUIRED_ROOT_FILES:
+        if (root / name).exists():
+            if verbose:
+                print(f"  present: {name}")
+        else:
+            failures.append(
+                f"presence: required community-health file {name} is missing from the "
+                f"repository root"
+            )
+
+
+def check_links(root, files, failures, verbose):
+    cache = {}
+    checked = 0
+    for rel in files:
+        path = root / rel
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            failures.append(f"links: cannot read {rel}: {e}")
+            continue
+        text = strip_fenced_blocks(raw)
+        for m in LINK_RE.finditer(text):
+            target = m.group("target")
+            line_no = text.count("\n", 0, m.start()) + 1
+            if target.startswith(("http://", "https://", "mailto:", "tel:")):
+                continue
+            if target.startswith("<") and target.endswith(">"):
+                target = target[1:-1]
+            frag = ""
+            if "#" in target:
+                target, frag = target.split("#", 1)
+            # Same-file anchor: [text](#section)
+            if target == "":
+                checked += 1
+                if frag and frag not in anchors_for(path, cache):
+                    failures.append(
+                        f"links: {rel}:{line_no} anchor #{frag} does not match any "
+                        f"heading in this file"
+                    )
+                continue
+            # Resolve relative to the containing file, as a markdown renderer does.
+            resolved = (path.parent / target.replace("%20", " ")).resolve()
+            checked += 1
+            if not resolved.exists():
+                failures.append(f"links: {rel}:{line_no} target {target} does not exist")
+                continue
+            if frag and resolved.is_file() and resolved.suffix.lower() in (".md", ".markdown"):
+                if frag not in anchors_for(resolved, cache):
+                    failures.append(
+                        f"links: {rel}:{line_no} anchor #{frag} does not match any "
+                        f"heading in {target}"
+                    )
+    if verbose:
+        print(f"  checked {checked} relative links/anchors across {len(files)} markdown files")
+
+
+def codeowners_default_owners(root, failures):
+    path = root / "CODEOWNERS"
+    if not path.exists():
+        return None
+    owners = None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split()
+        if parts[0] == "*":
+            if owners is not None:
+                failures.append(
+                    "roster: CODEOWNERS declares more than one '*' rule; the last one "
+                    "wins on GitHub, which makes the roster ambiguous to read"
+                )
+            owners = {p.lstrip("@").lower() for p in parts[1:] if p.startswith("@")}
+    if owners is None:
+        failures.append("roster: CODEOWNERS has no '*' default-owner rule")
+    return owners
+
+
+def governance_maintainers(root, failures):
+    path = root / "GOVERNANCE.md"
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8")
+    m = re.search(r"^##+\s+Maintainers\s*$(.*?)(?=^##+\s|\Z)", text, re.MULTILINE | re.DOTALL)
+    if not m:
+        failures.append("roster: GOVERNANCE.md has no '## Maintainers' section")
+        return None
+    handles = {h.lower() for h in re.findall(r"@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)", m.group(1))}
+    if not handles:
+        failures.append("roster: GOVERNANCE.md's Maintainers section lists no @handles")
+        return None
+    return handles
+
+
+def check_roster(root, failures, verbose):
+    owners = codeowners_default_owners(root, failures)
+    maintainers = governance_maintainers(root, failures)
+    if owners is None or maintainers is None:
+        return
+    if owners == maintainers:
+        if verbose:
+            print(f"  roster matches ({len(owners)}): {', '.join('@' + o for o in sorted(owners))}")
+        return
+    only_co = sorted(owners - maintainers)
+    only_gov = sorted(maintainers - owners)
+    detail = []
+    if only_co:
+        detail.append("in CODEOWNERS but not GOVERNANCE.md: " + ", ".join("@" + o for o in only_co))
+    if only_gov:
+        detail.append("in GOVERNANCE.md but not CODEOWNERS: " + ", ".join("@" + o for o in only_gov))
+    failures.append(
+        "roster: CODEOWNERS '*' owners and the GOVERNANCE.md maintainer table disagree "
+        "(" + "; ".join(detail) + "). CODEOWNERS drives review assignment, so the two "
+        "must be changed together."
+    )
+
+
+CHECKS = {
+    "presence": check_presence,
+    "links": check_links,
+    "roster": check_roster,
+}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--verbose", "-v", action="store_true", help="list what was checked")
+    ap.add_argument(
+        "--only", choices=sorted(CHECKS), action="append",
+        help="run only the named check (repeatable); default runs all three",
+    )
+    args = ap.parse_args()
+
+    root = repo_root()
+    files = tracked_markdown(root)
+    selected = args.only or sorted(CHECKS)
+
+    failures = []
+    for name in selected:
+        if args.verbose:
+            print(f"{name}:")
+        if name == "links":
+            CHECKS[name](root, files, failures, args.verbose)
+        else:
+            CHECKS[name](root, failures, args.verbose)
+
+    if failures:
+        print(f"\ncheck-docs: {len(failures)} problem(s) found\n", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        print(file=sys.stderr)
+        return 1
+    print(f"check-docs: ok ({', '.join(selected)})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

PRs #195 (LAB-5324) and #196 (LAB-5325) are both marked **merged**, but their content never reached `main`. They were stacked, and each merged into its parent *feature branch*:

| PR | Base it merged into | Merged | Reached `main`? |
|---|---|---|---|
| #193 | `main` | 2026-08-03 15:03:32Z | yes |
| #195 | `…/lab-2773-add-contributingmd` | 2026-08-03 15:10:16Z | **no** |
| #196 | `…/lab-5324-add-governancemd-maintainersmd` | 2026-08-10 17:07:51Z | **no** |

#195 merged into the #193 branch seven minutes after that branch had itself merged to `main`, so its commits landed somewhere nothing merges from again; #196 then stacked onto #195. GitHub only auto-retargets a child PR when the parent branch is deleted on merge — all three branches were kept, so no retarget happened.

Verified on `main` today: `GOVERNANCE.md` and `SUPPORT.md` both 404, and `CODEOWNERS` still reads `* @santiago-praetorian @praetorian-peter-mueller`.

## What this does

Re-lands exactly the content of #195 and #196 on top of current `main`:

- **`GOVERNANCE.md`**, **`SUPPORT.md`** — verbatim from the stacked branch tip (new files)
- **`CODEOWNERS`** — the roster change #195 flagged for confirmation (remove `@praetorian-peter-mueller`, add `@eli-wald` / `@logan-bayless`) plus the "must match GOVERNANCE.md" note
- **`CONTRIBUTING.md`**, **`README.md`** — only the cross-link hunks from #195/#196, re-applied onto today's `main`. Both files moved on `main` after #193 merged, so the branch versions could not be taken wholesale; nothing else from those files is touched.

Nothing else from the stale branches is carried over — they are 105 commits behind `main`.

## Review notes

- The `CODEOWNERS` roster change is the one item worth a second look: it was flagged for confirmation on #195 and is a one-line revert if wrong.
- After this merges, the three stale branches (`…/lab-2773-add-contributingmd`, `…/lab-5324-…`, `…/lab-5325-…`) should be deleted so nothing else stacks onto them.

Closes LAB-5870. Unblocks 13T-147 AC4 / AC6 / AC10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
