### PR TITLE
fix(security): convert gosec suppressions from //nolint:gosec to #nosec (LAB-6011)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,9 +35,14 @@ jobs:
       # `// Code generated ... DO NOT EDIT.` marker, e.g. test/grpc-server/labpb/*.pb.go).
       # Their unsafe.Pointer fast-paths are protoc-gen-go boilerplate, not
       # hand-written code, so gosec's G103 "audit unsafe" alerts on them are
-      # noise. Mirrors golangci-lint's `exclusions.generated: lax`. The rest of
-      # the args match the reusable workflow's default (observe-only + SARIF).
-      gosec-args: "-no-fail -exclude-generated -fmt sarif -out gosec-results.sarif ./..."
+      # noise. Mirrors golangci-lint's `exclusions.generated: lax`.
+      #
+      # No `-no-fail`: under it the job passed while publishing findings, which is how
+      # 28 accumulated unseen (LAB-6011). The reusable workflow passes these args through
+      # verbatim and exits on gosec's own code, so a finding now fails the job.
+      # `fail-on-findings: true` would do the same but also gates govulncheck, which is
+      # a separate concern here.
+      gosec-args: "-exclude-generated -fmt sarif -out gosec-results.sarif ./..."
       # The reusable workflow's v2.22.11 default links x/tools v0.39.0, which
       # cannot read go1.27 export data. Since the Gosec job runs
       # `go-version: stable`, every scan died before writing SARIF once go1.27

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,11 @@ make lint                     # Runs golangci-lint (gocritic, misspell, revive)
 # Format
 make fmt                      # Runs gofmt -s -w .
 
-# All checks (format, vet, lint, comment-claims, test, docs)
+# Gosec, at the version .github/workflows/security.yml pins. Fetched via `go run`,
+# so nothing needs installing. That CI job fails on findings, so this must be clean.
+make gosec
+
+# All checks (format, vet, lint, comment-claims, gosec, test, docs)
 make check
 
 # Community-health docs only (presence, link/anchor resolution, CODEOWNERS roster)
@@ -186,6 +190,7 @@ A file being edited is the moment to clear it.
 - Test files match source files (`foo.go` → `foo_test.go`)
 - Formatting enforced by `gofmt -s` (run `make fmt`)
 - Linting via `golangci-lint` with gocritic, misspell, revive (run `make lint`)
+- Gosec suppressions use `#nosec <RULE> -- <reason>`, never `//nolint:gosec`. gosec runs both inside `golangci-lint`, which honors `//nolint`, and as the separate `security / Gosec` job, which honors only `#nosec`, so a `//nolint:gosec` leaves `make lint` green while that job fails (LAB-6011). Run `make gosec`.
 - Package-level documentation lives in `doc.go` files
 
 ## Development Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ make coverage         # Coverage profile + per-function report (excludes test/)
 make live-test-clean  # Stop orphaned live-test services
 ```
 
-Note that `make check` runs `make fmt` first, which rewrites files in place via `gofmt -s -w .` — it validates *and* reformats. Expect it to modify your working tree, and check `git status` afterwards so any reformatting lands in your commit rather than surprising you later. Use `make vet lint test` if you want the checks without the rewrite.
+Note that `make check` runs `make fmt` first, which rewrites files in place via `gofmt -s -w .` — it validates *and* reformats. Expect it to modify your working tree, and check `git status` afterwards so any reformatting lands in your commit rather than surprising you later. Use `make vet lint gosec test` if you want the checks without the rewrite.
 
 ### Devcontainers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,10 +58,6 @@ No CLA or DCO sign-off is required to contribute.
   ```bash
   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
   ```
-- **gosec v2.28.0** — pin this version to match CI, which fails the build on findings:
-  ```bash
-  go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
-  ```
 - **CGO enabled** (`CGO_ENABLED=1`) — CI builds with it, so keep it on locally
 - **A real Chrome/Chromium** — only needed for headless crawling and the live test suite, not for unit tests
 
@@ -74,7 +70,7 @@ make test             # go test -race ./...
 make fmt              # gofmt -s -w .
 make vet              # go vet ./...
 make lint             # golangci-lint run
-make gosec            # gosec, same args and pin as the security / Gosec CI job
+make gosec            # gosec at the version CI pins; fetched via `go run`, nothing to install
 make check            # fmt + vet + lint + lint-comments + gosec + test + check-docs
 make coverage         # Coverage profile + per-function report (excludes test/)
 make live-test-clean  # Stop orphaned live-test services

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,10 @@ No CLA or DCO sign-off is required to contribute.
   ```bash
   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
   ```
+- **gosec v2.28.0** — pin this version to match CI, which fails the build on findings:
+  ```bash
+  go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+  ```
 - **CGO enabled** (`CGO_ENABLED=1`) — CI builds with it, so keep it on locally
 - **A real Chrome/Chromium** — only needed for headless crawling and the live test suite, not for unit tests
 
@@ -70,7 +74,8 @@ make test             # go test -race ./...
 make fmt              # gofmt -s -w .
 make vet              # go vet ./...
 make lint             # golangci-lint run
-make check            # fmt + vet + lint + test — run this before opening a PR
+make gosec            # gosec, same args and pin as the security / Gosec CI job
+make check            # fmt + vet + lint + lint-comments + gosec + test + check-docs
 make coverage         # Coverage profile + per-function report (excludes test/)
 make live-test-clean  # Stop orphaned live-test services
 ```
@@ -273,6 +278,7 @@ Run `make check` before submitting.
 - **Go file naming: lowercase with underscores** — `rest_classifier.go`, not `restClassifier.go`.
 - Keep functions under complexity 15. If the linter complains, split the function rather than suppressing it.
 - Add a `//nolint` directive only with a comment explaining why, and expect it to be questioned in review.
+- Suppress a **gosec** finding with `#nosec <RULE> -- <reason>`, never `//nolint:gosec`. gosec runs both inside `golangci-lint`, which honors `//nolint`, and as the separate `security / Gosec` job, which honors only `#nosec` — so `//nolint:gosec` leaves `make lint` green while the Gosec job fails. Put it trailing on the line, or on the line above when another linter already shares the trailing comment (LAB-6011).
 - Use `context.Context` for cancellation in all I/O paths.
 - Check every error. Return `(result, error)` rather than panicking.
 - Every source file carries the Apache 2.0 license header. Copy it from an existing file into new ones.
@@ -320,7 +326,7 @@ Two CI workflows gate a PR:
 
 ### PR checklist
 
-- [ ] `make check` passes (fmt, vet, lint, lint-comments, test, check-docs)
+- [ ] `make check` passes (fmt, vet, lint, lint-comments, gosec, test, check-docs)
 - [ ] Tests added or updated for the change
 - [ ] New classifier / generator / importer / probe registered where the pipeline expects it
 - [ ] Commit messages follow conventional commit format

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 BINARY := vespasian
 MODULE := github.com/praetorian-inc/vespasian
 BUILD_DIR := bin
+# Keep in step with gosec-version in .github/workflows/security.yml; that job fails on
+# findings, so a local run at another version can disagree with CI.
+GOSEC_VERSION ?= v2.28.0
 VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS   := -s -w -X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT) -X main.buildDate=$(BUILD_DATE)
 
-.PHONY: build test test-integration lint lint-comments lint-comments-selftest lint-comments-all fmt vet check check-docs coverage clean deps live-test-clean
+.PHONY: build test test-integration lint lint-comments lint-comments-selftest lint-comments-all fmt vet gosec check check-docs coverage clean deps live-test-clean
 
 build:
 	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/vespasian
@@ -58,7 +61,17 @@ fmt:
 vet:
 	go vet ./...
 
-check: fmt vet lint lint-comments test check-docs
+# The scan the `security / Gosec` job runs, same args and pin, so a finding can be
+# reproduced locally. That job no longer passes -no-fail. Expects gosec on PATH, the
+# way `lint` expects golangci-lint.
+gosec:
+	@command -v gosec >/dev/null 2>&1 || { \
+		echo "gosec not found. Install the pinned version:"; \
+		echo "  go install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)"; \
+		exit 1; }
+	gosec -exclude-generated ./...
+
+check: fmt vet lint lint-comments gosec test check-docs
 
 # Community-health docs: presence, link/anchor resolution, CODEOWNERS-vs-GOVERNANCE
 # roster equality. Also runs as its own CI job, because ci.yml's paths filter means a

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY := vespasian
 MODULE := github.com/praetorian-inc/vespasian
 BUILD_DIR := bin
-# Keep in step with gosec-version in .github/workflows/security.yml; that job fails on
+# Must match gosec-version in .github/workflows/security.yml; that job fails on
 # findings, so a local run at another version can disagree with CI.
 GOSEC_VERSION ?= v2.28.0
 VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
@@ -61,15 +61,13 @@ fmt:
 vet:
 	go vet ./...
 
-# The scan the `security / Gosec` job runs, same args and pin, so a finding can be
-# reproduced locally. That job no longer passes -no-fail. Expects gosec on PATH, the
-# way `lint` expects golangci-lint.
+# The scan the `security / Gosec` job runs, so a finding can be reproduced locally;
+# that job no longer passes -no-fail. Run through `go run @$(GOSEC_VERSION)` rather
+# than a PATH binary because a go-installed gosec reports its version as "dev", so
+# there is no way to check that an already-installed one matches CI. Text output
+# instead of the workflow's SARIF, which exists for the upload step.
 gosec:
-	@command -v gosec >/dev/null 2>&1 || { \
-		echo "gosec not found. Install the pinned version:"; \
-		echo "  go install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)"; \
-		exit 1; }
-	gosec -exclude-generated ./...
+	go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) -exclude-generated ./...
 
 check: fmt vet lint lint-comments gosec test check-docs
 

--- a/README.md
+++ b/README.md
@@ -595,7 +595,8 @@ cd vespasian
 make build       # Build the binary to bin/vespasian
 make test        # Run tests with race detection
 make lint        # Run golangci-lint (gocritic, misspell, revive)
-make check       # Run all checks (fmt, vet, lint, test)
+make gosec       # Run gosec at the version CI pins (fetched via go run)
+make check       # Run all checks (fmt, vet, lint, lint-comments, gosec, test, check-docs)
 ```
 
 ```bash

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -625,7 +625,7 @@ func (e *rodEngine) visitPage(ctx context.Context, target urlEntry) ([]ObservedR
 	}
 	defer func() {
 		// #nosec G104
-		page.Close() //nolint:errcheck,gosec // best-effort close; page may already be closed
+		page.Close() //nolint:errcheck // best-effort close; page may already be closed
 	}()
 
 	// Apply context and per-page timeout. pageDeadline mirrors that timeout as a

--- a/pkg/crawl/engine.go
+++ b/pkg/crawl/engine.go
@@ -149,9 +149,8 @@ type engineOptions struct {
 	// an empty capture. Only the visit of the SEED ITSELF calls it, gated on
 	// frontier-key identity rather than on Depth == 0 — resume restores pending
 	// entries before the seed is pushed and honors the depth the checkpoint claims,
-	// so depth 0 stopped being a reliable proxy for "is the seed" (LAB-4678 review,
-	// SEC-BE-004). See [learnSeedOrigin] and [seedScope] for the containment
-	// reasoning.
+	// so depth 0 stopped being a reliable proxy for "is the seed" (LAB-4678 review).
+	// See [learnSeedOrigin] and [seedScope] for the containment reasoning.
 	LearnEffectiveOrigin func(effectiveURL string)
 
 	// Completion-driven capture bounds (0 → the Default* above).
@@ -193,7 +192,7 @@ type rodEngine struct {
 	// backend, where one page is one request so it degenerates to a page cap.
 	// Removing `maxRequests := e.opts.MaxRequests` would have left --max-requests
 	// silently inert on the backend Guard actually uses, with every test still green
-	// (LAB-4678 review, TEST-004).
+	// (LAB-4678 review).
 	visit func(ctx context.Context, target urlEntry) ([]ObservedRequest, []string, error)
 }
 
@@ -280,7 +279,7 @@ func (e *rodEngine) Crawl(ctx context.Context, seedURL string, onResult func(Obs
 			"pass %s", redactSeedURL(seedURL), flagDangerousAllowPrivate)
 	}
 
-	// Track pages VISITED for MaxPages enforcement (LAB-4678, A1). The budget
+	// Track pages VISITED for MaxPages enforcement (LAB-4678). The budget
 	// counts pages (URLs visited), not captured requests: a single SPA page can
 	// fire dozens of XHR/fetch calls, so counting requests truncated the crawl
 	// far earlier than "max pages" implies, and hard-canceling the shared
@@ -302,7 +301,7 @@ func (e *rodEngine) Crawl(ctx context.Context, seedURL string, onResult func(Obs
 	// Workers run under ctx directly. The page budget no longer cancels the
 	// crawl (it just stops workers from taking new pages under the mutex), so
 	// the former context.WithCancel wrapper served no purpose beyond ctx's own
-	// parent cancellation and was removed (QUAL-006).
+	// parent cancellation and was removed.
 	var wg sync.WaitGroup
 	for i := range e.opts.Concurrency {
 		wg.Add(1)
@@ -625,6 +624,7 @@ func (e *rodEngine) visitPage(ctx context.Context, target urlEntry) ([]ObservedR
 		return nil, nil, fmt.Errorf("create tab: %w", err)
 	}
 	defer func() {
+		// #nosec G104
 		page.Close() //nolint:errcheck,gosec // best-effort close; page may already be closed
 	}()
 
@@ -732,7 +732,7 @@ func (e *rodEngine) visitPage(ctx context.Context, target urlEntry) ([]ObservedR
 // config — so under the proxy gate anyone able to write to checkpoint storage chose
 // which page decided the scope widening. Comparing against the seed's frontier key
 // restores the invariant seedScope's containment argument depends on
-// (LAB-4678 review, SEC-BE-004).
+// (LAB-4678 review).
 func (e *rodEngine) learnSeedOrigin(page *rod.Page, target urlEntry) {
 	if e.opts.LearnEffectiveOrigin == nil || seenKey(target.URL) != e.seedKey {
 		return
@@ -764,7 +764,7 @@ func (e *rodEngine) enrichTarget(page *rod.Page, navigated bool, pageURL string)
 		// https://admin:s3cret@target/` wrote cleartext credentials to stderr, which
 		// lands in CI job logs, shell scrollback, and any wrapper capturing the
 		// capability's stderr. Every other operator-facing URL echo in this package
-		// already redacts; this one was added without it (LAB-4678 review, SEC-BE-005).
+		// already redacts; this one was added without it (LAB-4678 review).
 		fmt.Fprintf(e.opts.Stderr, "interact: a click navigated away from %s and the page could not be restored; skipping DOM enrichment for it\n", redactSeedURL(pageURL)) //nolint:errcheck // best-effort
 	}
 	return nil
@@ -783,7 +783,7 @@ func (e *rodEngine) enrichTarget(page *rod.Page, navigated bool, pageURL string)
 // each return was O(total captured bytes) for the page. interactPage calls this once
 // per click plus once per returnToPage, so a page paid up to 16 full reconstructions
 // purely to throw them away, across Concurrency tabs, scaled by attacker-controlled
-// page content (LAB-4678 review, QUAL-005/SEC-BE-006).
+// page content (LAB-4678 review).
 //
 // deadline is the WHOLE PAGE's ceiling, shared by the baseline wait and every
 // interaction wait, so a page cannot exceed its budget by calling this
@@ -886,10 +886,10 @@ func enrichFromPage(page *rod.Page, captured []ObservedRequest, pageURL string, 
 	// A nil page means the DOM must not (or cannot) be read. visitPage passes nil
 	// when an interaction click navigated away, so the live DOM belongs to a
 	// document this worker was never assigned; the merger-threading contract is
-	// also tested through this path without standing up a real rod.Page (round-11
-	// TEST-001). jsluice over the captured RESPONSE bodies is a pure function of
-	// `captured` and stays valid either way, so it still runs — only the
-	// DOM-sourced inputs (hrefs, inline scripts, forms) are dropped.
+	// also tested through this path without standing up a real rod.Page. jsluice
+	// over the captured RESPONSE bodies is a pure function of `captured` and stays
+	// valid either way, so it still runs — only the DOM-sourced inputs (hrefs,
+	// inline scripts, forms) are dropped.
 	if page == nil {
 		captured, links := mergeEnrichedLinksFn(captured, nil, extractURLsFromResponses(captured), nil, nil, pageURL, pageURL, scopeFn)
 		return captured, links
@@ -934,7 +934,7 @@ func enrichFromPage(page *rod.Page, captured []ObservedRequest, pageURL string, 
 // page-extracted inputs with scope enforcement. Package-level var so tests
 // can verify the scopeFn argument is threaded correctly from e.opts.ScopeCheck
 // through enrichFromPage to mergeEnrichedLinks (the one-line call was
-// previously integration-only coverage — see LAB-2221 round-11 TEST-001).
+// previously integration-only coverage — see LAB-2221).
 // Production callers always see the real mergeEnrichedLinks.
 //
 // NOT PARALLEL-SAFE: tests swap this via a t.Cleanup-restored pattern and

--- a/pkg/crawl/http_crawler.go
+++ b/pkg/crawl/http_crawler.go
@@ -45,7 +45,7 @@ import (
 //     check and redirectScopeGuard. (LAB-4011.)
 //   - proxyURL == nil, allowPrivate false: a clone of http.DefaultTransport
 //     with DialContext wired to ssrfSafeDialContext so the DNS-rebinding TOCTOU
-//     window is closed at connect time (SEC-BE-002).
+//     window is closed at connect time.
 //   - proxyURL == nil, allowPrivate true: http.DefaultTransport unchanged.
 func newHTTPClient(scopeFn func(string) bool, allowPrivate bool, timeout time.Duration, proxyURL *url.URL, proxyInsecure bool) *http.Client {
 	transport := http.RoundTripper(http.DefaultTransport)
@@ -77,14 +77,14 @@ func newHTTPClient(scopeFn func(string) bool, allowPrivate bool, timeout time.Du
 		// real target through the tunnel and no substitute CA is involved, so
 		// verification is always kept for socks5 regardless of proxyInsecure.
 		if proxyInsecure && (proxyURL.Scheme == "http" || proxyURL.Scheme == "https") {
-			t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // G402: opt-in via --proxy-insecure for http/https proxy MITM (see doc comment)
+			t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in via --proxy-insecure for http/https proxy MITM (see doc comment)
 		}
 		transport = t
 	case !allowPrivate:
 		// Clone DefaultTransport and override only DialContext so we keep its
 		// TLS, keep-alive, HTTP/2, proxy, and idle-connection tunings while
 		// re-resolving and re-validating IPs at connect time, closing the
-		// DNS-rebinding TOCTOU window (SEC-BE-002).
+		// DNS-rebinding TOCTOU window.
 		base, ok := http.DefaultTransport.(*http.Transport)
 		if !ok {
 			// Defensive: stdlib always sets *http.Transport, but if a future
@@ -170,8 +170,8 @@ func (c *HTTPCrawler) Crawl(ctx context.Context, targetURL string) ([]ObservedRe
 	// HTTP client with redirect scope guard and bounded timeout.
 	// The per-page context (c.pageTimeout) already cancels hung fetches, but an
 	// explicit Client.Timeout provides defense-in-depth if the context is ever
-	// mis-wired on a future code path (SEC-BE-001). Both use c.pageTimeout so
-	// they track the same source (QUAL-004).
+	// mis-wired on a future code path. Both use c.pageTimeout so they track the
+	// same source.
 	client := newHTTPClient(scopeFn, c.opts.AllowPrivate, c.pageTimeout, proxyURL, c.opts.ProxyInsecure)
 
 	resumeCfg := c.opts.resume(targetURL)
@@ -454,7 +454,7 @@ func (c *HTTPCrawler) extractLinks(observed ObservedRequest, fullBody []byte, pa
 		// extractHTMLAndInlineScripts parses the body exactly once, returning
 		// both the navigable links and inline-script jsluice results. Previously
 		// extractFromHTML and extractInlineScripts each called
-		// goquery.NewDocumentFromReader separately (QUAL-002 double-parse fix).
+		// goquery.NewDocumentFromReader separately, which parsed the body twice.
 		var htmlLinks []string
 		var inlineScripts []jsExtractedURL
 		htmlLinks, base, inlineScripts = extractHTMLAndInlineScripts(fullBody, pageURL)

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -172,7 +172,7 @@ func inferSDL(endpoints []classify.ClassifiedRequest) ([]byte, error) { //nolint
 		}
 	}
 
-	// Reconcile type/union name collisions (D2, D6):
+	// Reconcile type/union name collisions:
 	// If a union XResult exists and a type XResponse also exists, merge XResponse fields
 	// into the first union member type and remove the empty XResponse.
 	for unionName, members := range syntheticUnions {
@@ -2093,6 +2093,7 @@ func parseGraphQLURL(rawURL string) *graphqlBody {
 	}
 	gb := &graphqlBody{Query: query}
 	if vars := u.Query().Get("variables"); vars != "" {
+		// #nosec G104
 		json.Unmarshal([]byte(vars), &gb.Variables) //nolint:errcheck,gosec // best-effort parse; invalid variables are silently ignored
 	}
 	return gb

--- a/pkg/generate/graphql/infer.go
+++ b/pkg/generate/graphql/infer.go
@@ -2094,7 +2094,7 @@ func parseGraphQLURL(rawURL string) *graphqlBody {
 	gb := &graphqlBody{Query: query}
 	if vars := u.Query().Get("variables"); vars != "" {
 		// #nosec G104
-		json.Unmarshal([]byte(vars), &gb.Variables) //nolint:errcheck,gosec // best-effort parse; invalid variables are silently ignored
+		json.Unmarshal([]byte(vars), &gb.Variables) //nolint:errcheck // best-effort parse; invalid variables are silently ignored
 	}
 	return gb
 }

--- a/pkg/probe/graphql.go
+++ b/pkg/probe/graphql.go
@@ -289,9 +289,9 @@ func (p *GraphQLProbe) sendIntrospection(ctx context.Context, targetURL, query s
 	}
 	defer func() {
 		// #nosec G104
-		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck // best-effort drain
 		// #nosec G104
-		resp.Body.Close() //nolint:errcheck,gosec // best-effort close
+		resp.Body.Close() //nolint:errcheck // best-effort close
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/pkg/probe/graphql.go
+++ b/pkg/probe/graphql.go
@@ -288,8 +288,10 @@ func (p *GraphQLProbe) sendIntrospection(ctx context.Context, targetURL, query s
 		return nil, nil
 	}
 	defer func() {
+		// #nosec G104
 		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
-		resp.Body.Close()                                    //nolint:errcheck,gosec // best-effort close
+		// #nosec G104
+		resp.Body.Close() //nolint:errcheck,gosec // best-effort close
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/pkg/probe/options.go
+++ b/pkg/probe/options.go
@@ -102,8 +102,10 @@ func (p *OptionsProbe) probeURL(ctx context.Context, url string) []string {
 		return nil
 	}
 	defer func() {
+		// #nosec G104
 		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
-		resp.Body.Close()                                    //nolint:errcheck,gosec // best-effort close on read-only response
+		// #nosec G104
+		resp.Body.Close() //nolint:errcheck,gosec // best-effort close on read-only response
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/pkg/probe/options.go
+++ b/pkg/probe/options.go
@@ -103,9 +103,9 @@ func (p *OptionsProbe) probeURL(ctx context.Context, url string) []string {
 	}
 	defer func() {
 		// #nosec G104
-		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck // best-effort drain
 		// #nosec G104
-		resp.Body.Close() //nolint:errcheck,gosec // best-effort close on read-only response
+		resp.Body.Close() //nolint:errcheck // best-effort close on read-only response
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/pkg/probe/schema.go
+++ b/pkg/probe/schema.go
@@ -110,8 +110,10 @@ func (p *SchemaProbe) probeURL(ctx context.Context, url string) map[string]inter
 		return nil
 	}
 	defer func() {
+		// #nosec G104
 		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
-		resp.Body.Close()                                    //nolint:errcheck,gosec // best-effort close on read-only response
+		// #nosec G104
+		resp.Body.Close() //nolint:errcheck,gosec // best-effort close on read-only response
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/pkg/probe/schema.go
+++ b/pkg/probe/schema.go
@@ -111,9 +111,9 @@ func (p *SchemaProbe) probeURL(ctx context.Context, url string) map[string]inter
 	}
 	defer func() {
 		// #nosec G104
-		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck // best-effort drain
 		// #nosec G104
-		resp.Body.Close() //nolint:errcheck,gosec // best-effort close on read-only response
+		resp.Body.Close() //nolint:errcheck // best-effort close on read-only response
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/pkg/probe/wsdl.go
+++ b/pkg/probe/wsdl.go
@@ -116,8 +116,10 @@ func (p *WSDLProbe) fetchWSDL(ctx context.Context, baseURL string) []byte {
 		return nil
 	}
 	defer func() {
+		// #nosec G104
 		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
-		resp.Body.Close()                                    //nolint:errcheck,gosec // best-effort close
+		// #nosec G104
+		resp.Body.Close() //nolint:errcheck,gosec // best-effort close
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/pkg/probe/wsdl.go
+++ b/pkg/probe/wsdl.go
@@ -117,9 +117,9 @@ func (p *WSDLProbe) fetchWSDL(ctx context.Context, baseURL string) []byte {
 	}
 	defer func() {
 		// #nosec G104
-		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck,gosec // best-effort drain
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096)) //nolint:errcheck // best-effort drain
 		// #nosec G104
-		resp.Body.Close() //nolint:errcheck,gosec // best-effort close
+		resp.Body.Close() //nolint:errcheck // best-effort close
 	}()
 
 	if resp.StatusCode >= 400 {

--- a/test/concat-spa/main.go
+++ b/test/concat-spa/main.go
@@ -80,7 +80,7 @@ func main() {
 	// live in test/internal/target, so there is one copy to reason about and one
 	// place for Test 18b to assert.
 	addr := target.Addr(port)
-	log.Printf("concat-spa listening on http://%s/", addr) //nolint:gosec // G706: local test target; port is a controlled PORT env/default, not attacker input
+	log.Printf("concat-spa listening on http://%s/", addr) // #nosec G706 -- local test target; port is a controlled PORT env/default, not attacker input
 	srv := target.Server(addr, mux)
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal(err)

--- a/test/forms-target/main.go
+++ b/test/forms-target/main.go
@@ -91,7 +91,7 @@ func main() {
 	// live in test/internal/target. forms-target keeps its own FORMS_TARGET_BIND_HOST
 	// seam in setup-live-targets.sh; only the in-process resolution is shared.
 	addr := target.Addr(port)
-	log.Printf("forms-target listening on http://%s/", addr) //nolint:gosec // G706: host/port come from controlled BIND_HOST/PORT env vars for a local test target, not attacker input
+	log.Printf("forms-target listening on http://%s/", addr) // #nosec G706 -- host/port come from controlled BIND_HOST/PORT env vars for a local test target, not attacker input
 	srv := target.Server(addr, mux)
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal(err)

--- a/test/grpc-server/main.go
+++ b/test/grpc-server/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	lis, err := net.Listen("tcp", "127.0.0.1:"+resolved)
 	if err != nil {
-		log.Fatalf("listen on :%s failed: %v", resolved, err) //nolint:gosec // G706: test server, log injection N/A
+		log.Fatalf("listen on :%s failed: %v", resolved, err) // #nosec G706 -- test server, log injection N/A
 	}
 
 	s := grpc.NewServer()
@@ -102,7 +102,7 @@ func main() {
 		s.GracefulStop()
 	}()
 
-	log.Printf("gRPC server listening on %s (reflection enabled, services: UserService, OrderService, AccountService)", lis.Addr().String()) //nolint:gosec // G706: test server, log injection N/A
+	log.Printf("gRPC server listening on %s (reflection enabled, services: UserService, OrderService, AccountService)", lis.Addr().String()) // #nosec G706 -- test server, log injection N/A
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("serve: %v", err)
 	}

--- a/test/rest-api/main.go
+++ b/test/rest-api/main.go
@@ -80,6 +80,7 @@ var (
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
+	// #nosec G104
 	json.NewEncoder(w).Encode(v) //nolint:errcheck,gosec // test server best-effort response
 }
 
@@ -312,7 +313,7 @@ func handleUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)        // 10MB upload cap
-	if err := r.ParseMultipartForm(10 << 20); err != nil { //nolint:gosec // G120: 10MB cap enforced via MaxBytesReader above
+	if err := r.ParseMultipartForm(10 << 20); err != nil { // #nosec G120 -- 10MB cap enforced via MaxBytesReader above
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid multipart"})
 		return
 	}
@@ -423,6 +424,7 @@ func handleBinaryResponse(w http.ResponseWriter, _ *http.Request) {
 	// Minimal PNG: 8-byte header + minimal IHDR + IEND
 	data := make([]byte, 128)
 	copy(data, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
+	// #nosec G104
 	w.Write(data) //nolint:errcheck,gosec // test server best-effort response
 }
 
@@ -468,6 +470,7 @@ func handleTrailingSlash(w http.ResponseWriter, r *http.Request) {
 func handleMismatchedContentType(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
+	// #nosec G104
 	json.NewEncoder(w).Encode(map[string]string{"status": "mismatched"}) //nolint:errcheck,gosec // test server best-effort response
 }
 
@@ -488,6 +491,7 @@ func handleDeepLinks(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w)
 	level := strings.TrimPrefix(r.URL.Path, "/api/deep/")
 	var depth int
+	// #nosec G104
 	fmt.Sscanf(level, "%d", &depth) //nolint:errcheck,gosec // test server best-effort parse
 	if depth <= 0 {
 		depth = 1
@@ -551,8 +555,10 @@ func handleGzipResponse(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Encoding", "gzip")
 	gz := gzip.NewWriter(w)
+	// #nosec G104
 	json.NewEncoder(gz).Encode(map[string]string{"compressed": "true", "data": "gzip-test-payload"}) //nolint:errcheck,gosec // test server best-effort response
-	gz.Close()                                                                                       //nolint:errcheck,gosec // best-effort cleanup
+	// #nosec G104
+	gz.Close() //nolint:errcheck,gosec // best-effort cleanup
 }
 
 // ── Classifier edge case endpoints ──────────────────────────
@@ -661,7 +667,7 @@ func handleEmptyOK(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// SEC-FE-001: indexHTML embeds an inline <script> that fires fetch() requests on
+// indexHTML embeds an inline <script> that fires fetch() requests on
 // page load to exercise vespasian's form-body parser during E2E crawls. This is
 // intentional and acceptable because this server is a local test fixture only —
 // it is never deployed and is not subject to CSP. Do NOT copy this pattern to
@@ -855,7 +861,7 @@ func main() {
 	// live in test/internal/target, so there is one copy to reason about and one
 	// place for Test 18b to assert.
 	addr := target.Addr(port)
-	log.Printf("rest-api listening on http://%s/", addr) //nolint:gosec // test server, log injection N/A
+	log.Printf("rest-api listening on http://%s/", addr) // #nosec G706 -- test server, log injection N/A
 	srv := target.Server(addr, mux)
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal(err)

--- a/test/rest-api/main.go
+++ b/test/rest-api/main.go
@@ -81,7 +81,7 @@ func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	// #nosec G104
-	json.NewEncoder(w).Encode(v) //nolint:errcheck,gosec // test server best-effort response
+	json.NewEncoder(w).Encode(v) //nolint:errcheck // test server best-effort response
 }
 
 func setCORSHeaders(w http.ResponseWriter) {
@@ -425,7 +425,7 @@ func handleBinaryResponse(w http.ResponseWriter, _ *http.Request) {
 	data := make([]byte, 128)
 	copy(data, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
 	// #nosec G104
-	w.Write(data) //nolint:errcheck,gosec // test server best-effort response
+	w.Write(data) //nolint:errcheck // test server best-effort response
 }
 
 // handleMixedContent returns JSON with a field containing base64 binary data.
@@ -471,7 +471,7 @@ func handleMismatchedContentType(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
 	// #nosec G104
-	json.NewEncoder(w).Encode(map[string]string{"status": "mismatched"}) //nolint:errcheck,gosec // test server best-effort response
+	json.NewEncoder(w).Encode(map[string]string{"status": "mismatched"}) //nolint:errcheck // test server best-effort response
 }
 
 // handleAuthRequired returns 401 unless Authorization header is present.
@@ -492,7 +492,7 @@ func handleDeepLinks(w http.ResponseWriter, r *http.Request) {
 	level := strings.TrimPrefix(r.URL.Path, "/api/deep/")
 	var depth int
 	// #nosec G104
-	fmt.Sscanf(level, "%d", &depth) //nolint:errcheck,gosec // test server best-effort parse
+	fmt.Sscanf(level, "%d", &depth) //nolint:errcheck // test server best-effort parse
 	if depth <= 0 {
 		depth = 1
 	}
@@ -556,9 +556,9 @@ func handleGzipResponse(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Encoding", "gzip")
 	gz := gzip.NewWriter(w)
 	// #nosec G104
-	json.NewEncoder(gz).Encode(map[string]string{"compressed": "true", "data": "gzip-test-payload"}) //nolint:errcheck,gosec // test server best-effort response
+	json.NewEncoder(gz).Encode(map[string]string{"compressed": "true", "data": "gzip-test-payload"}) //nolint:errcheck // test server best-effort response
 	// #nosec G104
-	gz.Close() //nolint:errcheck,gosec // best-effort cleanup
+	gz.Close() //nolint:errcheck // best-effort cleanup
 }
 
 // ── Classifier edge case endpoints ──────────────────────────

--- a/test/soap-service/main.go
+++ b/test/soap-service/main.go
@@ -185,7 +185,7 @@ func handleWSDL(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
 	// #nosec G104 G705
-	w.Write(wsdlData) //nolint:errcheck,gosec // test server best-effort response
+	w.Write(wsdlData) //nolint:errcheck // test server best-effort response
 }
 
 func handleIndex(w http.ResponseWriter, _ *http.Request) {

--- a/test/soap-service/main.go
+++ b/test/soap-service/main.go
@@ -171,7 +171,7 @@ func handleWSDL(w http.ResponseWriter, r *http.Request) {
 
 	var wsdlData []byte
 	for _, path := range candidates {
-		data, readErr := os.ReadFile(path) //nolint:gosec // G304: test server, path from known WSDL files
+		data, readErr := os.ReadFile(path) // #nosec G304 G703 -- test server, path from known WSDL files
 		if readErr == nil {
 			wsdlData = data
 			break
@@ -184,6 +184,7 @@ func handleWSDL(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	// #nosec G104 G705
 	w.Write(wsdlData) //nolint:errcheck,gosec // test server best-effort response
 }
 
@@ -207,7 +208,7 @@ func main() {
 	// live in test/internal/target, so there is one copy to reason about and one
 	// place for Test 18b to assert.
 	addr := target.Addr(port)
-	log.Printf("soap-service listening on http://%s/", addr) //nolint:gosec // test server, log injection N/A
+	log.Printf("soap-service listening on http://%s/", addr) // #nosec G706 -- test server, log injection N/A
 	srv := target.Server(addr, mux)
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Problem

`//nolint:gosec` is golangci-lint's directive. The `security / Gosec` job runs gosec directly and honors only `#nosec`, so no suppression in this repo reached the scanner that publishes to code scanning. gosec v2.28.0 with the workflow's own args reported 28 findings at 393bf02 — every one of them on a line carrying `//nolint:...gosec` — including G402 `InsecureSkipVerify` in `pkg/crawl/http_crawler.go` and G703 path traversal in `test/soap-service`. `ci / Lint` was green throughout.

The cost landed on unrelated PRs. An alert on a line a change merely shifted re-posted as a `github-advanced-security` review thread, and the org's "Require PR Conversation Resolution" ruleset turned that into a merge block on debt the PR did not introduce. That is what held up #197.

## What this does

Converts the directives. All 28 dispositions were re-read against their code and all 28 hold, so no behavior changes — the comments were right and the directive was wrong.

Three mechanics were measured before implementing, not assumed:

| Form | gosec v2.28.0 | golangci-lint 2.12.2 |
|---|---|---|
| `//nolint:gosec` alone | flags | 0 issues |
| `#nosec` folded into the `//nolint` comment | flags | not run |
| `// #nosec <RULE> -- <reason>` on the line above | silent | 0 issues |
| same, `//nolint` removed | silent | 0 issues |
| neither directive | flags | flags |

The bottom row is the one that matters: golangci-lint's bundled gosec does flag the bare line, so `#nosec` alone satisfies both tools and dropping the `gosec` element is safe. One `#nosec` also takes several rule IDs (needed for the two lines carrying two findings each) and one above `defer func() {` covers the whole block (needed for the four `pkg/probe` drain-and-close blocks).

The `gosec` element comes out of each `//nolint` list; `errcheck` and others stay, since golangci-lint still consumes them.

Also drops `-no-fail` from `gosec-args`. Under it the job reported success while publishing findings, which is how 28 accumulated unseen. The scan is clean as of this change, so a new finding fails the job instead of accumulating. No new gate script — the flag makes that redundant.

## Verification

- gosec 28 -> 0.
- Negative control: removing the single G402 `#nosec` returns exactly one finding at `pkg/crawl/http_crawler.go:80`; restoring it returns to 0.
- `make vet`, `make lint` (0 issues), `make lint-comments`, `make test` with `-race`, `make check-docs`, `make build`, `gofmt -l` clean.
- `yq` confirms the workflow parses and `gosec-args` reads back without `-no-fail`.
- macOS run. Pure Go source analysis, but the counts are unverified on the Linux runner.

## Not in scope

179 `//nolint:gosec` elements remain, on lines gosec does not flag today. No conversion there is verifiable because there is no finding to flip; dropping `-no-fail` is what catches them if gosec's rules ever reach those lines.

Reducing the suppression count, and the refactors that would allow it, stay with 13T-148 and LAB-3889.

24 gosec alerts are open on `main` and should close when this merges and the scan reruns.

Closes LAB-6011. LAB-3894 is closed as a duplicate — both fixes it recommended leave its finding live.
