### PR TITLE
ci: add OpenSSF Scorecard workflow + README badge (LAB-5328)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,8 +28,24 @@ jobs:
       security-events: write
       # Needed to publish results and get a badge (publish_results below).
       id-token: write
+      # A job-level permissions block replaces the top-level default outright
+      # (unlisted scopes become none), so re-grant the reads this job needs:
+      # checkout reads the repo, and codeql-action/upload-sarif reads run
+      # metadata (matches security.yml's convention in this repo).
+      contents: read
+      actions: read
 
     steps:
+      # Defense-in-depth egress monitoring on this non-container job, per
+      # AGENTS.md (LAB-4732) and the ci.yml/security.yml convention. Audit mode
+      # logs (does not block) outbound traffic — including this workflow's
+      # intended publish to api.scorecard.dev.
+      - name: "Harden the runner"
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -54,6 +70,6 @@ jobs:
 
       # Surface findings in the repository's code-scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+# OpenSSF Scorecard — objective, ongoing supply-chain hygiene scoring.
+# Complements (does not replace) security.yml, secrets-scan.yml, dependabot.yml
+# and verify-pins.yml. verify-pins.yml remains the enforced source of truth for
+# pin honesty on praetorian-inc/public-workflows references; Scorecard's
+# Pinned-Dependencies check is advisory scoring only — see the PR that added
+# this file for the reconciliation rationale.
+name: Scorecard supply-chain security
+
+on:
+  # Keeps the Branch-Protection check evaluating the current default-branch rules.
+  branch_protection_rule:
+  # Keeps the Maintained check fresh and re-scores on a regular cadence.
+  schedule:
+    - cron: "20 6 * * 1" # Mondays 06:20 UTC (aligns with security.yml's weekly cadence)
+  push:
+    branches: ["main"]
+
+# Declare default permissions as read-only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the OpenSSF REST API so the README badge resolves
+          # to a live score. Requires the id-token: write permission above.
+          publish_results: true
+
+      # Upload the raw SARIF as a workflow artifact for offline inspection.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Surface findings in the repository's code-scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,13 @@ on:
   push:
     branches: ["main"]
 
+# Serialize overlapping runs on the same ref (rapid pushes to main, or a push
+# landing during the scheduled run) so a later commit's score/SARIF never loses
+# a publish race to an earlier run. Matches the ci.yml/security.yml convention.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Declare default permissions as read-only.
 permissions: read-all
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <a href="https://github.com/praetorian-inc/vespasian/actions/workflows/ci.yml"><img src="https://github.com/praetorian-inc/vespasian/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://goreportcard.com/report/github.com/praetorian-inc/vespasian"><img src="https://goreportcard.com/badge/github.com/praetorian-inc/vespasian" alt="Go Report Card"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/praetorian-inc/vespasian"><img src="https://api.scorecard.dev/projects/github.com/praetorian-inc/vespasian/badge" alt="OpenSSF Scorecard"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
 </p>
 


### PR DESCRIPTION
## What

Adds the OpenSSF Scorecard workflow and a README badge (LAB-5328, Pillar 7 — community governance).

- **`.github/workflows/scorecard.yml`** — runs `ossf/scorecard-action` on a weekly schedule, on push to `main`, and on `branch_protection_rule`, with `publish_results: true` so the score is published to the OpenSSF API (badge) and SARIF is uploaded to the code-scanning dashboard.
- **`README.md`** — OpenSSF Scorecard badge added to the badge row.

All actions are pinned by full commit SHA with a `# vX.Y.Z` comment, matching this repo's existing convention (`actions/checkout` reuses the repo-wide `11bd719… # v4.2.2` pin). SHAs were each resolved from the GitHub API to their release tags: scorecard-action v2.4.4, upload-artifact v7.0.1, codeql-action/upload-sarif v3.37.9.

> Note: Scorecard's authoritative run happens **after this merges to `main`** (the workflow does not trigger on pull requests, by design — the same as the upstream starter workflow). The badge resolves to a live score once that first run publishes.

## Reconciliation with `verify-pins.yml` (one source of truth)

The ticket asks that Scorecard's Pinned-Dependencies check be reconciled with the existing `verify-pins.yml` rather than duplicated. They cover **different surfaces and are complementary**, so both stay:

- **`verify-pins.yml`** is the *enforced gate* (a required check). It verifies **pin honesty on `praetorian-inc/public-workflows` references** — that each first-party reusable-workflow `uses:` SHA matches the `# vX.Y.Z` comment beside it. It does **not** look at third-party actions.
- **Scorecard's Pinned-Dependencies** is *advisory scoring only* (not a gate). It scores whether **third-party** actions, container images, etc. are pinned by hash — precisely the surface `verify-pins.yml` does not touch.

No overlap in what they check, so nothing is duplicated. `verify-pins.yml` remains the single enforced source of truth for pin correctness; Scorecard's Pinned-Dependencies is an advisory signal over the complementary third-party surface. This rationale is also captured in a comment at the top of `scorecard.yml`.

## Branch protection on `main` — resolved

The ticket flagged that `gh api repos/praetorian-inc/vespasian/branches/main/protection` returns `404` and asked whether `main` is genuinely unprotected or the result is just token permissions.

**`main` is protected** — via **rulesets**, not classic branch protection. The classic `/branches/main/protection` endpoint returns 404 because no *classic* branch-protection object exists; the legacy endpoint does not report ruleset-based protection. Reading the effective rules (`gh api repos/praetorian-inc/vespasian/rules/branches/main`, which needs no admin) shows `main` is covered by both organization and repository rulesets enforcing:

- **Pull request required**, **≥1 approving review**, extra approval required for unattributed changes
- **No force-push** (`non_fast_forward`) and **no deletion**

This matches `GOVERNANCE.md` ("a branch ruleset enforces" the review requirement). **No protection change is needed.**

Caveat for the Scorecard run: Scorecard's own Branch-Protection check may still score low, because it needs a token with admin read access to enumerate protection settings; the default `GITHUB_TOKEN` cannot. That low score is a **token-visibility artifact, not a real gap** — `main` is protected.

## Initial triage (predicted; to reconcile against the first live run)

No local Scorecard runner was available (no Go toolchain / Docker on the build host), and the workflow does not run on PRs, so this triage is grounded in direct inspection of the repo's actual configuration and should be reconciled against the first post-merge run.

**Real, verified, fixable gaps (follow-ups proposed — see ticket):**
- **Pinned-Dependencies:** `release.yml` uses three unpinned actions — `actions/checkout@v6`, `actions/setup-go@v6`, `goreleaser/goreleaser-action@v7` — inconsistent with this repo's SHA-pinning convention elsewhere.
- **Token-Permissions:** five workflows lack a **top-level** `permissions:` block (`claude-code.yml`, `claude-md-drift.yml`, `codex-code.yml`, `external-contribution.yml`, `gemini-code.yml`). They set job-level permissions but not a scoped-down top-level default, which is what the check rewards.

**Predicted gaps (confirm against the live run):**
- **Fuzzing:** no Go native fuzz targets (`func Fuzz…`) present.
- **Signed-Releases:** GoReleaser produces checksums but cryptographic signing (cosign/provenance) depends on a `signs:` block in `.goreleaser.yml`.
- **CII-Best-Practices:** no OpenSSF Best Practices badge.

**Resolved / no action:** Branch-Protection (see above).

## Testing

- `scorecard.yml` validated as well-formed YAML and reviewed for correct Scorecard wiring (top-level `read-all`, job-level `security-events: write` + `id-token: write`, SARIF flow, `persist-credentials: false`).

Closes LAB-5328 once the post-merge run is confirmed green and the badge resolves.
