### PR TITLE
docs: add CITATION.cff (LAB-5327)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+title: "Vespasian: API Discovery and Attack Surface Mapping Tool"
+message: "If you use this software, please cite it as below."
+type: software
+authors:
+  - name: "Praetorian Security, Inc."
+    website: "https://www.praetorian.com"
+repository-code: "https://github.com/praetorian-inc/vespasian"
+url: "https://github.com/praetorian-inc/vespasian"
+license: Apache-2.0
+version: 1.0.0
+date-released: "2026-04-03"
+keywords:
+  - api-discovery
+  - api-enumeration
+  - api-security
+  - api-specification
+  - application-security
+  - attack-surface
+  - burp-suite
+  - capability
+  - golang
+  - graphql
+  - headless-browser
+  - openapi
+  - openapi-generator
+  - penetration-testing
+  - security-tools
+  - soap
+  - traffic-analysis
+  - wsdl
+abstract: >-
+  Vespasian is an API discovery tool that maps attack surfaces from captured
+  HTTP traffic and generates API specifications. It crawls targets with a
+  headless browser or imports external captures (Burp, HAR, mitmproxy),
+  classifies observed requests by API type (REST, GraphQL, SOAP/WSDL, gRPC),
+  optionally probes live endpoints, and emits specifications such as OpenAPI,
+  GraphQL SDL, WSDL, and proto3 for penetration testing and application
+  security assessments.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -50,6 +50,8 @@ Releases are triggered by pushing a `v*` tag; [`.github/workflows/release.yml`](
 
 Creating the tag is the gated part. An organization-level ruleset restricts creation of `refs/tags/v*`, so being on the roster above does not by itself let you cut a release. A maintainer without that permission asks a Praetorian organization administrator to create the tag.
 
+When cutting a release, update [`CITATION.cff`](CITATION.cff) so its `version` and `date-released` match the new tag and its release date. GitHub renders the "Cite this repository" metadata from that file, and nothing fails the build when it drifts, so it goes stale silently unless bumped here.
+
 ## Escalation
 
 If a pull request or issue stalls:


### PR DESCRIPTION
## Summary

Adds a `CITATION.cff` at the vespasian repo root so GitHub renders a **"Cite this repository"** button and external researchers get a canonical citation form. Mirrors the existing Praetorian OSS pattern (`praetorian-inc/trajan` ships one). Resolves [LAB-5327](https://linear.app/praetorianlabs/issue/LAB-5327/add-citationcff).

## Changes

- **`CITATION.cff`** (new) — entity-authored (`Praetorian Security, Inc.`), Apache-2.0, `version: 1.0.0` / `date-released: 2026-04-03` matching the latest release (`v1.0.0`, published 2026-04-03). Keywords reuse the repo's GitHub topics. Validated: `cffconvert --validate` → *"Citation metadata are valid according to schema version 1.2.0."*
- **`GOVERNANCE.md`** (§ Releases) — adds a note to bump `CITATION.cff`'s `version`/`date-released` when cutting a release, since nothing fails the build when it drifts.

## Acceptance (LAB-5327)

- [x] `CITATION.cff` at repo root, valid per `cffconvert`
- [x] `version` / `date-released` match the latest release (`v1.0.0` / 2026-04-03)
- [x] Note in the release process to keep them in sync (GOVERNANCE.md § Releases)
- [ ] GitHub "Cite this repository" button — renders automatically once a valid file is on the default branch (verifiable post-merge)

## Frame check (reviewing-the-premise)

**Skipped** — no non-trivial machinery: one metadata file plus a doc note that defines no behavior. Recorded per the skip condition.

## Needs a human decision

The ticket says authors need **legal / marketing** confirmation and optional named individuals. This PR uses the **entity-only** author form (matching trajan) as the safe default. If named individuals should be added, that's a one-line follow-up before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
