### PR TITLE
build(go): upgrade to Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read
     with:
+      golangci-lint-version: "v2.13.1"
       build-cmd-path: ./cmd/vespasian
       build-binary-name: vespasian
       build-cgo-enabled: "1"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,4 +43,5 @@ jobs:
       # `go-version: stable`, every scan died before writing SARIF once go1.27
       # became stable. v2.28.0 links x/tools v0.48.0. Pinned, never `latest`.
       gosec-version: "v2.28.0"
+      govulncheck-version: "v1.7.0"
     secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,10 +53,10 @@ No CLA or DCO sign-off is required to contribute.
 
 ### Prerequisites
 
-- **Go 1.25.8+** — the version in `go.mod` is the source of truth, and CI reads it from there
-- **golangci-lint v2.12.2** — pin this version to match CI:
+- **Go 1.27.0+** — the version in `go.mod` is the source of truth, and CI reads it from there
+- **golangci-lint v2.13.1** — pin this version to match CI:
   ```bash
-  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
   ```
 - **CGO enabled** (`CGO_ENABLED=1`) — CI builds with it, so keep it on locally
 - **A real Chrome/Chromium** — only needed for headless crawling and the live test suite, not for unit tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.27.0@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb AS build
+FROM golang:1.27.0-bookworm@sha256:484ef6066fa69acb059fdfeda7ba2b8f7391f2ef6abc6f9b8411e669ebd56466 AS build
 
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24@sha256:d2d2bc1c84f7e60d7d2438a3836ae7d0c847f4888464e7ec9ba3a1339a1ee804 AS build
+FROM golang:1.27.0@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb AS build
 
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
@@ -9,10 +9,10 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath \
+RUN CGO_ENABLED=1 go build -trimpath \
     -ldflags "-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildDate=${BUILD_DATE}" \
     -o /bin/vespasian ./cmd/vespasian
 
-FROM gcr.io/distroless/static-debian12@sha256:20bc6c0bc4d625a22a8fde3e55f6515709b32055ef8fb9cfbddaa06d1760f838
+FROM gcr.io/distroless/base-debian12@sha256:fabbf1c0c357a3d42550111351daed089b20a2c954df13ee2fcff60602515e84
 COPY --from=build /bin/vespasian /usr/local/bin/vespasian
 ENTRYPOINT ["vespasian"]

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ When analyzing JavaScript bundles served by an attacker-controlled application, 
 
 ### Prerequisites
 
-- [Go 1.24+](https://go.dev/dl/)
+- [Go 1.27.0+](https://go.dev/dl/)
 - [golangci-lint](https://golangci-lint.run/welcome/install/)
 
 ### Build and Test

--- a/cmd/vespasian/main_test.go
+++ b/cmd/vespasian/main_test.go
@@ -374,7 +374,8 @@ func TestValidateTargetURL_RedactsUserinfoInErrors(t *testing.T) {
 		{"fails validateURL (bad scheme)", "ftp://" + username + ":" + password + "@" + host + "/", host},
 		{"fails validateURL (missing host)", "https://" + username + ":" + password + "@", `"https:"`},
 		{"percent-encoded credential (missing host)", "https://" + username + ":" + encodedPassword + "@", `"https:"`},
-		{"fails CanonicalOrigin (duplicated port)", "https://" + username + ":" + password + "@" + host + ":8443:8443/", host},
+		{"url.Parse rejects duplicated port", "https://" + username + ":" + password + "@" + host + ":8443:8443/", "URL with userinfo redacted"},
+		{"fails CanonicalOrigin (IPv6 zone id)", "https://" + username + ":" + password + "@[fe80::1%25eth0]/", "fe80::1%25eth0"},
 	}
 
 	for _, tt := range tests {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/praetorian-inc/vespasian
 
-go 1.25.8
+go 1.27.0
 
 require (
 	github.com/BishopFox/jsluice v0.0.0-20240110145140-0ddfab153e06

--- a/test/README.md
+++ b/test/README.md
@@ -17,7 +17,7 @@ End-to-end live tests that spin up intentionally simple target applications, run
 
 ## Prerequisites
 
-- **Go 1.25+** — [https://go.dev/dl/](https://go.dev/dl/)
+- **Go 1.27.0+** — [https://go.dev/dl/](https://go.dev/dl/)
 - **Chrome/Chromium** — Required for headless crawling (see below)
 - **python3** — Required for test validation scripts
 - **Node.js** — Required for the graphql-server target


### PR DESCRIPTION
## Premise review — skipped

Mechanical toolchain/build migration; no new layer or abstraction.

## Summary
- raise the module, Docker builder, docs, and lint pin to Go 1.27-compatible versions
- retain existing gosec v2.28.0 and add govulncheck v1.7.0
- update the userinfo-redaction test for Go 1.27's strict duplicated-port parse while retaining CanonicalOrigin coverage through an IPv6 zone case
- align Docker with the repository's existing CGO requirement and a digest-pinned distroless libc base

Scanner args and generated-file exclusion remain unchanged. Exact gosec results are unchanged (28 → 28); govulncheck adds no IDs (19 → 0).

## Verification
Synchronized by fast-forward onto current `origin/main`, then exact Go 1.27 module/build/vet/full/race/lint/scanner checks passed. Browser integration with required Chrome, docs, Docker build, and container runtime smoke passed. macOS Bash 3 shell-harness failures are documented pre-existing platform limitations; Linux PR CI is authoritative.
