### PR TITLE
ci(security): bump gosec pin to v2.28.0 for go1.27 (LAB-6009)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,4 +38,9 @@ jobs:
       # noise. Mirrors golangci-lint's `exclusions.generated: lax`. The rest of
       # the args match the reusable workflow's default (observe-only + SARIF).
       gosec-args: "-no-fail -exclude-generated -fmt sarif -out gosec-results.sarif ./..."
+      # The reusable workflow's v2.22.11 default links x/tools v0.39.0, which
+      # cannot read go1.27 export data. Since the Gosec job runs
+      # `go-version: stable`, every scan died before writing SARIF once go1.27
+      # became stable. v2.28.0 links x/tools v0.48.0. Pinned, never `latest`.
+      gosec-version: "v2.28.0"
     secrets: inherit


### PR DESCRIPTION
## Description

Fixes the `security / Gosec` job, which has failed on `main` since the run at `2026-08-20T14:52Z` (`f6c0624e`). It errors before producing any output, so no findings are reported and no SARIF is written:

```
internal error: package "encoding/xml" without types was imported from "command-line-arguments"
Path does not exist: ./gosec-results.sarif
```

The named stdlib package varies by run because it is whichever package loads first, not anything specific to that package.

The cause is not in this repo's Go code. `security.yml` calls `public-workflows/.github/workflows/go-sec.yml`, whose `Gosec` job deliberately runs `setup-go` with `go-version: "stable"` while pinning gosec to `v2.22.11`. `go1.27.0` became stable between the last green run (`ff299ba6`, on `go1.26.6`) and the first red one (on `go1.27.0`). `gosec v2.22.11` links `golang.org/x/tools v0.39.0`, which cannot read `go1.27` export data.

The `kin-openapi` bump in that window is unrelated: `go.mod`'s `go` directive did not change, and this job does not read `go.mod` for its toolchain.

This is the only failing check on #197, which otherwise has an approving review and green checks.

Ticket: LAB-6009

## Changes

- Pass `gosec-version: "v2.28.0"` to the reusable workflow, overriding its `v2.22.11` default. `v2.28.0` links `x/tools v0.48.0`, which reads `go1.27` export data.

One functional line in `.github/workflows/security.yml`, plus a comment recording why. Nothing else changes: `gosec-args` is byte-identical, so `-no-fail` and the SARIF output are untouched, and there is no `continue-on-error` and no change to the upload step. Kept pinned rather than `latest`, per that input's own guidance that `@latest` has broken consumers when a new gosec required a newer Go than the runner provided.

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [x] Manual verification (describe below)

The two boxes above are unchecked because this change touches only `.github/workflows/security.yml`. It cannot affect Go code, and `make test` / `make lint` do not exercise it.

Note that `security / Gosec` does not appear on this PR at all, and cannot: the workflow's `pull_request` trigger filters on `**/*.go`, `go.mod`, `go.sum`, `.golangci*`, and `Makefile`, so a change to `security.yml` itself never triggers it. That gap is pre-existing and not widened here; fixing it would mean touching the trigger, which this PR deliberately does not.

So it was verified by dispatching the workflow directly on this branch. `workflow_dispatch` run [32493377516](https://github.com/praetorian-inc/vespasian/actions/runs/32493377516) on this branch: `go1.27.0`, `gosec@v2.28.0`, `Run gosec` success, `gosec findings (30)`, `Upload gosec SARIF` success.

Reproduced locally first, same args as CI, against this module:

| gosec | Go | exit | SARIF |
|---|---|---|---|
| v2.22.11 | go1.26.3 | 0 | 21 findings |
| v2.22.11 | go1.27.0 | 1 | none, internal error |
| v2.28.0 | go1.27.0 | 0 | 30 findings |

## Reviewer notes

**Findings count goes 21 to 30, and that is not a regression to fix here.** The delta is entirely four rules `v2.22.11` does not have: `G706` log injection (6), `G120` unbounded form parsing (1), `G703` path traversal (1), `G705` XSS (1). Every pre-existing rule count is unchanged. Seven of the eight error-level findings are in `test/` fixture targets, which are deliberately vulnerable scanner targets; the one in product code is `G402` TLS `InsecureSkipVerify` at `pkg/crawl/http_crawler.go:80`. `-no-fail` plus the workflow's default `fail-on-findings: false` keeps all of them observe-only, so none can block a build. Triage is separate work.

**`Govulncheck` has the same defect and is not fixed here.** `govulncheck v1.1.4` links `x/tools v0.29.0` and panics `unexpected expr: *ast.KeyValueExpr` on `go1.27`, intermittently at roughly 50%. It is not a failing check on #197, and bumping it is a six-minor-version jump on a security tool, so it is kept separate rather than riding along with this.

**The shared default is still broken for other consumers.** `public-workflows` still defaults `gosec-version` to `v2.22.11`, so the ten other repos calling `go-sec.yml` will hit this on their next run. None has been observed failing yet because none has run since `go1.27.0` went stable. Fixing that needs the owning team. Worth raising with them: `go-version: "stable"` against a pinned analyzer re-breaks on every Go minor release, and consumers pin `public-workflows` by SHA, so a corrected default does not reach them without a per-repo bump.

## Checklist

- [x] Code follows project conventions
- [ ] Tests added/updated for new functionality
- [ ] Documentation updated (if applicable)

No tests: there is no harness for workflow YAML in this repo, and the verification is the CI run linked above. No docs change: no user-facing behavior, CLI flag, or config option changes.
